### PR TITLE
Set the views/reposts/loves count appropriately

### DIFF
--- a/Sources/Controllers/Stream/CellDequeing/StreamFooterCellPresenter.swift
+++ b/Sources/Controllers/Stream/CellDequeing/StreamFooterCellPresenter.swift
@@ -38,7 +38,6 @@ public struct StreamFooterCellPresenter {
             configureDisplayCounts(cell, post: post, streamKind: streamKind)
             configureToolBarItems(cell, post: post, currentUser: currentUser, streamKind: streamKind)
             configureCommentControl(cell, streamCellItem: streamCellItem, streamKind: streamKind)
-            configureGridSpecificLayout(cell, streamKind: streamKind)
         }
     }
 
@@ -48,8 +47,6 @@ public struct StreamFooterCellPresenter {
         currentUser: User?,
         streamKind: StreamKind)
     {
-        cell.comments = post.commentsCount?.numberToHuman()
-
         let ownPost = (currentUser?.id == post.authorId || (post.repostAuthor?.id != nil && currentUser?.id == post.repostAuthor?.id))
 
         let repostingEnabled = post.author?.hasRepostingEnabled ?? true
@@ -114,26 +111,22 @@ public struct StreamFooterCellPresenter {
         }
     }
 
-    private static func configureGridSpecificLayout(
-        cell: StreamFooterCell,
-        streamKind: StreamKind)
-    {
-    }
-
     private static func configureDisplayCounts(
         cell: StreamFooterCell,
         post: Post,
         streamKind: StreamKind)
     {
-        if streamKind.isGridView {
+        let rounding = streamKind.isGridView ? 0 : 2
+        if cell.frame.width < 155 {
             cell.views = ""
             cell.reposts = ""
             cell.loves = ""
         }
         else {
-            cell.views = post.viewsCount?.numberToHuman()
-            cell.reposts = post.repostsCount?.numberToHuman()
-            cell.loves = post.lovesCount?.numberToHuman()
+            cell.views = post.viewsCount?.numberToHuman(rounding: rounding)
+            cell.reposts = post.repostsCount?.numberToHuman(rounding: rounding)
+            cell.loves = post.lovesCount?.numberToHuman(rounding: rounding)
         }
+        cell.comments = post.commentsCount?.numberToHuman(rounding: rounding)
     }
 }

