### PR TITLE
Re-fixes column layouts (image stretching) and adds support for 3 columns on all streams

### DIFF
--- a/ShareExtension/ShareTrackerOverrides.swift
+++ b/ShareExtension/ShareTrackerOverrides.swift
@@ -31,5 +31,6 @@ public class Tracker {
 }
 
 public class Window {
-    static let isWide = false
+    static public func isWide(width: Float) -> Bool { return false }
+    static public var width: Float { return 0 }
 }

--- a/Sources/Controllers/App/AppViewController.swift
+++ b/Sources/Controllers/App/AppViewController.swift
@@ -66,7 +66,7 @@ public class AppViewController: BaseElloViewController {
 
     public override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
-        postNotification(Application.Notifications.ViewSizeDidChange, value: size)
+        postNotification(Application.Notifications.ViewSizeWillChange, value: size)
     }
 
     public class func instantiateFromStoryboard() -> AppViewController {

--- a/Sources/Controllers/Profile/ProfileHeaderCellSizeCalculator.swift
+++ b/Sources/Controllers/Profile/ProfileHeaderCellSizeCalculator.swift
@@ -24,7 +24,7 @@ public class ProfileHeaderCellSizeCalculator: NSObject {
         label.lineBreakMode = .ByWordWrapping
     }
 
-    public func processCells(cellItems: [StreamCellItem], withWidth width: CGFloat, completion: ElloEmptyCompletion) {
+    public func processCells(cellItems: [StreamCellItem], withWidth width: CGFloat, columnCount: Int, completion: ElloEmptyCompletion) {
         self.cellItems = cellItems
         self.completion = completion
         self.maxWidth = width

--- a/Sources/Controllers/Stream/CellDequeing/StreamImageCellPresenter.swift
+++ b/Sources/Controllers/Stream/CellDequeing/StreamImageCellPresenter.swift
@@ -91,7 +91,7 @@ public struct StreamImageCellPresenter {
             cell.hideBorder()
             let margin = configureCellWidthAndLayout(cell, imageRegion: imageRegion, streamCellItem: streamCellItem)
             if let attachmentWidth = attachmentToLoad?.width {
-                let columnWidth: CGFloat = calculateColumnWidth(screenWidth: UIWindow.windowWidth(), columnCount: streamKind.columnCount)
+                let columnWidth: CGFloat = calculateColumnWidth(screenWidth: UIWindow.windowWidth(), columnCount: streamKind.columnCountFor(width: cell.frame.width))
                 preventImageStretching(cell, attachmentWidth: attachmentWidth, columnWidth: columnWidth, leftMargin: margin)
             }
             cell.layoutIfNeeded()

--- a/Sources/Controllers/Stream/CellDequeing/StreamImageCellPresenter.swift
+++ b/Sources/Controllers/Stream/CellDequeing/StreamImageCellPresenter.swift
@@ -74,19 +74,15 @@ public struct StreamImageCellPresenter {
                 cell.isGif = true
             }
 
-            let columnWidth: CGFloat
-            let columnCount: CGFloat = CGFloat(streamKind.columnCount)
             if streamKind.isGridView {
                 cell.failWidthConstraint.constant = StreamImageCellPresenter.multiColumnFailWidth
                 cell.failHeightConstraint.constant = StreamImageCellPresenter.multiColumnFailHeight
                 attachmentToLoad = attachmentToLoad ?? imageRegion.asset?.gridLayoutAttachment
-                columnWidth = (UIWindow.windowWidth() - 10 * (columnCount - 1)) / columnCount
             }
             else {
                 cell.failWidthConstraint.constant = StreamImageCellPresenter.singleColumnFailWidth
                 cell.failHeightConstraint.constant = StreamImageCellPresenter.singleColumnFailHeight
                 attachmentToLoad = attachmentToLoad ?? imageRegion.asset?.oneColumnAttachment
-                columnWidth = UIWindow.windowWidth()
             }
 
             let imageToShow = attachmentToLoad?.image
@@ -95,6 +91,7 @@ public struct StreamImageCellPresenter {
             cell.hideBorder()
             let margin = configureCellWidthAndLayout(cell, imageRegion: imageRegion, streamCellItem: streamCellItem)
             if let attachmentWidth = attachmentToLoad?.width {
+                let columnWidth: CGFloat = calculateColumnWidth(screenWidth: UIWindow.windowWidth(), columnCount: streamKind.columnCount)
                 preventImageStretching(cell, attachmentWidth: attachmentWidth, columnWidth: columnWidth, leftMargin: margin)
             }
             cell.layoutIfNeeded()

--- a/Sources/Controllers/Stream/CellDequeing/StreamImageCellPresenter.swift
+++ b/Sources/Controllers/Stream/CellDequeing/StreamImageCellPresenter.swift
@@ -75,11 +75,12 @@ public struct StreamImageCellPresenter {
             }
 
             let columnWidth: CGFloat
+            let columnCount: CGFloat = CGFloat(streamKind.columnCount)
             if streamKind.isGridView {
                 cell.failWidthConstraint.constant = StreamImageCellPresenter.multiColumnFailWidth
                 cell.failHeightConstraint.constant = StreamImageCellPresenter.multiColumnFailHeight
                 attachmentToLoad = attachmentToLoad ?? imageRegion.asset?.gridLayoutAttachment
-                columnWidth = (UIWindow.windowWidth() - 10) / 2
+                columnWidth = (UIWindow.windowWidth() - 10 * (columnCount - 1)) / columnCount
             }
             else {
                 cell.failWidthConstraint.constant = StreamImageCellPresenter.singleColumnFailWidth

--- a/Sources/Controllers/Stream/Cells/StreamImageCellSizeCalculator.swift
+++ b/Sources/Controllers/Stream/Cells/StreamImageCellSizeCalculator.swift
@@ -12,6 +12,7 @@ public class StreamImageCellSizeCalculator: NSObject {
 
     var screenWidth: CGFloat = 0.0
     var maxWidth: CGFloat = 0.0
+    var columnCount: Int = 1
     public var cellItems: [StreamCellItem] = []
     public var completion: ElloEmptyCompletion = {}
 
@@ -38,10 +39,11 @@ public class StreamImageCellSizeCalculator: NSObject {
 
 // MARK: Public
 
-    public func processCells(cellItems: [StreamCellItem], withWidth width: CGFloat, completion: ElloEmptyCompletion) {
+    public func processCells(cellItems: [StreamCellItem], withWidth width: CGFloat, columnCount: Int, completion: ElloEmptyCompletion) {
         self.completion = completion
         self.cellItems = cellItems
         self.screenWidth = width
+        self.columnCount = columnCount
         loadNext()
     }
 
@@ -71,7 +73,7 @@ public class StreamImageCellSizeCalculator: NSObject {
                     ratio = 16.0/9.0
                 }
                 item.calculatedOneColumnCellHeight = StreamImageCell.Size.bottomMargin + maxWidth / ratio
-                item.calculatedMultiColumnCellHeight = StreamImageCell.Size.bottomMargin + ((maxWidth - 10.0) / 2) / ratio
+                item.calculatedMultiColumnCellHeight = StreamImageCell.Size.bottomMargin + calculateColumnWidth(screenWidth: maxWidth, columnCount: columnCount) / ratio
             }
             loadNext()
         }
@@ -89,10 +91,11 @@ public class StreamImageCellSizeCalculator: NSObject {
     }
 
     private func multiColumnImageHeight(imageBlock: ImageRegion) -> CGFloat {
-        var imageWidth = (maxWidth - 10.0) / 2
+        var imageWidth = calculateColumnWidth(screenWidth: maxWidth, columnCount: columnCount)
         if let assetWidth = imageBlock.asset?.gridLayoutAttachment?.width {
             imageWidth = min(imageWidth, CGFloat(assetWidth))
         }
-        return  (imageWidth / StreamImageCellSizeCalculator.aspectRatioForImageRegion(imageBlock)) + 10
+        return ceil((imageWidth / StreamImageCellSizeCalculator.aspectRatioForImageRegion(imageBlock)) + 10)
     }
+
 }

--- a/Sources/Controllers/Stream/Cells/StreamNotificationCellSizeCalculator.swift
+++ b/Sources/Controllers/Stream/Cells/StreamNotificationCellSizeCalculator.swift
@@ -36,7 +36,7 @@ public class StreamNotificationCellSizeCalculator: NSObject, UIWebViewDelegate {
         }
     }
 
-    public func processCells(cellItems: [StreamCellItem], withWidth width: CGFloat, completion: StreamTextCellSizeCalculated) {
+    public func processCells(cellItems: [StreamCellItem], withWidth width: CGFloat, columnCount: Int, completion: StreamTextCellSizeCalculated) {
         self.completion = completion
         self.cellItems = cellItems
         self.originalWidth = width

--- a/Sources/Controllers/Stream/Cells/StreamTextCellSizeCalculator.swift
+++ b/Sources/Controllers/Stream/Cells/StreamTextCellSizeCalculator.swift
@@ -27,7 +27,7 @@ public class StreamTextCellSizeCalculator: NSObject, UIWebViewDelegate {
         self.webView.delegate = self
     }
 
-    public func processCells(cellItems: [StreamCellItem], withWidth width: CGFloat, completion: StreamTextCellSizeCalculated) {
+    public func processCells(cellItems: [StreamCellItem], withWidth width: CGFloat, columnCount: Int, completion: StreamTextCellSizeCalculated) {
         self.completion = completion
         self.cellItems = cellItems
         self.maxWidth = width

--- a/Sources/Controllers/Stream/StreamCollectionViewLayout.swift
+++ b/Sources/Controllers/Stream/StreamCollectionViewLayout.swift
@@ -42,23 +42,33 @@ public class StreamCollectionViewLayout: UICollectionViewLayout {
     }
 
     var columnCount: Int {
-        didSet { invalidateLayout() }
+        didSet { if columnCount != oldValue {
+            invalidateLayout()
+        } }
     }
 
     var minimumColumnSpacing: CGFloat {
-        didSet { invalidateLayout() }
+        didSet { if minimumColumnSpacing != oldValue {
+            invalidateLayout()
+        } }
     }
 
     var minimumInteritemSpacing: CGFloat {
-        didSet { invalidateLayout() }
+        didSet { if minimumInteritemSpacing != oldValue {
+            invalidateLayout()
+        } }
     }
 
     var sectionInset: UIEdgeInsets {
-        didSet { invalidateLayout() }
+        didSet { if sectionInset != oldValue {
+            invalidateLayout()
+        } }
     }
 
     var itemRenderDirection: Direction {
-        didSet { invalidateLayout() }
+        didSet { if itemRenderDirection != oldValue {
+            invalidateLayout()
+        } }
     }
 
     weak var delegate: StreamCollectionViewLayoutDelegate? {

--- a/Sources/Controllers/Stream/StreamDataSource.swift
+++ b/Sources/Controllers/Stream/StreamDataSource.swift
@@ -698,17 +698,17 @@ public class StreamDataSource: NSObject, UICollectionViewDataSource {
         }
         let afterAll = after(4, block: completion)
 
-        self.imageSizeCalculator.processCells(imageCells.normal, withWidth: withWidth) {
-            self.imageSizeCalculator.processCells(imageCells.repost, withWidth: withWidth - 30.0, completion: afterAll)
+        self.imageSizeCalculator.processCells(imageCells.normal, withWidth: withWidth, columnCount: streamKind.columnCount) {
+            self.imageSizeCalculator.processCells(imageCells.repost, withWidth: withWidth - 30.0, columnCount: self.streamKind.columnCount, completion: afterAll)
         }
         // -30.0 acounts for the 15 on either side for constraints
         let textLeftRightConstraintWidth = (StreamTextCellPresenter.postMargin * 2)
-        self.textSizeCalculator.processCells(textCells.normal, withWidth: withWidth - textLeftRightConstraintWidth) {
+        self.textSizeCalculator.processCells(textCells.normal, withWidth: withWidth - textLeftRightConstraintWidth, columnCount: streamKind.columnCount) {
             // extra -30.0 acounts for the left indent on a repost with the black line
-            self.textSizeCalculator.processCells(textCells.repost, withWidth: withWidth - (textLeftRightConstraintWidth * 2), completion: afterAll)
+            self.textSizeCalculator.processCells(textCells.repost, withWidth: withWidth - (textLeftRightConstraintWidth * 2), columnCount: self.streamKind.columnCount, completion: afterAll)
         }
-        self.notificationSizeCalculator.processCells(notificationElements, withWidth: withWidth, completion: afterAll)
-        self.profileHeaderSizeCalculator.processCells(profileHeaderItems, withWidth: withWidth, completion: afterAll)
+        self.notificationSizeCalculator.processCells(notificationElements, withWidth: withWidth, columnCount: streamKind.columnCount, completion: afterAll)
+        self.profileHeaderSizeCalculator.processCells(profileHeaderItems, withWidth: withWidth, columnCount: streamKind.columnCount, completion: afterAll)
     }
 
     private func filterTextCells(cellItems: [StreamCellItem]) -> (normal: [StreamCellItem], repost: [StreamCellItem]) {

--- a/Sources/Controllers/Stream/StreamDataSource.swift
+++ b/Sources/Controllers/Stream/StreamDataSource.swift
@@ -226,12 +226,22 @@ public class StreamDataSource: NSObject, UICollectionViewDataSource {
     public func heightForIndexPath(indexPath: NSIndexPath, numberOfColumns: NSInteger) -> CGFloat {
         if !isValidIndexPath(indexPath) { return 0 }
 
-        // alway try to return a calculated value before the default
+        // always try to return a calculated value before the default
         if numberOfColumns == 1 {
-            return visibleCellItems[indexPath.item].calculatedOneColumnCellHeight ?? visibleCellItems[indexPath.item].type.oneColumnHeight ?? 0.0
+            if let height = visibleCellItems[indexPath.item].calculatedOneColumnCellHeight {
+                return height
+            }
+            else {
+                return visibleCellItems[indexPath.item].type.oneColumnHeight
+            }
         }
         else {
-            return visibleCellItems[indexPath.item].calculatedMultiColumnCellHeight ?? visibleCellItems[indexPath.item].type.multiColumnHeight
+            if let height = visibleCellItems[indexPath.item].calculatedMultiColumnCellHeight {
+                return height
+            }
+            else {
+                return visibleCellItems[indexPath.item].type.multiColumnHeight
+            }
         }
     }
 

--- a/Sources/Controllers/Stream/StreamImageViewer.swift
+++ b/Sources/Controllers/Stream/StreamImageViewer.swift
@@ -60,7 +60,7 @@ extension StreamImageViewer: JTSImageViewControllerOptionsDelegate {
 extension StreamImageViewer: JTSImageViewControllerDismissalDelegate {
     public func imageViewerDidDismiss(imageViewer: JTSImageViewController) {
         if let prevSize = prevWindowSize where prevSize != UIWindow.windowSize() {
-            postNotification(Application.Notifications.ViewSizeDidChange, value: UIWindow.windowSize())
+            postNotification(Application.Notifications.ViewSizeWillChange, value: UIWindow.windowSize())
         }
     }
 

--- a/Sources/Controllers/Stream/StreamKind.swift
+++ b/Sources/Controllers/Stream/StreamKind.swift
@@ -76,8 +76,12 @@ public enum StreamKind {
     }
 
     public var columnCount: Int {
+        return columnCountFor(width: Window.width)
+    }
+
+    public func columnCountFor(width width: CGFloat) -> Int {
         let gridColumns: Int
-        if Window.isWide {
+        if Window.isWide(width) {
             gridColumns = 3
         }
         else {

--- a/Sources/Controllers/Stream/StreamKind.swift
+++ b/Sources/Controllers/Stream/StreamKind.swift
@@ -77,8 +77,7 @@ public enum StreamKind {
 
     public var columnCount: Int {
         let gridColumns: Int
-        let isWide = Window.isWide
-        if case .AllCategories = self where isWide {
+        if Window.isWide {
             gridColumns = 3
         }
         else {

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -721,7 +721,9 @@ extension StreamViewController: StreamCollectionViewLayoutDelegate {
     public func collectionView(collectionView: UICollectionView,
         layout collectionViewLayout: UICollectionViewLayout,
         sizeForItemAtIndexPath indexPath: NSIndexPath) -> CGSize {
-            return CGSize(width: UIWindow.windowWidth(), height: dataSource.heightForIndexPath(indexPath, numberOfColumns: 1))
+            let width = calculateColumnWidth(screenWidth: UIWindow.windowWidth(), columnCount: streamKind.columnCount)
+            let height = dataSource.heightForIndexPath(indexPath, numberOfColumns: 1)
+            return CGSize(width: width, height: height)
     }
 
     public func collectionView(collectionView: UICollectionView,

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -432,7 +432,11 @@ public class StreamViewController: BaseElloViewController {
         rotationNotification = NotificationObserver(notification: Application.Notifications.DidChangeStatusBarOrientation) { [unowned self] _ in
             self.collectionView.reloadData()
         }
-        sizeChangedNotification = NotificationObserver(notification: Application.Notifications.ViewSizeDidChange) { [unowned self] _ in
+        sizeChangedNotification = NotificationObserver(notification: Application.Notifications.ViewSizeDidChange) { [unowned self] size in
+            if let layout = self.collectionView.collectionViewLayout as? StreamCollectionViewLayout {
+                layout.columnCount = self.streamKind.columnCountFor(width: size.width)
+                layout.invalidateLayout()
+            }
             self.collectionView.reloadData()
         }
 

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -171,6 +171,12 @@ public class StreamViewController: BaseElloViewController {
             self.pullToRefreshView?.defaultContentInset = contentInset
         }
     }
+    public var columnCount: Int {
+        guard let layout = self.collectionView.collectionViewLayout as? StreamCollectionViewLayout else {
+            return 1
+        }
+        return layout.columnCount
+    }
 
     var pullToRefreshEnabled: Bool = true {
         didSet { pullToRefreshView?.hidden = !pullToRefreshEnabled }
@@ -523,7 +529,7 @@ public class StreamViewController: BaseElloViewController {
     }
 
     private func updateCellHeight(indexPath: NSIndexPath, height: CGFloat) {
-        let existingHeight = dataSource.heightForIndexPath(indexPath, numberOfColumns: streamKind.columnCount)
+        let existingHeight = dataSource.heightForIndexPath(indexPath, numberOfColumns: columnCount)
         if height != existingHeight {
             collectionView.performBatchUpdates({
                 self.dataSource.updateHeightForIndexPath(indexPath, height: height)
@@ -546,7 +552,7 @@ public class StreamViewController: BaseElloViewController {
     // this gets reset whenever the streamKind changes
     private func setupCollectionViewLayout() {
         if let layout = collectionView.collectionViewLayout as? StreamCollectionViewLayout {
-            layout.columnCount = streamKind.columnCount
+            layout.columnCount = streamKind.columnCountFor(width: view.frame.width)
             layout.sectionInset = UIEdgeInsetsZero
             layout.minimumColumnSpacing = streamKind.columnSpacing
             layout.minimumInteritemSpacing = 0
@@ -723,7 +729,7 @@ extension StreamViewController: StreamCollectionViewLayoutDelegate {
     public func collectionView(collectionView: UICollectionView,
         layout collectionViewLayout: UICollectionViewLayout,
         sizeForItemAtIndexPath indexPath: NSIndexPath) -> CGSize {
-            let width = calculateColumnWidth(screenWidth: UIWindow.windowWidth(), columnCount: streamKind.columnCount)
+            let width = calculateColumnWidth(screenWidth: UIWindow.windowWidth(), columnCount: columnCount)
             let height = dataSource.heightForIndexPath(indexPath, numberOfColumns: 1)
             return CGSize(width: width, height: height)
     }

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -432,7 +432,7 @@ public class StreamViewController: BaseElloViewController {
         rotationNotification = NotificationObserver(notification: Application.Notifications.DidChangeStatusBarOrientation) { [unowned self] _ in
             self.collectionView.reloadData()
         }
-        sizeChangedNotification = NotificationObserver(notification: Application.Notifications.ViewSizeDidChange) { [unowned self] size in
+        sizeChangedNotification = NotificationObserver(notification: Application.Notifications.ViewSizeWillChange) { [unowned self] size in
             if let layout = self.collectionView.collectionViewLayout as? StreamCollectionViewLayout {
                 layout.columnCount = self.streamKind.columnCountFor(width: size.width)
                 layout.invalidateLayout()

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -242,8 +242,10 @@ public class StreamViewController: BaseElloViewController {
     }
 
     public func imageCellHeightUpdated(cell: StreamImageCell) {
-        if let indexPath = collectionView.indexPathForCell(cell) {
-            updateCellHeight(indexPath, height: cell.calculatedHeight)
+        if let indexPath = collectionView.indexPathForCell(cell),
+            calculatedHeight = cell.calculatedHeight
+        {
+            updateCellHeight(indexPath, height: calculatedHeight)
         }
     }
 

--- a/Sources/Extensions/ScreenExtensions.swift
+++ b/Sources/Extensions/ScreenExtensions.swift
@@ -23,5 +23,8 @@ extension UIWindow {
 
 
 public class Window {
-    static public var isWide: Bool { return UIWindow.mainWindow.frame.size.width > 1000 }
+    static public func isWide(width: CGFloat) -> Bool {
+        return width > 1000
+    }
+    static public var width: CGFloat { return UIWindow.mainWindow.frame.size.width }
 }

--- a/Sources/Model/Regions/Asset.swift
+++ b/Sources/Model/Regions/Asset.swift
@@ -63,7 +63,7 @@ public final class Asset: JSONAble {
     }
 
     public var gridLayoutAttachment: Attachment? {
-        let isWide = Window.isWide
+        let isWide = Window.isWide(Window.width)
         if isWide {
             return self.hdpi
         }

--- a/Sources/Utilities/Application.swift
+++ b/Sources/Utilities/Application.swift
@@ -27,7 +27,7 @@ public class Application {
         public static let WillTerminate = TypedNotification<Application>(name: "com.Ello.Application.WillTerminate")
         public static let SizeCategoryDidChange = TypedNotification<Application>(name: "com.Ello.Application.SizeCategoryDidChange")
         public static let TraitCollectionDidChange = TypedNotification<UITraitCollection>(name: "com.Ello.Application.TraitCollectionDidChange")
-        public static let ViewSizeDidChange = TypedNotification<CGSize>(name: "com.Ello.Application.ViewSizeDidChange")
+        public static let ViewSizeWillChange = TypedNotification<CGSize>(name: "com.Ello.Application.ViewSizeWillChange")
     }
 
     public class func shared() -> Application {

--- a/Sources/Utilities/Math.swift
+++ b/Sources/Utilities/Math.swift
@@ -46,3 +46,7 @@ public func pixelAwareFloor(value: Double) -> Double {
     let scale = Double(UIScreen.mainScreen().scale)
     return floor(value*scale)/scale
 }
+
+public func calculateColumnWidth(screenWidth screenWidth: CGFloat, columnCount: Int) -> CGFloat {
+    return (screenWidth - 10 * CGFloat(columnCount - 1)) / CGFloat(columnCount)
+}

--- a/Specs/Controllers/Stream/StreamNotificationCellSizeCalculatorSpec.swift
+++ b/Specs/Controllers/Stream/StreamNotificationCellSizeCalculatorSpec.swift
@@ -43,8 +43,8 @@ class StreamNotificationCellSizeCalculatorSpec : QuickSpec {
                 let activity: Activity = stub(["kind": "new_follower_post", "subject": user])
                 let notification: Notification = stub(["activity": activity])
                 let item = StreamCellItem(jsonable: notification, type: .Notification)
-                subject.processCells([item], withWidth: 320, completion: {
-                })
+                subject.processCells([item], withWidth: 320, columnCount: 1) {
+                }
                 expect(item.calculatedWebHeight) == 0
                 expect(item.calculatedOneColumnCellHeight) == 67
                 expect(item.calculatedMultiColumnCellHeight) == 67
@@ -53,8 +53,8 @@ class StreamNotificationCellSizeCalculatorSpec : QuickSpec {
                 let activity: Activity = stub(["kind": "repost_notification", "subject": postWithText])
                 let notification: Notification = stub(["activity": activity])
                 let item = StreamCellItem(jsonable: notification, type: .Notification)
-                subject.processCells([item], withWidth: 320, completion: {
-                })
+                subject.processCells([item], withWidth: 320, columnCount: 1) {
+                }
                 expect(item.calculatedWebHeight) == 50
                 expect(item.calculatedOneColumnCellHeight) == 112
                 expect(item.calculatedMultiColumnCellHeight) == 112
@@ -63,8 +63,8 @@ class StreamNotificationCellSizeCalculatorSpec : QuickSpec {
                 let activity: Activity = stub(["kind": "repost_notification", "subject": postWithImage])
                 let notification: Notification = stub(["activity": activity])
                 let item = StreamCellItem(jsonable: notification, type: .Notification)
-                subject.processCells([item], withWidth: 320, completion: {
-                })
+                subject.processCells([item], withWidth: 320, columnCount: 1) {
+                }
                 expect(item.calculatedOneColumnCellHeight) == 129
                 expect(item.calculatedMultiColumnCellHeight) == 129
             }
@@ -72,8 +72,8 @@ class StreamNotificationCellSizeCalculatorSpec : QuickSpec {
                 let activity: Activity = stub(["kind": "repost_notification", "subject": postWithTextAndImage])
                 let notification: Notification = stub(["activity": activity])
                 let item = StreamCellItem(jsonable: notification, type: .Notification)
-                subject.processCells([item], withWidth: 320, completion: {
-                })
+                subject.processCells([item], withWidth: 320, columnCount: 1) {
+                }
                 expect(item.calculatedWebHeight) == 50
                 expect(item.calculatedOneColumnCellHeight) == 129
                 expect(item.calculatedMultiColumnCellHeight) == 129
@@ -85,8 +85,8 @@ class StreamNotificationCellSizeCalculatorSpec : QuickSpec {
                 let activity: Activity = stub(["kind": "comment_notification", "subject": postWithText])
                 let notification: Notification = stub(["activity": activity])
                 let item = StreamCellItem(jsonable: notification, type: .Notification)
-                subject.processCells([item], withWidth: 320, completion: {
-                })
+                subject.processCells([item], withWidth: 320, columnCount: 1) {
+                }
                 expect(item.calculatedWebHeight) == 50
                 expect(item.calculatedOneColumnCellHeight) == 157
                 expect(item.calculatedMultiColumnCellHeight) == 157

--- a/Specs/Environment/AppSetupSpec.swift
+++ b/Specs/Environment/AppSetupSpec.swift
@@ -18,6 +18,9 @@ class AppSetupSpec: QuickSpec {
                 if UIDevice.currentDevice().name == "iPhone Simulator" {
                     expect(AppSetup.sharedState.isSimulator) == true
                 }
+                else if UIDevice.currentDevice().name == "iPad Simulator" {
+                    expect(AppSetup.sharedState.isSimulator) == true
+                }
                 else {
                     expect(AppSetup.sharedState.isSimulator) == false
                 }

--- a/Specs/Fakes/FakeProfileHeaderCellSizeCalculator.swift
+++ b/Specs/Fakes/FakeProfileHeaderCellSizeCalculator.swift
@@ -11,7 +11,7 @@ import Ello
 
 public class FakeProfileHeaderCellSizeCalculator: ProfileHeaderCellSizeCalculator {
 
-    override public func processCells(cellItems:[StreamCellItem], withWidth: CGFloat, completion:ElloEmptyCompletion) {
+    override public func processCells(cellItems:[StreamCellItem], withWidth: CGFloat, columnCount: Int, completion:ElloEmptyCompletion) {
         self.completion = completion
         self.cellItems = cellItems
         for item in cellItems {

--- a/Specs/Fakes/FakeStreamNotificationCellSizeCalculator.swift
+++ b/Specs/Fakes/FakeStreamNotificationCellSizeCalculator.swift
@@ -12,7 +12,7 @@ import Foundation
 
 public class FakeStreamNotificationCellSizeCalculator: StreamNotificationCellSizeCalculator {
 
-    override public func processCells(cellItems:[StreamCellItem], withWidth: CGFloat, completion:StreamTextCellSizeCalculated) {
+    override public func processCells(cellItems:[StreamCellItem], withWidth: CGFloat, columnCount: Int, completion:StreamTextCellSizeCalculated) {
         self.completion = completion
         self.cellItems = cellItems
         for item in cellItems {

--- a/Specs/Fakes/FakeStreamTextCellSizeCalculator.swift
+++ b/Specs/Fakes/FakeStreamTextCellSizeCalculator.swift
@@ -11,7 +11,7 @@ import Ello
 
 public class FakeStreamTextCellSizeCalculator: StreamTextCellSizeCalculator {
 
-    override public func processCells(cellItems:[StreamCellItem], withWidth: CGFloat, completion:StreamTextCellSizeCalculated) {
+    override public func processCells(cellItems:[StreamCellItem], withWidth: CGFloat, columnCount: Int, completion:StreamTextCellSizeCalculated) {
         self.completion = completion
         self.cellItems = cellItems
         for item in cellItems {


### PR DESCRIPTION
Images were being stretched because the `cell.frame` can change *after* `cellForItemAtIndexPath` is called.

The frame is used to determine the "expected height", and so this check needs to be in `layoutSubviews`, where it can listen for all changes to the frame.

Originally I created this branch to support 3-columns on all streams - that's done, too!