### PR TITLE
Only show category in .Discover(.Featured) stream

### DIFF
--- a/Sources/Controllers/Stream/CellDequeing/StreamHeaderCellPresenter.swift
+++ b/Sources/Controllers/Stream/CellDequeing/StreamHeaderCellPresenter.swift
@@ -75,7 +75,12 @@ public struct StreamHeaderCellPresenter {
                 followButtonVisible = false
             }
 
-            cell.setDetails(user: author, repostedBy: repostedBy, category: post?.category)
+            var category: Category?
+            if streamKind.showsCategory {
+                category = post?.category
+            }
+
+            cell.setDetails(user: author, repostedBy: repostedBy, category: category)
             cell.followButtonVisible = followButtonVisible
             if streamKind.isGridView {
                 cell.timeStamp = ""

--- a/Sources/Controllers/Stream/StreamKind.swift
+++ b/Sources/Controllers/Stream/StreamKind.swift
@@ -92,6 +92,13 @@ public enum StreamKind {
         }
     }
 
+    public var showsCategory: Bool {
+        if case let .Discover(type) = self where type == .Featured {
+            return true
+        }
+        return false
+    }
+
     public var tappingTextOpensDetail: Bool {
         switch self {
         case .Following, .Starred:

--- a/Specs/Controllers/Stream/CellDequeing/StreamHeaderCellPresenterSpec.swift
+++ b/Specs/Controllers/Stream/CellDequeing/StreamHeaderCellPresenterSpec.swift
@@ -253,13 +253,20 @@ class StreamHeaderCellPresenterSpec: QuickSpec {
                     cell = StreamHeaderCell.loadFromNib() as StreamHeaderCell
                     item = StreamCellItem(jsonable: post, type: .Header)
                 }
-                it("sets followButtonVisible") {
+                it("sets categoryButton in .Featured stream") {
                     cell.followButtonVisible = false
-                    StreamHeaderCellPresenter.configure(cell, streamCellItem: item, streamKind: .PostDetail(postParam: "768"), indexPath: NSIndexPath(forItem: 0, inSection: 0), currentUser: currentUser)
+                    StreamHeaderCellPresenter.configure(cell, streamCellItem: item, streamKind: .Discover(type: .Featured), indexPath: NSIndexPath(forItem: 0, inSection: 0), currentUser: currentUser)
                     expect(cell.followButtonVisible) == false
                     expect(cell.relationshipControl.hidden) == true
                     expect(cell.categoryButton.currentTitle) == "in Art"
                     expect(cell.categoryButton.hidden) == false
+                }
+                it("hides categoryButton if not in .Featured stream") {
+                    cell.followButtonVisible = false
+                    StreamHeaderCellPresenter.configure(cell, streamCellItem: item, streamKind: .PostDetail(postParam: "768"), indexPath: NSIndexPath(forItem: 0, inSection: 0), currentUser: currentUser)
+                    expect(cell.followButtonVisible) == false
+                    expect(cell.relationshipControl.hidden) == true
+                    expect(cell.categoryButton.hidden) == true
                 }
             }
 

--- a/Specs/Controllers/Stream/StreamKindSpec.swift
+++ b/Specs/Controllers/Stream/StreamKindSpec.swift
@@ -125,6 +125,31 @@ class StreamKindSpec: QuickSpec {
                 }
             }
 
+            describe("showsCategory") {
+                let expectations: [(StreamKind, Bool)] = [
+                    (.CurrentUserStream, false),
+                    (.MoreCategories, false),
+                    (.AllCategories, false),
+                    (.Discover(type: .Featured), true),
+                    (.Discover(type: .Trending), false),
+                    (.Discover(type: .Recent), false),
+                    (.CategoryPosts(slug: "art"), false),
+                    (.Following, false),
+                    (.Starred, false),
+                    (.Notifications(category: nil), false),
+                    (.Notifications(category: "comments"), false),
+                    (.PostDetail(postParam: "postId"), false),
+                    (.SimpleStream(endpoint: .AwesomePeopleStream, title: "Awesome People"), false),
+                    (.UserStream(userParam: "userId"), false),
+                    (.Unknown, false),
+                ]
+                for (streamKind, expectedValue) in expectations {
+                    it("\(streamKind) \(expectedValue ? "can" : "cannot") show category") {
+                        expect(streamKind.showsCategory) == expectedValue
+                    }
+                }
+            }
+
             describe("tappingTextOpensDetail") {
                 var followingIsGrid = false
                 var starredIsGrid = false


### PR DESCRIPTION
Last PR for 1.9.1 - hide category everywhere *except* the `discover/featured/` stream