### PR TITLE
Update the onboarding logic

### DIFF
--- a/Ello.xcodeproj/project.pbxproj
+++ b/Ello.xcodeproj/project.pbxproj
@@ -571,6 +571,9 @@
 		1DBF85C11AF8022E00889349 /* ElloWebBrowserViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBF85C01AF8022E00889349 /* ElloWebBrowserViewControllerSpec.swift */; };
 		1DC10FA51C3DEB7600846ED6 /* availability__error.json in Resources */ = {isa = PBXBuildFile; fileRef = 1DC10FA31C3DEB7600846ED6 /* availability__error.json */; };
 		1DC10FA61C3DEB7600846ED6 /* availability.json in Resources */ = {isa = PBXBuildFile; fileRef = 1DC10FA41C3DEB7600846ED6 /* availability.json */; };
+		1DC29BB51D3824720041B1DC /* Onboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3128BF1B557BD500E3D5B6 /* Onboarding.swift */; };
+		1DC29BB71D3824D30041B1DC /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC29BB61D3824D30041B1DC /* Defaults.swift */; };
+		1DC29BB81D3824DE0041B1DC /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC29BB61D3824D30041B1DC /* Defaults.swift */; };
 		1DC309F81B03E64E00EAD920 /* CommunitySelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC309F51B03E64E00EAD920 /* CommunitySelectionViewController.swift */; };
 		1DC309F91B03E64E00EAD920 /* OnboardingHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC309F61B03E64E00EAD920 /* OnboardingHeaderCell.swift */; };
 		1DC309FA1B03E64E00EAD920 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC309F71B03E64E00EAD920 /* OnboardingViewController.swift */; };
@@ -1378,6 +1381,7 @@
 		1DBF85C01AF8022E00889349 /* ElloWebBrowserViewControllerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElloWebBrowserViewControllerSpec.swift; sourceTree = "<group>"; };
 		1DC10FA31C3DEB7600846ED6 /* availability__error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = availability__error.json; sourceTree = "<group>"; };
 		1DC10FA41C3DEB7600846ED6 /* availability.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = availability.json; sourceTree = "<group>"; };
+		1DC29BB61D3824D30041B1DC /* Defaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Defaults.swift; sourceTree = "<group>"; };
 		1DC309F51B03E64E00EAD920 /* CommunitySelectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommunitySelectionViewController.swift; sourceTree = "<group>"; };
 		1DC309F61B03E64E00EAD920 /* OnboardingHeaderCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingHeaderCell.swift; sourceTree = "<group>"; };
 		1DC309F71B03E64E00EAD920 /* OnboardingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
@@ -2600,6 +2604,7 @@
 				1D7750F81ABB68DF00D92191 /* ToNSData.swift */,
 				127128251A77373300695F15 /* TypedNotifications.swift */,
 				12F6AE611A4339C600493660 /* Validator.swift */,
+				1DC29BB61D3824D30041B1DC /* Defaults.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -3993,6 +3998,7 @@
 				1207C9A11C752F1300939ADB /* ElloURI.swift in Sources */,
 				122B30B61C6A3FBB00C1B9D8 /* DynamicSetting.swift in Sources */,
 				1D2F65AA1D185B120099D036 /* DiscoverType.swift in Sources */,
+				1DC29BB51D3824720041B1DC /* Onboarding.swift in Sources */,
 				122B30FA1C6A429E00C1B9D8 /* AttributedStringExtensions.swift in Sources */,
 				122D1BA61C6134D5001386CE /* UIViewNibLoading.swift in Sources */,
 				122B30B31C6A3FBB00C1B9D8 /* Availability.swift in Sources */,
@@ -4073,6 +4079,7 @@
 				122B30C21C6A3FBB00C1B9D8 /* Profile.swift in Sources */,
 				122B30EB1C6A3FC400C1B9D8 /* UnknownRegion.swift in Sources */,
 				122D1B4F1C602337001386CE /* MutableBox.swift in Sources */,
+				1DC29BB81D3824DE0041B1DC /* Defaults.swift in Sources */,
 				122D1B9A1C6130B4001386CE /* NSObjectClassName.swift in Sources */,
 				122D1B991C61308F001386CE /* AlertAction.swift in Sources */,
 				122B30C01C6A3FBB00C1B9D8 /* NotificationAttributedTitle.swift in Sources */,
@@ -4377,6 +4384,7 @@
 				122B30CB1C6A3FBC00C1B9D8 /* Comment.swift in Sources */,
 				1207C9AD1C75314300939ADB /* OmnibarRegion.swift in Sources */,
 				1D807DAC1B06B725009B0F71 /* ImportFriendsViewController.swift in Sources */,
