### PR TITLE
Updates Moya to 6.5, and Result to 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
 - bundle exec pod keys set HttpProtocol $ELLO_HTTP_PROTOCOL Ello
 - bundle exec pod keys set SegmentKey $ELLO_SEGMENT_KEY Ello
 - bundle exec pod keys set TeamId ABC123 Ello
+- bundle exec pod repo update
 - bundle exec pod install
 before_script:
 - export LANG=en_US.UTF-8

--- a/Podfile
+++ b/Podfile
@@ -43,7 +43,7 @@ def common_pods
   pod 'FLAnimatedImage', '~> 1.0'
   pod 'YapDatabase', '2.8.1'
   pod 'Alamofire', '~> 3.0'
-  pod 'Moya', '~> 6.0.0'
+  pod 'Moya', '~> 6.5'
   pod 'KeychainAccess', '~> 2.3'
   pod 'SwiftyUserDefaults', '~> 1.3.0'
   pod 'SwiftyJSON', git: 'https://github.com/ello/SwiftyJSON', branch: 'Swift-2.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -33,11 +33,11 @@ PODS:
   - Keys (1.0.0)
   - KINWebBrowser (1.1.0)
   - MBProgressHUD (0.9.2)
-  - Moya (6.0.1):
-    - Moya/Core (= 6.0.1)
-  - Moya/Core (6.0.1):
+  - Moya (6.5.0):
+    - Moya/Core (= 6.5.0)
+  - Moya/Core (6.5.0):
     - Alamofire (~> 3.0)
-    - Result (~> 1.0)
+    - Result (~> 2.0)
   - Nimble (4.0.1)
   - Nimble-Snapshots (4.1.0):
     - FBSnapshotTestCase (~> 2.0)
@@ -65,7 +65,7 @@ PODS:
     - FLAnimatedImage (>= 1.0)
     - PINRemoteImage/Core
   - Quick (0.9.2)
-  - Result (1.0.2)
+  - Result (2.0.0)
   - SnapKit (0.20.0)
   - SSPullToRefresh (1.2.4)
   - SVGKit (2.0.1):
@@ -137,7 +137,7 @@ DEPENDENCIES:
   - Keys (from `Pods/CocoaPodsKeys`)
   - KINWebBrowser (from `https://github.com/ello/KINWebBrowser`)
   - MBProgressHUD (~> 0.9.0)
-  - Moya (~> 6.0.0)
+  - Moya (~> 6.5)
   - Nimble (~> 4.0)
   - Nimble-Snapshots (from `https://github.com/ashfurrow/Nimble-Snapshots`)
   - OHHTTPStubs (~> 4.3)
@@ -224,14 +224,14 @@ SPEC CHECKSUMS:
   Keys: 9c35bf00f612ee1d48556f4a4b9b4551e224e90f
   KINWebBrowser: dad85d7d93e6f4620a8589b96992394affffa66e
   MBProgressHUD: 1569cf7ace17a8bac47aabfbb8580a49690386d1
-  Moya: fcd80ed553234960a4d28529c184850a8fb43b80
+  Moya: f7a4044719381cc6299f9ad3e0ef05f426f0557b
   Nimble: 0f3c8b8b084cda391209c3c5efbb48bedeeb920a
   Nimble-Snapshots: 2da4d2ec829b458d6886c06812c52493fce284c9
   OHHTTPStubs: b393565822317305b87a1440d4c7aff131679f66
   PINCache: 078426d356ab95ef875e9e62e5c35a2ea3333c28
   PINRemoteImage: 77a7f7bfacd2b4040786a0e31192a81003fdd41f
   Quick: 18d057bc66451eedd5d1c8dc99ba2a5db6e60226
-  Result: dd3dd71af3fa2e262f1a999e14fba2c25ec14f16
+  Result: 9e75e1111c774c6ac594e14907b15057053a7959
   SnapKit: 5fce3c1bbbf1fbd31de9aa92f33eb9fa03f15650
   SSPullToRefresh: 369e862c1d6528c7a354fc85cd4763d4e670e9af
   SVGKit: 2afbeaf2c2be4615476951284750c3ddb790d0c7
@@ -242,6 +242,6 @@ SPEC CHECKSUMS:
   WebLinking: d5b5ab4f7305bcf29821deb5cecd775f6c37efae
   YapDatabase: 861c720d5850a59f9e5c0bad0fd95334012b9dc9
 
-PODFILE CHECKSUM: b872b7c532a08e79279d8d2ec6fe8fc603337464
+PODFILE CHECKSUM: 787af9531c658954503e15c92d61bf8e95b6d130
 
-COCOAPODS: 1.0.0
+COCOAPODS: 1.0.0.rc.2


### PR DESCRIPTION
Reduces Swift 2.2 warnings, and keeps us fresh and clean.