### PR TITLE
Keyboard.shared() -> Keyboard.shared

### DIFF
--- a/Sources/Controllers/Omnibar/OmnibarScreen.swift
+++ b/Sources/Controllers/Omnibar/OmnibarScreen.swift
@@ -587,14 +587,14 @@ public class OmnibarScreen: UIView, OmnibarScreenProtocol {
 
     public func keyboardWillShow() {
         self.setNeedsLayout()
-        animate(duration: Keyboard.shared().duration, options: Keyboard.shared().options) {
+        animate(duration: Keyboard.shared.duration, options: Keyboard.shared.options) {
             self.layoutIfNeeded()
         }
     }
 
     public func keyboardWillHide() {
         self.setNeedsLayout()
-        animate(duration: Keyboard.shared().duration, options: Keyboard.shared().options) {
+        animate(duration: Keyboard.shared.duration, options: Keyboard.shared.options) {
             self.layoutIfNeeded()
         }
     }
@@ -638,7 +638,7 @@ public class OmnibarScreen: UIView, OmnibarScreenProtocol {
         regionsTableView.frame = CGRect(x: 0, y: avatarButton.frame.maxY + Size.toolbarMargin, right: bounds.size.width, bottom: bounds.size.height)
         textScrollView.frame = regionsTableView.frame
 
-        var bottomInset = Keyboard.shared().keyboardBottomInset(inView: self)
+        var bottomInset = Keyboard.shared.keyboardBottomInset(inView: self)
 
         if bottomInset == 0 {
             bottomInset = ElloTabBar.Size.height + Size.keyboardButtonSize.height
@@ -655,7 +655,7 @@ public class OmnibarScreen: UIView, OmnibarScreenProtocol {
         keyboardButtonView.frame.size = CGSize(width: frame.width, height: Size.keyboardButtonSize.height)
         tabbarSubmitButton.frame.size = CGSize(width: frame.width, height: Size.keyboardButtonSize.height)
 
-        if Keyboard.shared().active {
+        if Keyboard.shared.active {
             tabbarSubmitButton.frame.origin.y = frame.height
         }
         else {

--- a/Sources/Utilities/Keyboard.swift
+++ b/Sources/Utilities/Keyboard.swift
@@ -10,8 +10,6 @@ import UIKit
 import Foundation
 import CoreGraphics
 
-private let sharedKeyboard = Keyboard()
-
 public class Keyboard {
     public struct Notifications {
         public static let KeyboardWillShow = TypedNotification<Keyboard>(name: "com.Ello.Keyboard.KeyboardWillShow")
@@ -19,13 +17,11 @@ public class Keyboard {
         public static let KeyboardWillHide = TypedNotification<Keyboard>(name: "com.Ello.Keyboard.KeyboardWillHide")
         public static let KeyboardDidHide = TypedNotification<Keyboard>(name: "com.Ello.Keyboard.KeyboardDidHide")
     }
-
-    public class func shared() -> Keyboard {
-        return sharedKeyboard
-    }
+    
+    public static let shared = Keyboard()
 
     public class func setup() {
-        let _ = shared()
+        let _ = shared
     }
 
     public var active = false

--- a/Sources/controllers/Alerts/AlertViewControllerKeyboardExtension.swift
+++ b/Sources/controllers/Alerts/AlertViewControllerKeyboardExtension.swift
@@ -11,12 +11,12 @@ import Foundation
 public extension AlertViewController {
 
     func keyboardUpdateFrame(keyboard: Keyboard) {
-        let availHeight = UIWindow.mainWindow.frame.height - (Keyboard.shared().active ? Keyboard.shared().endFrame.height : 0)
+        let availHeight = UIWindow.mainWindow.frame.height - (Keyboard.shared.active ? Keyboard.shared.endFrame.height : 0)
         let top = max(15, (availHeight - view.frame.height) / 2)
-        animate(duration: Keyboard.shared().duration) {
+        animate(duration: Keyboard.shared.duration) {
             self.view.frame.origin.y = top
 
-            let bottomInset = Keyboard.shared().keyboardBottomInset(inView: self.tableView)
+            let bottomInset = Keyboard.shared.keyboardBottomInset(inView: self.tableView)
             self.tableView.contentInset.bottom = bottomInset
             self.tableView.scrollIndicatorInsets.bottom = bottomInset
             self.tableView.scrollEnabled = (bottomInset > 0 || self.view.frame.height == MaxHeight)

--- a/Specs/Controllers/SignIn/SignInViewControllerSpec.swift
+++ b/Specs/Controllers/SignIn/SignInViewControllerSpec.swift
@@ -184,8 +184,8 @@ class SignInViewControllerSpec: QuickSpec {
                     context("keyboard is docked") {
 
                         it("adjusts scrollview") {
-                            Keyboard.shared().bottomInset = screenHeight - 303.0
-                            postNotification(Keyboard.Notifications.KeyboardWillShow, value: Keyboard.shared())
+                            Keyboard.shared.bottomInset = screenHeight - 303.0
+                            postNotification(Keyboard.Notifications.KeyboardWillShow, value: Keyboard.shared)
 
                             expect(subject.scrollView.contentInset.bottom) > 50
                         }
@@ -194,8 +194,8 @@ class SignInViewControllerSpec: QuickSpec {
                     context("keyboard is not docked") {
                         xit("does NOT adjust scrollview") {
                             // this is not easily faked with Keyboard unfortunately
-                            Keyboard.shared().bottomInset = screenHeight - 100.0
-                            postNotification(Keyboard.Notifications.KeyboardWillShow, value: Keyboard.shared())
+                            Keyboard.shared.bottomInset = screenHeight - 100.0
+                            postNotification(Keyboard.Notifications.KeyboardWillShow, value: Keyboard.shared)
 
                             expect(subject.scrollView.contentInset.bottom) == 0
                         }
@@ -205,8 +205,8 @@ class SignInViewControllerSpec: QuickSpec {
                 describe("UIKeyboardWillHideNotification") {
 
                     it("adjusts scrollview") {
-                        Keyboard.shared().bottomInset = 0.0
-                        postNotification(Keyboard.Notifications.KeyboardWillHide, value: Keyboard.shared())
+                        Keyboard.shared.bottomInset = 0.0
+                        postNotification(Keyboard.Notifications.KeyboardWillHide, value: Keyboard.shared)
 
                         expect(subject.scrollView.contentInset.bottom) == 0.0
                     }

--- a/Specs/Utilities/KeyboardSpec.swift
+++ b/Specs/Utilities/KeyboardSpec.swift
@@ -13,7 +13,7 @@ import Nimble
 class KeyboardSpec: QuickSpec {
     override func spec() {
         var window: UIWindow!
-        let keyboard: Keyboard = Keyboard.shared()
+        let keyboard: Keyboard = Keyboard.shared
         var textView: UITextView!
         var insetScrollView: UIScrollView!
 


### PR DESCRIPTION
this made sense to me - it hasn't been tested. 

I thought a global `private let` didn't seem as clean as a `public static let`