+				1DC29BB71D3824D30041B1DC /* Defaults.swift in Sources */,
 				1207C9771C73FEE000939ADB /* DateFormatting.swift in Sources */,
 				122B30E11C6A3FBF00C1B9D8 /* Tracker.swift in Sources */,
 				12551FBA1A68729900ABC5D9 /* OmnibarViewController.swift in Sources */,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9,8 +9,6 @@ import PINRemoteImage
 import PINCache
 import ElloUIFonts
 
-public let GroupDefaults = NSUserDefaults(suiteName: "group.ello.Ello") ?? NSUserDefaults.standardUserDefaults()
-
 @UIApplicationMain
 public class AppDelegate: UIResponder, UIApplicationDelegate {
 

--- a/Sources/Controllers/App/AppViewController.swift
+++ b/Sources/Controllers/App/AppViewController.swift
@@ -117,12 +117,19 @@ public class AppViewController: BaseElloViewController {
                 self.logoView.stopAnimatingLogo()
                 self.currentUser = user
 
-                let shouldShowOnboarding = !Onboarding.shared().hasSeenLatestVersion()
+                let shouldShowOnboarding = Onboarding.shared().showOnboarding(user)
+                let shouldSaveOnboarding = Onboarding.shared().saveOnboarding(user)
+
                 if shouldShowOnboarding {
                     self.showOnboardingScreen(user)
                 }
                 else {
+                    Onboarding.shared().updateVersionToLatest()
                     self.showMainScreen(user)
+                }
+
+                if shouldSaveOnboarding {
+                    profileService.updateUserProfile(["web_onboarding_version": Onboarding.currentVersion], success: { _ in }, failure: { _ in })
                 }
             },
             failure: { (error, _) in

--- a/Sources/Model/ElloLinkedStore.swift
+++ b/Sources/Model/ElloLinkedStore.swift
@@ -66,11 +66,8 @@ private extension ElloLinkedStore {
         if let overrideDefaults = overrideDefaults {
             defaults = overrideDefaults
         }
-        else if let groupDefaults = NSUserDefaults(suiteName: "group.ello.Ello") {
-            defaults = groupDefaults
-        }
         else {
-            defaults = NSUserDefaults.standardUserDefaults()
+            defaults = GroupDefaults
         }
 
         let didDeleteNonSharedDB = defaults["DidDeleteNonSharedDB"].bool ?? false
@@ -107,7 +104,7 @@ private extension ElloLinkedStore {
 
     static func databasePath() -> String {
         var path = ""
-        if let baseURL = NSFileManager.defaultManager().containerURLForSecurityApplicationGroupIdentifier("group.ello.Ello") {
+        if let baseURL = NSFileManager.defaultManager().containerURLForSecurityApplicationGroupIdentifier(ElloGroupName) {
             path = baseURL.URLByAppendingPathComponent(ElloLinkedStore.databaseName).path ?? ""
         }
         return path

--- a/Sources/Model/User.swift
+++ b/Sources/Model/User.swift
@@ -35,6 +35,7 @@ public final class User: JSONAble {
     public var externalLinksList: [[String: String]]?
     public var coverImage: Asset?
     public var backgroundPosition: String?
+    public var onboardingVersion: Int?
     // links
     public var posts: [Post]? { return getLinkArray("posts") as? [Post] }
     public var mostRecentPost: Post? { return getLinkObject("most_recent_post") as? Post }
@@ -121,6 +122,7 @@ public final class User: JSONAble {
         self.externalLinksList = decoder.decodeOptionalKey("externalLinksList")
         self.coverImage = decoder.decodeOptionalKey("coverImage")
         self.backgroundPosition = decoder.decodeOptionalKey("backgroundPosition")
+        self.onboardingVersion = decoder.decodeOptionalKey("onboardingVersion")
         // profile
         self.profile = decoder.decodeOptionalKey("profile")
         super.init(coder: decoder.coder)
@@ -153,6 +155,7 @@ public final class User: JSONAble {
         coder.encodeObject(externalLinksList, forKey: "externalLinksList")
         coder.encodeObject(coverImage, forKey: "coverImage")
         coder.encodeObject(backgroundPosition, forKey: "backgroundPosition")
+        coder.encodeObject(onboardingVersion, forKey: "onboardingVersion")
         // profile
         coder.encodeObject(profile, forKey: "profile")
         super.encodeWithCoder(coder.coder)
@@ -202,6 +205,9 @@ public final class User: JSONAble {
         user.externalLinksList = json["external_links_list"].arrayValue.map { ["text": $0["text"].stringValue, "url": $0["url"].stringValue] }
         user.coverImage = Asset.parseAsset("user_cover_image_\(user.id)", node: data["cover_image"] as? [String: AnyObject])
         user.backgroundPosition = json["background_positiion"].stringValue
+        if let webOnboardingVersion = json["web_onboarding_version"].string {
+            user.onboardingVersion = Int(webOnboardingVersion)
+        }
         // links
         user.links = data["links"] as? [String: AnyObject]
         // profile

--- a/Sources/Networking/ElloManager.swift
+++ b/Sources/Networking/ElloManager.swift
@@ -22,7 +22,7 @@ public struct ElloManager {
 
     public static var manager: Manager {
         let config = NSURLSessionConfiguration.defaultSessionConfiguration()
-        config.sharedContainerIdentifier = "group.ello.Ello"
+        config.sharedContainerIdentifier = ElloGroupName
         return Manager(
             configuration: config,
             serverTrustPolicyManager: ServerTrustPolicyManager(policies: ElloManager.serverTrustPolicies)
@@ -31,7 +31,7 @@ public struct ElloManager {
 
     public static var shareExtensionManager: Manager {
         let config = NSURLSessionConfiguration.backgroundSessionConfigurationWithIdentifier("co.ello.shareextension.background")
-        config.sharedContainerIdentifier = "group.ello.Ello"
+        config.sharedContainerIdentifier = ElloGroupName
         config.sessionSendsLaunchEvents = false
         return Manager(
             configuration: config,

--- a/Sources/Utilities/Defaults.swift
+++ b/Sources/Utilities/Defaults.swift
@@ -1,0 +1,8 @@
+////
+///  Defaults.swift
+//
+
+import Foundation
+
+public let ElloGroupName = "group.ello.Ello"
+public let GroupDefaults = NSUserDefaults(suiteName: ElloGroupName) ?? NSUserDefaults.standardUserDefaults()

--- a/Sources/Utilities/ObjectCache.swift
+++ b/Sources/Utilities/ObjectCache.swift
@@ -18,7 +18,7 @@ public class ObjectCache<T: AnyObject> {
 
     public init(name: String) {
         self.name = name
-        persistentLayer = NSUserDefaults(suiteName: "group.ello.Ello") ?? NSUserDefaults.standardUserDefaults()
+        persistentLayer = GroupDefaults
     }
 
     public init(name: String, persistentLayer: PersistentLayer) {

--- a/Sources/Utilities/Onboarding.swift
+++ b/Sources/Utilities/Onboarding.swift
@@ -9,13 +9,13 @@ private let _sharedInstance = Onboarding()
 private let _currentVersion = 1
 
 public class Onboarding {
-    private var version: Int {
+    public private(set) var version: Int {
         didSet {
             GroupDefaults["ViewedOnboardingVersion"] = version
         }
     }
 
-    public class func currentVersion() -> Int {
+    public static var currentVersion: Int {
         return _currentVersion
     }
 
@@ -35,8 +35,23 @@ public class Onboarding {
         version = GroupDefaults["ViewedOnboardingVersion"].int ?? 0
     }
 
-    public func hasSeenLatestVersion() -> Bool {
-        return version >= _currentVersion
+    // only show if webVersion is set and
+    // localVersion < currentVersion and
+    // webVersion < currentVersion
+    public func showOnboarding(user: User) -> Bool {
+        guard let webVersion = user.onboardingVersion else {
+            return false
+        }
+        return version < _currentVersion && webVersion < _currentVersion
+    }
+
+    // save to API if webVersion is nil,
+    // or less than currentVersion
+    public func saveOnboarding(user: User) -> Bool {
+        guard let webVersion = user.onboardingVersion else {
+            return true
+        }
+        return webVersion < _currentVersion
     }
 
 }

--- a/Specs/Helpers/Stubs.swift
+++ b/Specs/Helpers/Stubs.swift
@@ -77,6 +77,7 @@ extension User: Stubbable {
         user.externalLinksList = (values["externalLinksList"] as? [[String:String]]) ?? [["text": "ello.co", "url": "http://ello.co"]]
         user.coverImage = values["coverImage"] as? Asset
         user.backgroundPosition = (values["backgroundPosition"] as? String) ?? "stub-user-background-position"
+        user.onboardingVersion = (values["onboardingVersion"] as? Int)
         // links / nested resources
         if let posts = values["posts"] as? [Post] {
             var postIds = [String]()

--- a/Specs/Utilities/ObjectCacheSpec.swift
+++ b/Specs/Utilities/ObjectCacheSpec.swift
@@ -22,7 +22,7 @@ class ObjectCacheSpec: QuickSpec {
             it("sets NSUserDefaults as the default persistent layer") {
                 let cache = ObjectCache<NSString>(name: "test")
                 cache.append("hello")
-                let defaults = NSUserDefaults(suiteName: "group.ello.Ello") ?? NSUserDefaults.standardUserDefaults()
+                let defaults = NSUserDefaults(suiteName: ElloGroupName) ?? NSUserDefaults.standardUserDefaults()
                 expect(defaults.objectForKey("test") as? [String]) == ["hello"]
             }
         }

--- a/Specs/Utilities/OnboardingSpec.swift
+++ b/Specs/Utilities/OnboardingSpec.swift
@@ -8,39 +8,64 @@
 
 import Quick
 import Nimble
-import Ello
 import SwiftyUserDefaults
+@testable
+import Ello
 
 
 class OnboardingSpec: QuickSpec {
     override func spec() {
-        let currentVersion: Int? = GroupDefaults["ViewedOnboardingVersion"].int
-        afterEach {
-            GroupDefaults["ViewedOnboardingVersion"] = currentVersion
-        }
+        describe("Onboarding") {
+            let currentVersion: Int? = GroupDefaults["ViewedOnboardingVersion"].int
+            afterSuite {
+                GroupDefaults["ViewedOnboardingVersion"] = currentVersion
+            }
 
-        describe("onboarding version has never been set") {
-            beforeEach {
-                GroupDefaults["ViewedOnboardingVersion"] = nil
-            }
-            it("should show onboarding") {
-                expect(Onboarding.shared().hasSeenLatestVersion()).to(beFalse())
-            }
-        }
-        describe("onboarding version has been set to older version") {
-            beforeEach {
-                GroupDefaults["ViewedOnboardingVersion"] = 0
-            }
-            it("should show onboarding") {
-                expect(Onboarding.shared().hasSeenLatestVersion()).to(beFalse())
-            }
-        }
-        describe("onboarding version has been set to current version") {
-            beforeEach {
-                Onboarding.shared().updateVersionToLatest()
-            }
-            it("should not show onboarding") {
-                expect(Onboarding.shared().hasSeenLatestVersion()).to(beTrue())
+            let expectations: [(localIsCurrent: Bool, webIsCurrent: Bool?, showOnboarding: Bool, saveOnboarding: Bool)] = [
+                (localIsCurrent: true, webIsCurrent: nil, showOnboarding: false, saveOnboarding: true),
+                (localIsCurrent: true, webIsCurrent: false, showOnboarding: false, saveOnboarding: true),
+                (localIsCurrent: true, webIsCurrent: true, showOnboarding: false, saveOnboarding: false),
+                (localIsCurrent: false, webIsCurrent: nil, showOnboarding: false, saveOnboarding: true),
+                (localIsCurrent: false, webIsCurrent: false, showOnboarding: true, saveOnboarding: true),
+                (localIsCurrent: false, webIsCurrent: true, showOnboarding: false, saveOnboarding: false),
+            ]
+            for (localIsCurrent, webIsCurrent, showOnboarding, saveOnboarding) in expectations {
+                let title1: String
+                if localIsCurrent { title1 = "localVersion is currentVersion" }
+                else { title1 = "localVersion less than currentVersion" }
+                let title2: String
+                switch webIsCurrent {
+                case .None:        title2 = "webVersion is nil"
+                case .Some(true):  title2 = "webVersion is currentVersion"
+                case .Some(false): title2 = "webVersion less than currentVersion"
+                }
+                describe("\(title1) and \(title2)") {
+                    it("showOnboarding should be \(showOnboarding), saveOnboarding should be \(saveOnboarding)") {
+                        if localIsCurrent {
+                            GroupDefaults["ViewedOnboardingVersion"] = 1
+                        }
+                        else {
+                            GroupDefaults["ViewedOnboardingVersion"] = 0
+                        }
+                        let onboarding = Onboarding()
+
+                        var props: [String: AnyObject] = [:]
+                        if case let .Some(webIsCurrent) = webIsCurrent {
+                            props["onboardingVersion"] = (webIsCurrent ? 1 : 0)
+                        }
+                        let user: User = stub(props)
+
+                        expect(onboarding.version) == (localIsCurrent ? 1 : 0)
+                        if let webIsCurrent = webIsCurrent {
+                            expect(user.onboardingVersion ?? -1) == (webIsCurrent ? 1 : 0)
+                        }
+                        else {
+                            expect(user.onboardingVersion).to(beNil())
+                        }
+                        expect(onboarding.showOnboarding(user)) == showOnboarding
+                        expect(onboarding.saveOnboarding(user)) == saveOnboarding
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
See specs for a complete table of expectations, but essentially:

- only show onboarding once, on any platform
- if web value is nil, assume it's been seen
- if web and local are both < current, show onboarding

then:

- update the API as needed