### PR TITLE
Don't disable embed cell interactions

### DIFF
--- a/Sources/Controllers/Stream/Cells/StreamImageCell.swift
+++ b/Sources/Controllers/Stream/Cells/StreamImageCell.swift
@@ -143,7 +143,6 @@ public class StreamImageCell: StreamRegionableCell {
     }
 
     private func imageLoadFailed() {
-        imageButton.userInteractionEnabled = false
         failImage.hidden = false
         failBackgroundView.hidden = false
         circle.stopPulse()


### PR DESCRIPTION
Youtube embedded links did not allow interaction with the play button when thumbnail failed to load.

Partially [fixes #121961001](https://www.pivotaltracker.com/story/show/121961001)

The remaining fix is determining why the thumbnail was not included in the json.

```
{
  "kind": "embed",
  "data": {
      "service": "youtube",
      "id": "T0GQIq64cCk",
      "url": "https://www.youtube.com/watch?v=T0GQIq64cCk",
      "thumbnail_large_url": null,
      "thumbnail_small_url": null
     }
}
```