### PR TITLE
Remove nib IBAction tap in embed cells

### DIFF
--- a/Sources/Controllers/Stream/Cells/StreamEmbedCell.xib
+++ b/Sources/Controllers/Stream/Cells/StreamEmbedCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -37,9 +37,6 @@
                     </imageView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cba-zi-ctG" userLabel="imageButton">
                         <rect key="frame" x="0.0" y="0.0" width="587" height="109"/>
-                        <connections>
-                            <action selector="imageTapped" destination="miB-hg-eZF" eventType="touchUpInside" id="tqD-w4-7IU"/>
-                        </connections>
                     </button>
                 </subviews>
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>


### PR DESCRIPTION
This fixes a regression introduced when we added double tap to love. We removed the IBAction in `StreamImageCell` but forgot to remove it in the subclass `StreamEmbedCell` nib.

[fixes #122085233](https://www.pivotaltracker.com/story/show/122085233)