### PR TITLE
Adds support for `native_redirect` universal links

### DIFF
--- a/Sources/Networking/ElloURI.swift
+++ b/Sources/Networking/ElloURI.swift
@@ -184,6 +184,18 @@ public enum ElloURI: String {
         if path.beginsWith("ello://") {
             return path.stringByReplacingOccurrencesOfString("ello://", withString: "\(baseURL)/")
         }
+        if let url = NSURLComponents(string: path),
+            items = url.queryItems
+            where path.contains("native_redirect")
+        {
+            for item in items {
+                if let value = item.value
+                    where item.name == "target"
+                {
+                    return value
+                }
+            }
+        }
         return path
     }
 

--- a/Specs/Networking/ElloURISpec.swift
+++ b/Specs/Networking/ElloURISpec.swift
@@ -247,6 +247,20 @@ class ElloURISpec: QuickSpec {
                     }
                 }
 
+                describe("with native_redirect urls") {
+                    it("matches with https://ello.co/native_redirect?target=https%3A%2F%2Fello.co%2Felloblog") {
+                        let (type, data) = ElloURI.match("https://ello.co/native_redirect?target=https%3A%2F%2Fello.co%2Felloblog")
+                        expect(type).to(equal(ElloURI.Profile))
+                        expect(data).to(equal("elloblog"))
+                    }
+
+                    it("matches with https://ello.co/native_redirect?target=https%3A%2F%2Fello.co%2Felloblog%2Fpost%2F123") {
+                        let (type, data) = ElloURI.match("https://ello.co/native_redirect?target=https%3A%2F%2Fello.co%2Felloblog%2Fpost%2F123")
+                        expect(type).to(equal(ElloURI.Post))
+                        expect(data).to(equal("123"))
+                    }
+                }
+
                 describe("known ello root routes") {
                     let tests: [String: (input: String, output: ElloURI)] = [
                         "with Confirm urls": (input: "confirm", output: .Confirm),


### PR DESCRIPTION
These were being parsed incorrectly, and eventually leading to a call to `UIApplication.openURL`, hence the bouncing back and forth.