### PR TITLE
Accept username *or* email in Sign In screen

### DIFF
--- a/Sources/Controllers/SignIn/SignInViewController.swift
+++ b/Sources/Controllers/SignIn/SignInViewController.swift
@@ -91,7 +91,7 @@ public class SignInViewController: BaseElloViewController, HasAppController {
     private var password: String { return passwordTextField.text ?? "" }
 
     private func hasValidCredentials() -> Bool {
-        return trimmedEmail.isValidEmail() && password.isValidPassword()
+        return (trimmedEmail.isValidEmail() || trimmedEmail.isValidUsername()) && password.isValidPassword()
     }
 
     private func invalidCredentialsReason() -> String {

--- a/Sources/Controllers/SignIn/SignInViewController.xib
+++ b/Sources/Controllers/SignIn/SignInViewController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
@@ -93,7 +93,7 @@
                                                 <action selector="enterTapped:" destination="-1" eventType="touchUpInside" id="Xvx-43-uxr"/>
                                             </connections>
                                         </button>
-                                        <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Enter your email address" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ciS-FV-Pbi" userLabel="emailTextField" customClass="ElloTextField" customModule="Ello" customModuleProvider="target">
+                                        <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Enter your username or email" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ciS-FV-Pbi" userLabel="emailTextField" customClass="ElloTextField" customModule="Ello" customModuleProvider="target">
                                             <rect key="frame" x="0.0" y="120" width="374" height="49"/>
                                             <color key="backgroundColor" red="0.78030639889999998" green="0.78044152259999999" blue="0.78029787539999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <constraints>

--- a/Sources/Utilities/InterfaceString.swift
+++ b/Sources/Utilities/InterfaceString.swift
@@ -236,7 +236,7 @@ public struct InterfaceString {
     }
 
     public struct SignIn {
-        static let EmailInvalid = NSLocalizedString("Invalid email", comment: "Invalid email message")
+        static let EmailInvalid = NSLocalizedString("Invalid email or username", comment: "Invalid email or username message")
         static let PasswordInvalid = NSLocalizedString("Invalid password", comment: "Invalid password message")
         static let CredentialsInvalid = NSLocalizedString("Invalid credentials", comment: "Invalid credentials message")
         static let LoadUserError = NSLocalizedString("Unable to load user.", comment: "Unable to load user message")

--- a/Sources/Utilities/Validator.swift
+++ b/Sources/Utilities/Validator.swift
@@ -9,9 +9,16 @@
 public extension String {
 
     func isValidEmail() -> Bool {
-        let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,20}"
+        let emailRegEx = "^[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,20}$"
         let emailTest = NSPredicate(format:"SELF MATCHES %@", emailRegEx)
         let result = emailTest.evaluateWithObject(self)
+        return result ?? false
+    }
+
+    func isValidUsername() -> Bool {
+        let usernameRegEx = "^[_-]|[\\w-]{2,}$"
+        let usernameTest = NSPredicate(format:"SELF MATCHES %@", usernameRegEx)
+        let result = usernameTest.evaluateWithObject(self)
         return result ?? false
     }
 

--- a/Specs/Controllers/SignIn/SignInViewControllerSpec.swift
+++ b/Specs/Controllers/SignIn/SignInViewControllerSpec.swift
@@ -134,10 +134,24 @@ class SignInViewControllerSpec: QuickSpec {
                         expect(subject.passwordTextField.isFirstResponder()) == false
                     }
 
-                    context("input is valid") {
+                    context("input is valid email") {
 
                         it("disables input") {
                             subject.emailTextField.text = "name@example.com"
+                            subject.passwordTextField.text = "12345678"
+
+                            subject.enterTapped(subject.enterButton)
+                            expect(subject.emailTextField.enabled) == false
+                            expect(subject.passwordTextField.enabled) == false
+                            expect(subject.view.userInteractionEnabled) == false
+                        }
+
+                    }
+
+                    context("input is valid username") {
+
+                        it("disables input") {
+                            subject.emailTextField.text = "name"
                             subject.passwordTextField.text = "12345678"
 
                             subject.enterTapped(subject.enterButton)

--- a/Specs/Utilities/ValidatorSpec.swift
+++ b/Specs/Utilities/ValidatorSpec.swift
@@ -15,59 +15,66 @@ class ValidatorSpec: QuickSpec {
     override func spec() {
 
         context("email validation") {
+            let expectations: [(String, Bool)] = [
+                ("name@test.com", true),
+                ("n@t.co", true),
+                ("n@t.shopping", true),
+                ("some.name@domain.co.uk", true),
+                ("some+name@domain.somethingreallylong", true),
+                ("test.com", false),
+                ("name@test", false),
+                ("name@.com", false),
+                ("name@name.com.", false),
+                ("name@name.t", false),
+                ("", false),
+            ]
 
-            it("returns true for a valid email") {
-                var email = "name@test.com"
-                expect(email.isValidEmail()) == true
-
-                email = "n@t.co"
-                expect(email.isValidEmail()) == true
-
-                email = "n@t.shopping"
-                expect(email.isValidEmail()) == true
-
-                email = "some.name@domain.co.uk"
-                expect(email.isValidEmail()) == true
-
-                email = "some+name@domain.somethingreallylong"
-                expect(email.isValidEmail()) == true
+            for (test, expected) in expectations {
+                it("returns \(expected) for \(test)") {
+                    expect(test.isValidEmail()) == expected
+                }
             }
 
-            it("returns false for an invalid email") {
-                var email = "test.com"
-                expect(email.isValidEmail()) == false
+        }
 
-                email = "name@test"
-                expect(email.isValidEmail()) == false
+        context("username validation") {
+            let expectations: [(String, Bool)] = [
+                ("", false),
+                ("a", false),
+                ("aa", true),
+                ("-a", true),
+                ("a-", true),
+                ("--", true),
+                ("user%", false),
+            ]
 
-                email = "name@.com"
-                expect(email.isValidEmail()) == false
-
-                email = "name@name.com."
-                expect(email.isValidEmail()) == false
-
-                email = "name@name.t"
-                expect(email.isValidEmail()) == false
-
-                email = ""
-                expect(email.isValidEmail()) == false
+            for (test, expected) in expectations {
+                it("returns \(expected) for \(test)") {
+                    expect(test.isValidUsername()) == expected
+                }
             }
 
         }
 
         context("password validation") {
+            let expectations: [(String, Bool)] = [
+                ("asdfasdf", true),
+                ("12345678", true),
+                ("123456789", true),
+                ("", false),
+                ("1", false),
+                ("12", false),
+                ("123", false),
+                ("1234", false),
+                ("12345", false),
+                ("123456", false),
+                ("1234567", false),
+            ]
 
-            it("returns true for a valid password") {
-                var password = "asdfasdf"
-                expect(password.isValidPassword()) == true
-
-                password = "123456789"
-                expect(password.isValidPassword()) == true
-            }
-
-            it("returns false for an invalid password") {
-                let password = ""
-                expect(password.isValidPassword()) == false
+            for (test, expected) in expectations {
+                it("returns \(expected) for \(test)") {
+                    expect(test.isValidPassword()) == expected
+                }
             }
         }
     }


### PR DESCRIPTION
Adds username validation, and validates email *or* username before sending credentials