### PR TITLE
Store the updated post AFTER posting the notification

### DIFF
--- a/Sources/Model/ExperienceUpdate.swift
+++ b/Sources/Model/ExperienceUpdate.swift
@@ -34,12 +34,15 @@ public enum ContentChange {
         }
         for post in affectedPosts {
             if let post = post, let count = post.commentsCount {
+                postNotification(PostCommentsCountChangedNotification, value: (post, delta))
+                postNotification(PostChangedNotification, value: (post, .Update))
+
+                // this must happen AFTER the notification, otherwise the
+                // storedPost will be in-memory, and the notification will update the comment count
                 if let storedPost = ElloLinkedStore.sharedInstance.getObject(post.id, inCollection: MappingType.PostsType.rawValue) as? Post {
                     storedPost.commentsCount = count + delta
                     ElloLinkedStore.sharedInstance.setObject(storedPost, forKey: post.id, inCollection: MappingType.PostsType.rawValue)
                 }
-                postNotification(PostCommentsCountChangedNotification, value: (post, delta))
-                postNotification(PostChangedNotification, value: (post, .Update))
             }
         }
 

--- a/Specs/Model/ExperienceUpdateSpec.swift
+++ b/Specs/Model/ExperienceUpdateSpec.swift
@@ -21,9 +21,12 @@ class ExperienceUpdateSpec: QuickSpec {
                     "parentPost": post1,
                     "loadedFromPost": post2
                     ])
+                ElloLinkedStore.sharedInstance.setObject(post1, forKey: post1.id, inCollection: MappingType.PostsType.rawValue)
                 ContentChange.updateCommentCount(comment, delta: 1)
                 expect(post1.commentsCount) == 2
                 expect(post2.commentsCount) == 2
+                let storedPost = ElloLinkedStore.sharedInstance.getObject(post1.id, inCollection: MappingType.PostsType.rawValue) as! Post
+                expect(storedPost.commentsCount) == 2
             }
         }
     }


### PR DESCRIPTION
Otherwise the "still in memory" post will have its comment count updated twice