### PR TITLE
Remove streamkind from preloadImage calls

### DIFF
--- a/Sources/Networking/PostService.swift
+++ b/Sources/Networking/PostService.swift
@@ -28,7 +28,7 @@ public struct PostService {
             ElloAPI.PostDetail(postParam: postParam, commentCount: commentCount),
             success: { (data, responseConfig) in
                 if let post = data as? Post {
-                    Preloader().preloadImages([post],  streamKind: .PostDetail(postParam: postParam))
+                    Preloader().preloadImages([post])
                     success(post: post, responseConfig: responseConfig)
                 }
                 else if let failure = failure {

--- a/Sources/Networking/StreamService.swift
+++ b/Sources/Networking/StreamService.swift
@@ -29,7 +29,7 @@ public class StreamService: NSObject {
             success: { (data, responseConfig) in
                 if let jsonables = data as? [JSONAble] {
                     if let streamKind = streamKind {
-                        Preloader().preloadImages(jsonables,  streamKind: streamKind)
+                        Preloader().preloadImages(jsonables)
                         NewContentService().updateCreatedAt(jsonables, streamKind: streamKind)
                     }
                     success(jsonables: jsonables, responseConfig: responseConfig)
@@ -57,9 +57,7 @@ public class StreamService: NSObject {
             endpoint,
             success: { (data, responseConfig) in
                 if let user = data as? User {
-                    if let streamKind = streamKind {
-                        Preloader().preloadImages([user], streamKind: streamKind)
-                    }
+                    Preloader().preloadImages([user])
                     success(user: user, responseConfig: responseConfig)
                 }
                 else {
@@ -86,9 +84,7 @@ public class StreamService: NSObject {
                         comment.loadedFromPostId = postId
                     }
 
-                    if let streamKind = streamKind {
-                        Preloader().preloadImages(comments, streamKind: streamKind)
-                    }
+                    Preloader().preloadImages(comments)
                     success(jsonables: comments, responseConfig: responseConfig)
                 }
                 else if let noContent = noContent {

--- a/Sources/Utilities/Preloader.swift
+++ b/Sources/Utilities/Preloader.swift
@@ -15,7 +15,7 @@ public struct Preloader {
 
     public init(){}
 
-    public func preloadImages(jsonables: [JSONAble], streamKind: StreamKind) {
+    public func preloadImages(jsonables: [JSONAble]) {
 
         for jsonable in jsonables {
 
@@ -57,17 +57,17 @@ public struct Preloader {
             if  let activity = jsonable as? Activity,
                 let post = activity.subject as? Post
             {
-                preloadImagesinPost(post, streamKind: streamKind)
+                preloadImagesinPost(post)
             }
 
             // post image regions
             else if let post = jsonable as? Post {
-                preloadImagesinPost(post, streamKind: streamKind)
+                preloadImagesinPost(post)
             }
 
             // comment image regions
             else if let comment = jsonable as? ElloComment {
-                preloadImagesInRegions(comment.content, streamKind: streamKind)
+                preloadImagesInRegions(comment.content)
             }
 
             // user's posts image regions
@@ -75,7 +75,7 @@ public struct Preloader {
                     let posts = user.posts
             {
                 for post in posts {
-                    preloadImagesinPost(post, streamKind: streamKind)
+                    preloadImagesinPost(post)
                 }
             }
 
@@ -97,13 +97,13 @@ public struct Preloader {
         }
     }
 
-    private func preloadImagesinPost(post: Post, streamKind: StreamKind) {
+    private func preloadImagesinPost(post: Post) {
         if let content = post.content {
-            preloadImagesInRegions(content, streamKind: streamKind)
+            preloadImagesInRegions(content)
         }
     }
 
-    private func preloadImagesInRegions(regions: [Regionable], streamKind: StreamKind) {
+    private func preloadImagesInRegions(regions: [Regionable]) {
         for region in regions {
             if  let imageRegion = region as? ImageRegion,
                 let asset = imageRegion.asset,

--- a/Specs/Utilities/PreloaderSpec.swift
+++ b/Specs/Utilities/PreloaderSpec.swift
@@ -129,7 +129,7 @@ class PreloaderSpec: QuickSpec {
             ])
         }
 
-        describe("preloadImages(_:streamKind:)") {
+        describe("preloadImages(_)") {
 
             it("preloads activity image assets and avatars") {
 
@@ -143,19 +143,19 @@ class PreloaderSpec: QuickSpec {
                     "id" : "345",
                 ])
 
-                subject.preloadImages([activityOne, activityTwo], streamKind: StreamKind.Following)
+                subject.preloadImages([activityOne, activityTwo])
 
                 expect(fakeManager.downloads.count) == 5
             }
 
             it("preloads posts image assets and avatars") {
-                subject.preloadImages([oneImagePost, twoImagePost, threeImagePost], streamKind: StreamKind.Following)
+                subject.preloadImages([oneImagePost, twoImagePost, threeImagePost])
 
                 expect(fakeManager.downloads.count) == 9
             }
 
             it("preloads comments image assets and avatars") {
-                subject.preloadImages([oneImageComment, threeImageComment], streamKind: StreamKind.Following)
+                subject.preloadImages([oneImageComment, threeImageComment])
 
                 expect(fakeManager.downloads.count) == 6
             }
@@ -167,14 +167,14 @@ class PreloaderSpec: QuickSpec {
                     "posts" : [twoImagePost, threeImagePost]
                 ])
 
-                subject.preloadImages([user], streamKind: StreamKind.CurrentUserStream)
+                subject.preloadImages([user])
 
                 expect(fakeManager.downloads.count) == 8
             }
 
             it("loads hdpi for single column StreamKinds") {
                 StreamKind.Following.setIsGridView(false)
-                subject.preloadImages([oneImagePost], streamKind: StreamKind.Following)
+                subject.preloadImages([oneImagePost])
 
                 // grab the second image, first is the avatar of post's author
                 expect(fakeManager.downloads[1].absoluteString) == "http://www.example.com/hdpi.jpg"
@@ -182,7 +182,7 @@ class PreloaderSpec: QuickSpec {
 
             it("loads hpdi for grid layout StreamKinds") {
                 StreamKind.Starred.setIsGridView(true)
-                subject.preloadImages([imagePostWithSummary], streamKind: StreamKind.Starred)
+                subject.preloadImages([imagePostWithSummary])
 
                 // grab the second image, first is the avatar of post's author
                 expect(fakeManager.downloads[1].absoluteString) == "http://www.example.com/hdpi.jpg"
@@ -194,7 +194,7 @@ class PreloaderSpec: QuickSpec {
                     "avatar" : avatarAsset1,
                 ])
 
-                subject.preloadImages([user], streamKind: StreamKind.PostDetail(postParam: "fake-id"))
+                subject.preloadImages([user])
 
                 expect(fakeManager.downloads.first?.absoluteString) == "http://www.example.com/regular.jpg"
             }


### PR DESCRIPTION
`Preloader().preloadImages(...)` never used the `streamKind` parameter. Less code is the best code!