### PR TITLE
Check parentPost.author *and* repostAuthor when check authorship

### DIFF
--- a/Sources/Model/User.swift
+++ b/Sources/Model/User.swift
@@ -254,6 +254,6 @@ extension User {
     }
 
     func isOwnParentPost(comment: ElloComment) -> Bool {
-        return id == comment.loadedFromPost?.authorId
+        return id == comment.loadedFromPost?.authorId || id == comment.loadedFromPost?.repostAuthor?.id
     }
 }

--- a/Specs/Controllers/Stream/CellDequeing/StreamHeaderCellPresenterSpec.swift
+++ b/Specs/Controllers/Stream/CellDequeing/StreamHeaderCellPresenterSpec.swift
@@ -323,7 +323,45 @@ class StreamHeaderCellPresenterSpec: QuickSpec {
                             ])
                         let comment: ElloComment = stub([
                             "id" : "362",
+                            "loadedFromPost" : post,
+                            "content" : content
+                            ])
+
+                        cell = StreamHeaderCell.loadFromNib() as StreamHeaderCell
+                        item = StreamCellItem(jsonable: comment, type: .CommentHeader)
+                    }
+                    it("ownPost should be true") {
+                        StreamHeaderCellPresenter.configure(cell, streamCellItem: item, streamKind: .Following, indexPath: NSIndexPath(forItem: 0, inSection: 0), currentUser: currentUser)
+                        expect(cell.ownPost) == true
+                    }
+                    it("ownComment should be false") {
+                        StreamHeaderCellPresenter.configure(cell, streamCellItem: item, streamKind: .Following, indexPath: NSIndexPath(forItem: 0, inSection: 0), currentUser: currentUser)
+                        expect(cell.ownComment) == false
+                    }
+                }
+                fcontext("when currentUser is the repost author") {
+                    beforeEach {
+                        let reposter: User = stub([:])
+                        let post: Post = stub([
+                            "id" : "768",
+                            "author": currentUser,
+                            "viewsCount" : 9,
+                            "repostsCount" : 4,
+                            "commentsCount" : 6,
+                            "lovesCount" : 14,
+                            ])
+                        let repost: Post = stub([
+                            "id" : "901",
+                            "author": reposter,
+                            "viewsCount" : 9,
+                            "repostsCount" : 4,
+                            "commentsCount" : 6,
+                            "lovesCount" : 14,
+                            ])
+                        let comment: ElloComment = stub([
+                            "id" : "362",
                             "parentPost" : post,
+                            "loadedFromPost": repost,
                             "content" : content
                             ])
 

--- a/Specs/Controllers/Stream/CellDequeing/StreamHeaderCellPresenterSpec.swift
+++ b/Specs/Controllers/Stream/CellDequeing/StreamHeaderCellPresenterSpec.swift
@@ -339,7 +339,7 @@ class StreamHeaderCellPresenterSpec: QuickSpec {
                         expect(cell.ownComment) == false
                     }
                 }
-                fcontext("when currentUser is the repost author") {
+                context("when currentUser is the repost author") {
                     beforeEach {
                         let reposter: User = stub([:])
                         let post: Post = stub([

--- a/Specs/Controllers/Stream/CellDequeing/StreamHeaderCellPresenterSpec.swift
+++ b/Specs/Controllers/Stream/CellDequeing/StreamHeaderCellPresenterSpec.swift
@@ -342,17 +342,10 @@ class StreamHeaderCellPresenterSpec: QuickSpec {
                 context("when currentUser is the repost author") {
                     beforeEach {
                         let reposter: User = stub([:])
-                        let post: Post = stub([
-                            "id" : "768",
-                            "author": currentUser,
-                            "viewsCount" : 9,
-                            "repostsCount" : 4,
-                            "commentsCount" : 6,
-                            "lovesCount" : 14,
-                            ])
                         let repost: Post = stub([
                             "id" : "901",
                             "author": reposter,
+                            "repostAuthor": currentUser,
                             "viewsCount" : 9,
                             "repostsCount" : 4,
                             "commentsCount" : 6,
@@ -360,7 +353,7 @@ class StreamHeaderCellPresenterSpec: QuickSpec {
                             ])
                         let comment: ElloComment = stub([
                             "id" : "362",
-                            "parentPost" : post,
+                            "parentPost" : repost,
                             "loadedFromPost": repost,
                             "content" : content
                             ])


### PR DESCRIPTION
enables deleting a comment on a repost of your post