--- a/Sources/Extensions/NumberExtensions.swift
+++ b/Sources/Extensions/NumberExtensions.swift
@@ -14,26 +14,27 @@ let thousand = 1_000.0
 
 public extension Int {
 
-    func numberToHuman(showZero showZero: Bool = false) -> String {
+    func numberToHuman(rounding rounding: Int = 2, showZero: Bool = false) -> String {
         if self == 0 && !showZero { return "" }
 
+        let roundingFactor: Double = pow(10, Double(rounding))
         let double = Double(self)
         let num: Float
         let suffix: String
         if double >= billion {
-            num = Float(round(double / billion * 100.0) / 100.0)
+            num = Float(round(double / billion * roundingFactor) / roundingFactor)
             suffix = "B"
         }
         else if double >= million {
-            num = Float(round(double / million * 100.0) / 100.0)
+            num = Float(round(double / million * roundingFactor) / roundingFactor)
             suffix = "M"
         }
         else if double >= thousand {
-            num = Float(round(double / thousand * 100.0) / 100.0)
+            num = Float(round(double / thousand * roundingFactor) / roundingFactor)
             suffix = "K"
         }
         else {
-            num = Float(round(double * 100.0) / 100.0)
+            num = Float(round(double * roundingFactor) / roundingFactor)
             suffix = ""
         }
         var strNum = "\(num)"

--- a/Specs/Controllers/Stream/CellDequeing/StreamFooterCellPresenterSpec.swift
+++ b/Specs/Controllers/Stream/CellDequeing/StreamFooterCellPresenterSpec.swift
@@ -34,7 +34,7 @@ class StreamFooterCellPresenterSpec: QuickSpec {
 
             context("grid layout") {
 
-                it("configures a stream footer cell") {
+                it("configures a thin stream footer cell") {
                     let post: Post = stub([
                         "id" : "768",
                         "viewsCount" : 9,
@@ -43,6 +43,7 @@ class StreamFooterCellPresenterSpec: QuickSpec {
                         "lovesCount" : 14
                     ])
                     let cell: StreamFooterCell = StreamFooterCell.loadFromNib()
+                    cell.frame = CGRect(origin: .zero, size: CGSize(width: 150, height: 60))
                     let item: StreamCellItem = StreamCellItem(jsonable: post, type: .Footer)
 
                     GroupDefaults["StarredIsGridView"] = true
@@ -54,6 +55,29 @@ class StreamFooterCellPresenterSpec: QuickSpec {
                     expect(cell.reposts) == ""
                     expect(cell.comments) == "6"
                     expect(cell.loves) == ""
+                }
+
+                it("configures a wide stream footer cell") {
+                    let post: Post = stub([
+                        "id" : "768",
+                        "viewsCount" : 9,
+                        "repostsCount" : 4,
+                        "commentsCount" : 6,
+                        "lovesCount" : 14
+                    ])
+                    let cell: StreamFooterCell = StreamFooterCell.loadFromNib()
+                    cell.frame = CGRect(origin: .zero, size: CGSize(width: 180, height: 60))
+                    let item: StreamCellItem = StreamCellItem(jsonable: post, type: .Footer)
+
+                    GroupDefaults["StarredIsGridView"] = true
+                    StreamFooterCellPresenter.configure(cell, streamCellItem: item, streamKind: .Starred, indexPath: NSIndexPath(forItem: 0, inSection: 0), currentUser: nil)
+
+                    expect(cell.commentsControl.selected).to(beFalse())
+                    expect(cell.commentsOpened).to(beFalse())
+                    expect(cell.views) == "9"
+                    expect(cell.reposts) == "4"
+                    expect(cell.comments) == "6"
+                    expect(cell.loves) == "14"
                 }
             }
 

--- a/Specs/Extensions/NumberExtensionsSpec.swift
+++ b/Specs/Extensions/NumberExtensionsSpec.swift
@@ -13,18 +13,46 @@ import Nimble
 class NumberExtensionsSpec: QuickSpec {
     override func spec() {
 
-        let expectations: [Int: String] = [
-            123 : "123",
-            1234 : "1.23K",
-            12345 : "12.35K",
-            1234567 : "1.23M",
-            1234567890 : "1.23B",
+        let expectations: [(Int, String)] = [
+            (123, "123"),
+            (1234, "1.23K"),
+            (12345, "12.35K"),
+            (1234567, "1.23M"),
+            (1234567890, "1.23B"),
         ]
 
         for (number, expected) in expectations {
             it("returns \(expected) with \(number)") {
                 expect(number.numberToHuman()) == expected
             }
+        }
+
+        context("rounding") {
+
+            let expectations: [(Int, Int, String)] = [
+                (0, 123, "123"),
+                (1, 123, "123"),
+                (2, 123, "123"),
+                (0, 1234, "1K"),
+                (1, 1234, "1.2K"),
+                (2, 1234, "1.23K"),
+                (0, 12345, "12K"),
+                (1, 12345, "12.3K"),
+                (2, 12345, "12.35K"),
+                (0, 1234567, "1M"),
+                (1, 1234567, "1.2M"),
+                (2, 1234567, "1.23M"),
+                (0, 1234567890, "1B"),
+                (1, 1234567890, "1.2B"),
+                (2, 1234567890, "1.23B"),
+            ]
+
+            for (rounding, number, expected) in expectations {
+                it("returns \(expected) with \(number)") {
+                    expect(number.numberToHuman(rounding: rounding)) == expected
+                }
+            }
+
         }
 
         context("when told to show zero") {


### PR DESCRIPTION
In grid view, the following changes:

- iphone5 / 4" is too small for any more numbers, so no change
- iphone6 / iphone6+ is large enough for more numbers, but large numbers are more truncated