### PR TITLE
Fixes the cover image on iPad

### DIFF
--- a/Resources/StubbedResponses/CustomResponses/affiliate-image-region.json
+++ b/Resources/StubbedResponses/CustomResponses/affiliate-image-region.json
@@ -68,24 +68,6 @@
                             "width": 1500,
                             "height": 641
                         }
-                    },
-                    "xxhdpi": {
-                        "url": "https://example.com/85/xxhdpi.jpg",
-                        "metadata": {
-                            "size": 728689,
-                            "type": "image/jpeg",
-                            "width": 2560,
-                            "height": 1094
-                        }
-                    },
-                    "xxxhdpi": {
-                        "url": "https://example.com/85/xxxhdpi.jpg",
-                        "metadata": {
-                            "size": 728687,
-                            "type": "image/jpeg",
-                            "width": 2560,
-                            "height": 1094
-                        }
                     }
                 }
             }

--- a/Resources/StubbedResponses/activity-own-post.json
+++ b/Resources/StubbedResponses/activity-own-post.json
@@ -69,24 +69,6 @@
                             "width": 1500,
                             "height": 641
                         }
-                    },
-                    "xxhdpi": {
-                        "url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/asset/attachment/5381/xxhdpi.jpg",
-                        "metadata": {
-                            "size": 728689,
-                            "type": "image/jpeg",
-                            "width": 2560,
-                            "height": 1094
-                        }
-                    },
-                    "xxxhdpi": {
-                        "url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/asset/attachment/5381/xxxhdpi.jpg",
-                        "metadata": {
-                            "size": 728687,
-                            "type": "image/jpeg",
-                            "width": 2560,
-                            "height": 1094
-                        }
                     }
                 }
             }

--- a/Resources/StubbedResponses/asset.json
+++ b/Resources/StubbedResponses/asset.json
@@ -11,6 +11,15 @@
                     "height": 1094
                 }
             },
+            "original": {
+                "url": "//example.com/5381/original.jpg",
+                "metadata": {
+                    "size": 728689,
+                    "type": "image/jpeg",
+                    "width": 2560,
+                    "height": 1094
+                }
+            },
             "small_screen": {
                 "url": "//example.com/5381/small_screen.jpg",
                 "metadata": {
@@ -54,24 +63,6 @@
                     "type": "image/jpeg",
                     "width": 1500,
                     "height": 641
-                }
-            },
-            "xxhdpi": {
-                "url": "https://example.com/5381/xxhdpi.jpg",
-                "metadata": {
-                    "size": 728689,
-                    "type": "image/jpeg",
-                    "width": 2560,
-                    "height": 1094
-                }
-            },
-            "xxxhdpi": {
-                "url": "https://example.com/5381/xxxhdpi.jpg",
-                "metadata": {
-                    "size": 728687,
-                    "type": "image/jpeg",
-                    "width": 2560,
-                    "height": 1094
                 }
             }
         }

--- a/Resources/StubbedResponses/friends.json
+++ b/Resources/StubbedResponses/friends.json
@@ -256,24 +256,6 @@
                         "width": 1500,
                         "height": 641
                     }
-                },
-                "xxhdpi": {
-                    "url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/asset/attachment/5381/xxhdpi.jpg",
-                    "metadata": {
-                        "size": 728689,
-                        "type": "image/jpeg",
-                        "width": 2560,
-                        "height": 1094
-                    }
-                },
-                "xxxhdpi": {
-                    "url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/asset/attachment/5381/xxxhdpi.jpg",
-                    "metadata": {
-                        "size": 728687,
-                        "type": "image/jpeg",
-                        "width": 2560,
-                        "height": 1094
-                    }
                 }
             }
         }]

--- a/Resources/StubbedResponses/image-region.json
+++ b/Resources/StubbedResponses/image-region.json
@@ -67,24 +67,6 @@
                             "width": 1500,
                             "height": 641
                         }
-                    },
-                    "xxhdpi": {
-                        "url": "https://example.com/85/xxhdpi.jpg",
-                        "metadata": {
-                            "size": 728689,
-                            "type": "image/jpeg",
-                            "width": 2560,
-                            "height": 1094
-                        }
-                    },
-                    "xxxhdpi": {
-                        "url": "https://example.com/85/xxxhdpi.jpg",
-                        "metadata": {
-                            "size": 728687,
-                            "type": "image/jpeg",
-                            "width": 2560,
-                            "height": 1094
-                        }
                     }
                 }
             }

--- a/Resources/StubbedResponses/posts.json
+++ b/Resources/StubbedResponses/posts.json
@@ -110,24 +110,6 @@
                             "width": 1500,
                             "height": 641
                         }
-                    },
-                    "xxhdpi": {
-                        "url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/asset/attachment/85/xxhdpi.jpg",
-                        "metadata": {
-                            "size": 728689,
-                            "type": "image/jpeg",
-                            "width": 2560,
-                            "height": 1094
-                        }
-                    },
-                    "xxxhdpi": {
-                        "url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/asset/attachment/85/xxxhdpi.jpg",
-                        "metadata": {
-                            "size": 728687,
-                            "type": "image/jpeg",
-                            "width": 2560,
-                            "height": 1094
-                        }
                     }
                 }
             }

--- a/Sources/Model/Regions/Asset.swift
+++ b/Sources/Model/Regions/Asset.swift
@@ -20,19 +20,17 @@ public final class Asset: JSONAble {
     public var mdpi: Attachment?
     public var hdpi: Attachment?
     public var xhdpi: Attachment?
-    public var xxhdpi: Attachment?
     public var original: Attachment?
     // optional avatar
     public var largeOrBest: Attachment? {
         // we originally had this expressed via
-        // return large ?? optimized ?? xxhdpi ?? xhdpi ?? hdpi ?? regular
+        // return large ?? optimized ?? xhdpi ?? hdpi ?? regular
         //
         // unfortunately that took 12.4 seconds to compile
         // this (much more verbose) code compiles very quickly
         if let large = large { return large }
         if let optimized = optimized { return optimized }
-        if let xxhdpi = xxhdpi { return xxhdpi }
-        if let xhdpi = large { return xhdpi }
+        if let xhdpi = xhdpi { return xhdpi }
         if let hdpi = hdpi { return hdpi }
         if let regular = regular { return regular }
         return nil
@@ -107,7 +105,6 @@ public final class Asset: JSONAble {
         self.mdpi = decoder.decodeOptionalKey("mdpi")
         self.hdpi = decoder.decodeOptionalKey("hdpi")
         self.xhdpi = decoder.decodeOptionalKey("xhdpi")
-        self.xxhdpi = decoder.decodeOptionalKey("xxhdpi")
         self.original = decoder.decodeOptionalKey("original")
         // optional avatar
         self.large = decoder.decodeOptionalKey("large")
@@ -127,7 +124,6 @@ public final class Asset: JSONAble {
         coder.encodeObject(mdpi, forKey: "mdpi")
         coder.encodeObject(hdpi, forKey: "hdpi")
         coder.encodeObject(xhdpi, forKey: "xhdpi")
-        coder.encodeObject(xxhdpi, forKey: "xxhdpi")
         coder.encodeObject(original, forKey: "original")
         // optional avatar
         coder.encodeObject(large, forKey: "large")
@@ -164,9 +160,6 @@ public final class Asset: JSONAble {
         }
         if let xhdpi = node?["xhdpi"] as? [String: AnyObject] {
             asset.xhdpi = Attachment.fromJSON(xhdpi) as? Attachment
-        }
-        if let xxhdpi = node?["xxhdpi"] as? [String: AnyObject] {
-            asset.xxhdpi = Attachment.fromJSON(xxhdpi) as? Attachment
         }
         if let original = node?["original"] as? [String: AnyObject] {
             asset.original = Attachment.fromJSON(original) as? Attachment

--- a/Sources/Model/User.swift
+++ b/Sources/Model/User.swift
@@ -278,12 +278,7 @@ extension User {
         if animated && (!postsAdultContent || viewsAdultContent == true) && coverImage?.original?.url.absoluteString.endsWith(".gif") == true {
             return coverImage?.original?.url
         }
-        if UIDevice.currentDevice().userInterfaceIdiom == .Pad {
-            return coverImage?.original?.url
-        }
-        else {
-            return coverImage?.xhdpi?.url
-        }
+        return coverImage?.xhdpi?.url
     }
 
     public func avatarURL(viewsAdultContent viewsAdultContent: Bool? = false, animated: Bool = false) -> NSURL? {

--- a/Sources/Model/User.swift
+++ b/Sources/Model/User.swift
@@ -278,7 +278,12 @@ extension User {
         if animated && (!postsAdultContent || viewsAdultContent == true) && coverImage?.original?.url.absoluteString.endsWith(".gif") == true {
             return coverImage?.original?.url
         }
-        return coverImage?.hdpi?.url
+        if UIDevice.currentDevice().userInterfaceIdiom == .Pad {
+            return coverImage?.original?.url
+        }
+        else {
+            return coverImage?.xhdpi?.url
+        }
     }
 
     public func avatarURL(viewsAdultContent viewsAdultContent: Bool? = false, animated: Bool = false) -> NSURL? {

--- a/Specs/Helpers/Stubs.swift
+++ b/Specs/Helpers/Stubs.swift
@@ -367,7 +367,6 @@ extension Asset: Stubbable {
         asset.mdpi = (values["mdpi"] as? Attachment) ?? defaultAttachment
         asset.hdpi = (values["hdpi"] as? Attachment) ?? defaultAttachment
         asset.xhdpi = (values["xhdpi"] as? Attachment) ?? defaultAttachment
-        asset.xxhdpi = (values["xxhdpi"] as? Attachment) ?? defaultAttachment
         asset.original = (values["original"] as? Attachment) ?? defaultAttachment
         asset.large = (values["large"] as? Attachment) ?? defaultAttachment
         asset.regular = (values["regular"] as? Attachment) ?? defaultAttachment

--- a/Specs/Model/CommentSpec.swift
+++ b/Specs/Model/CommentSpec.swift
@@ -100,12 +100,12 @@ class CommentSpec: QuickSpec {
                     expect(imageRegion.url?.absoluteString) == "http://www.example5.com"
                     expect(imageAsset.id) == "qwerty"
 
-                    let assetXXHDPI = imageAsset.xxhdpi!
-                    expect(assetXXHDPI.url.absoluteString) == "http://www.example2.com"
-                    expect(assetXXHDPI.width) == 112
-                    expect(assetXXHDPI.height) == 98
-                    expect(assetXXHDPI.size) == 5673
-                    expect(assetXXHDPI.type) == "png"
+                    let assetXhdpi = imageAsset.xhdpi!
+                    expect(assetXhdpi.url.absoluteString) == "http://www.example2.com"
+                    expect(assetXhdpi.width) == 112
+                    expect(assetXhdpi.height) == 98
+                    expect(assetXhdpi.size) == 5673
+                    expect(assetXhdpi.type) == "png"
 
                     let assetHDPI = imageAsset.hdpi!
                     expect(assetHDPI.url.absoluteString) == "http://www.example.com"
@@ -134,7 +134,7 @@ class CommentSpec: QuickSpec {
                         "size" : 666987
                     ])
 
-                    let xxhdpi: Attachment = stub([
+                    let xhdpi: Attachment = stub([
                         "url" : NSURL(string: "http://www.example2.com")!,
                         "height" : 98,
                         "width" : 112,
@@ -145,7 +145,7 @@ class CommentSpec: QuickSpec {
                     let asset: Asset = stub([
                         "id" : "qwerty",
                         "hdpi" : hdpi,
-                        "xxhdpi" : xxhdpi
+                        "xhdpi" : xhdpi
                     ])
 
                     let textRegion: TextRegion = stub([

--- a/Specs/Model/PostSpec.swift
+++ b/Specs/Model/PostSpec.swift
@@ -131,12 +131,12 @@ class PostSpec: QuickSpec {
                     expect(imageRegion.url?.absoluteString) == "http://www.example5.com"
                     expect(imageAsset.id) == "qwerty"
 
-                    let assetXXHDPI = imageAsset.xxhdpi!
-                    expect(assetXXHDPI.url.absoluteString) == "http://www.example2.com"
-                    expect(assetXXHDPI.width) == 10
-                    expect(assetXXHDPI.height) == 99
-                    expect(assetXXHDPI.size) == 986896
-                    expect(assetXXHDPI.type) == "png"
+                    let assetXhdpi = imageAsset.xhdpi!
+                    expect(assetXhdpi.url.absoluteString) == "http://www.example2.com"
+                    expect(assetXhdpi.width) == 10
+                    expect(assetXhdpi.height) == 99
+                    expect(assetXhdpi.size) == 986896
+                    expect(assetXhdpi.type) == "png"
 
                     let assetHDPI = imageAsset.hdpi!
                     expect(assetHDPI.url.absoluteString) == "http://www.example.com"
@@ -161,7 +161,7 @@ class PostSpec: QuickSpec {
                         "size" : 445566
                     ])
 
-                    let xxhdpi: Attachment = stub([
+                    let xhdpi: Attachment = stub([
                         "url" : NSURL(string: "http://www.example2.com")!,
                         "height" : 99,
                         "width" : 10,
@@ -172,7 +172,7 @@ class PostSpec: QuickSpec {
                     let asset: Asset = stub([
                         "id" : "qwerty",
                         "hdpi" : hdpi,
-                        "xxhdpi" : xxhdpi
+                        "xhdpi" : xhdpi
                     ])
 
                     let textRegion: TextRegion = stub([

--- a/Specs/Model/Regions/AssetSpec.swift
+++ b/Specs/Model/Regions/AssetSpec.swift
@@ -45,7 +45,6 @@ class AssetSpec: QuickSpec {
                 expect(asset.id) == "5381"
 
                 let optimized = asset.optimized!
-
                 expect(optimized.url.absoluteString) == "https://example.com/5381/optimized.jpg"
                 expect(optimized.size) == 728689
                 expect(optimized.type) == "image/jpeg"
@@ -53,7 +52,6 @@ class AssetSpec: QuickSpec {
                 expect(optimized.height) == 1094
 
                 let smallScreen = asset.smallScreen!
-
                 expect(smallScreen.url.absoluteString) == "https://example.com/5381/small_screen.jpg"
                 expect(smallScreen.size) == 58160
                 expect(smallScreen.type) == "image/jpeg"
@@ -61,7 +59,6 @@ class AssetSpec: QuickSpec {
                 expect(smallScreen.height) == 274
 
                 let ldpi = asset.ldpi!
-
                 expect(ldpi.url.absoluteString) == "https://example.com/5381/ldpi.jpg"
                 expect(ldpi.size) == 4437
                 expect(ldpi.type) == "image/jpeg"
@@ -69,7 +66,6 @@ class AssetSpec: QuickSpec {
                 expect(ldpi.height) == 64
 
                 let mdpi = asset.mdpi!
-
                 expect(mdpi.url.absoluteString) == "https://example.com/5381/mdpi.jpg"
                 expect(mdpi.size) == 21813
                 expect(mdpi.type) == "image/jpeg"
@@ -77,7 +73,6 @@ class AssetSpec: QuickSpec {
                 expect(mdpi.height) == 160
 
                 let hdpi = asset.hdpi!
-
                 expect(hdpi.url.absoluteString) == "https://example.com/5381/hdpi.jpg"
                 expect(hdpi.size) == 77464
                 expect(hdpi.type) == "image/jpeg"
@@ -85,28 +80,18 @@ class AssetSpec: QuickSpec {
                 expect(hdpi.height) == 321
 
                 let xhdpi = asset.xhdpi!
-
                 expect(xhdpi.url.absoluteString) == "https://example.com/5381/xhdpi.jpg"
                 expect(xhdpi.size) == 274363
                 expect(xhdpi.type) == "image/jpeg"
                 expect(xhdpi.width) == 1500
                 expect(xhdpi.height) == 641
 
-                let xxhdpi = asset.xxhdpi!
-
-                expect(xxhdpi.url.absoluteString) == "https://example.com/5381/xxhdpi.jpg"
-                expect(xxhdpi.size) == 728689
-                expect(xxhdpi.type) == "image/jpeg"
-                expect(xxhdpi.width) == 2560
-                expect(xxhdpi.height) == 1094
-//
-//                let original = asset.original!
-//
-//                expect(original.url.absoluteString) == "https://example.com/5381/xxxhdpi.jpg"
-//                expect(original.size) == 728687
-//                expect(original.type) == "image/jpeg"
-//                expect(original.width) == 2560
-//                expect(original.height) == 1094
+                let original = asset.original!
+                expect(original.url.absoluteString) == "https://example.com/5381/original.jpg"
+                expect(original.size) == 728689
+                expect(original.type) == "image/jpeg"
+                expect(original.width) == 2560
+                expect(original.height) == 1094
             }
         }
 
@@ -189,14 +174,6 @@ class AssetSpec: QuickSpec {
                         "size" : 666666
                     ])
 
-                    let xxhdpi: Attachment = stub([
-                        "url" : NSURL(string: "http://www.example7.com")!,
-                        "height" : 70,
-                        "width" : 80,
-                        "type" : "png",
-                        "size" : 777777
-                    ])
-
                     let original: Attachment = stub([
                         "url" : NSURL(string: "http://www.example8.com")!,
                         "height" : 80,
@@ -213,7 +190,6 @@ class AssetSpec: QuickSpec {
                         "mdpi" : mdpi,
                         "hdpi" : hdpi,
                         "xhdpi" : xhdpi,
-                        "xxhdpi" : xxhdpi,
                         "original" : original
                     ])
 
@@ -272,14 +248,6 @@ class AssetSpec: QuickSpec {
                     expect(unArchivedxhdpi.height) == 60
                     expect(unArchivedxhdpi.size) == 666666
                     expect(unArchivedxhdpi.type) == "jpeg"
-
-                    let unArchivedxxhdpi = unArchivedAsset.xxhdpi!
-
-                    expect(unArchivedxxhdpi.url.absoluteString) == "http://www.example7.com"
-                    expect(unArchivedxxhdpi.width) == 80
-                    expect(unArchivedxxhdpi.height) == 70
-                    expect(unArchivedxxhdpi.size) == 777777
-                    expect(unArchivedxxhdpi.type) == "png"
 
                     let unArchivedOriginal = unArchivedAsset.original!
 

--- a/Specs/Model/Regions/ImageRegionSpec.swift
+++ b/Specs/Model/Regions/ImageRegionSpec.swift
@@ -31,10 +31,10 @@ class ImageRegionSpec: QuickSpec {
 
                 let xhdpi = asset.xhdpi!
                 expect(xhdpi.url.absoluteString) == "https://example.com/85/xhdpi.jpg"
-                expect(xhdpi.size) == 728689
+                expect(xhdpi.size) == 274363
                 expect(xhdpi.type) == "image/jpeg"
-                expect(xhdpi.width) == 2560
-                expect(xhdpi.height) == 1094
+                expect(xhdpi.width) == 1500
+                expect(xhdpi.height) == 641
             }
 
             it("parses affiliate region correctly") {
@@ -57,10 +57,10 @@ class ImageRegionSpec: QuickSpec {
 
                 let xhdpi = asset.xhdpi!
                 expect(xhdpi.url.absoluteString) == "https://example.com/85/xhdpi.jpg"
-                expect(xhdpi.size) == 728689
+                expect(xhdpi.size) == 274363
                 expect(xhdpi.type) == "image/jpeg"
-                expect(xhdpi.width) == 2560
-                expect(xhdpi.height) == 1094
+                expect(xhdpi.width) == 1500
+                expect(xhdpi.height) == 641
             }
 
         }

--- a/Specs/Model/Regions/ImageRegionSpec.swift
+++ b/Specs/Model/Regions/ImageRegionSpec.swift
@@ -20,24 +20,21 @@ class ImageRegionSpec: QuickSpec {
                 expect(region.alt) == "region-alt.jpeg"
 
                 let asset = region.asset!
-
                 expect(asset.id) == "85"
 
                 let hdpi = asset.hdpi!
-
                 expect(hdpi.url.absoluteString) == "https://example.com/85/hdpi.jpg"
                 expect(hdpi.size) == 77464
                 expect(hdpi.type) == "image/jpeg"
                 expect(hdpi.width) == 750
                 expect(hdpi.height) == 321
 
-                let xxhdpi = asset.xxhdpi!
-
-                expect(xxhdpi.url.absoluteString) == "https://example.com/85/xxhdpi.jpg"
-                expect(xxhdpi.size) == 728689
-                expect(xxhdpi.type) == "image/jpeg"
-                expect(xxhdpi.width) == 2560
-                expect(xxhdpi.height) == 1094
+                let xhdpi = asset.xhdpi!
+                expect(xhdpi.url.absoluteString) == "https://example.com/85/xhdpi.jpg"
+                expect(xhdpi.size) == 728689
+                expect(xhdpi.type) == "image/jpeg"
+                expect(xhdpi.width) == 2560
+                expect(xhdpi.height) == 1094
             }
 
             it("parses affiliate region correctly") {
@@ -49,24 +46,21 @@ class ImageRegionSpec: QuickSpec {
                 expect(region.alt) == "region-alt.jpeg"
 
                 let asset = region.asset!
-
                 expect(asset.id) == "85"
 
                 let hdpi = asset.hdpi!
-
                 expect(hdpi.url.absoluteString) == "https://example.com/85/hdpi.jpg"
                 expect(hdpi.size) == 77464
                 expect(hdpi.type) == "image/jpeg"
                 expect(hdpi.width) == 750
                 expect(hdpi.height) == 321
 
-                let xxhdpi = asset.xxhdpi!
-
-                expect(xxhdpi.url.absoluteString) == "https://example.com/85/xxhdpi.jpg"
-                expect(xxhdpi.size) == 728689
-                expect(xxhdpi.type) == "image/jpeg"
-                expect(xxhdpi.width) == 2560
-                expect(xxhdpi.height) == 1094
+                let xhdpi = asset.xhdpi!
+                expect(xhdpi.url.absoluteString) == "https://example.com/85/xhdpi.jpg"
+                expect(xhdpi.size) == 728689
+                expect(xhdpi.type) == "image/jpeg"
+                expect(xhdpi.width) == 2560
+                expect(xhdpi.height) == 1094
             }
 
         }
@@ -102,31 +96,31 @@ class ImageRegionSpec: QuickSpec {
 
                 it("decodes successfully") {
                     let hdpi: Attachment = stub([
-                        "url" : NSURL(string: "http://www.example.com")!,
-                        "height" : 2,
-                        "width" : 5,
-                        "type" : "jpeg",
-                        "size" : 45644
+                        "url": NSURL(string: "http://www.example.com")!,
+                        "height": 2,
+                        "width": 5,
+                        "type": "jpeg",
+                        "size": 45644
                     ])
 
-                    let xxhdpi: Attachment = stub([
-                        "url" : NSURL(string: "http://www.example2.com")!,
-                        "height" : 67,
-                        "width" : 999,
-                        "type" : "png",
-                        "size" : 114574
+                    let xhdpi: Attachment = stub([
+                        "url": NSURL(string: "http://www.example2.com")!,
+                        "height": 67,
+                        "width": 999,
+                        "type": "png",
+                        "size": 114574
                     ])
 
                     let asset: Asset = stub([
-                        "id" : "qwerty",
-                        "hdpi" : hdpi,
-                        "xxhdpi" : xxhdpi
+                        "id": "qwerty",
+                        "hdpi": hdpi,
+                        "xhdpi": xhdpi
                     ])
 
                     let imageRegion: ImageRegion = stub([
-                        "asset" : asset,
-                        "alt" : "some-altness",
-                        "url" : NSURL(string: "http://www.example5.com")!
+                        "asset": asset,
+                        "alt": "some-altness",
+                        "url": NSURL(string: "http://www.example5.com")!
                     ])
 
                     NSKeyedArchiver.archiveRootObject(imageRegion, toFile: filePath)
@@ -139,24 +133,21 @@ class ImageRegionSpec: QuickSpec {
                     expect(unArchivedRegion.alt) == "some-altness"
 
                     let unArchivedAsset = unArchivedRegion.asset!
-
                     expect(unArchivedAsset.id) == "qwerty"
 
                     let unArchivedHdpi = unArchivedAsset.hdpi!
-
                     expect(unArchivedHdpi.url.absoluteString) == "http://www.example.com"
                     expect(unArchivedHdpi.size) == 45644
                     expect(unArchivedHdpi.type) == "jpeg"
                     expect(unArchivedHdpi.width) == 5
                     expect(unArchivedHdpi.height) == 2
 
-                    let unArchivedXxhdpi = unArchivedAsset.xxhdpi!
-
-                    expect(unArchivedXxhdpi.url.absoluteString) == "http://www.example2.com"
-                    expect(unArchivedXxhdpi.size) == 114574
-                    expect(unArchivedXxhdpi.type) == "png"
-                    expect(unArchivedXxhdpi.width) == 999
-                    expect(unArchivedXxhdpi.height) == 67
+                    let unArchivedXhdpi = unArchivedAsset.xhdpi!
+                    expect(unArchivedXhdpi.url.absoluteString) == "http://www.example2.com"
+                    expect(unArchivedXhdpi.size) == 114574
+                    expect(unArchivedXhdpi.type) == "png"
+                    expect(unArchivedXhdpi.width) == 999
+                    expect(unArchivedXhdpi.height) == 67
                 }
             }
         }

--- a/Specs/Model/UserSpec.swift
+++ b/Specs/Model/UserSpec.swift
@@ -16,8 +16,8 @@ class UserSpec: QuickSpec {
                 let originalGif: Attachment = stub(["url": "http://original.gif"])
                 let optimized: Attachment = stub(["url": "http://optimized.png"])
                 let hdpi: Attachment = stub(["url": "http://hdpi.png"])
-                let asset: Asset = stub(["original": originalPng, "hdpi": hdpi, "optimized": optimized])
-                let assetGif: Asset = stub(["original": originalGif, "hdpi": hdpi, "optimized": optimized])
+                let asset: Asset = stub(["original": originalPng, "xhdpi": hdpi, "optimized": optimized])
+                let assetGif: Asset = stub(["original": originalGif, "xhdpi": hdpi, "optimized": optimized])
                 let emptyAsset: Asset = stub([:])
 
                 it("should return nil if there is no image") {
@@ -192,7 +192,7 @@ class UserSpec: QuickSpec {
                         let attachment: Attachment = stub(["url": NSURL(string: "http://www.example.com")!, "height": 0, "width": 0, "type": "png", "size": 0 ])
                         let asset: Asset = stub(["regular" : attachment])
                         let coverAttachment: Attachment = stub(["url": NSURL(string: "http://www.example2.com")!, "height": 0, "width": 0, "type": "png", "size": 0 ])
-                        let coverAsset: Asset = stub(["hdpi" : coverAttachment])
+                        let coverAsset: Asset = stub(["xhdpi" : coverAttachment])
 
                         let user: User = stub([
                             "avatar" : asset,

--- a/Specs/Networking/ProfileServiceSpec.swift
+++ b/Specs/Networking/ProfileServiceSpec.swift
@@ -29,7 +29,7 @@ class ProfileServiceSpec: QuickSpec {
                     expect(loadedUser!.id) == "42"
                     expect(loadedUser!.username) == "archer"
                     expect(loadedUser!.formattedShortBio) == "<p>Have been <strong>spying</strong> for a while now.</p>"
-                    expect(loadedUser!.coverImageURL(viewsAdultContent: true)?.absoluteString) == "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/565/ello-hdpi-768defd5.jpg"
+                    expect(loadedUser!.coverImageURL(viewsAdultContent: true)?.absoluteString) == "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/565/ello-xhdpi-768defd5.jpg"
                 }
             }
 


### PR DESCRIPTION
uses `original` instead of `hdpi`, and uses `xhdpi` instead of `hdpi` on iPhone, which should look much better on iPhone 6+

The `hdpi` cover image is actually pretty dang small.  This brings us closer in line w/ webapp (esp in landscape).

Also, this PR removes all references to `xxhdpi` and `xxxhdpi`, because the server doesn't generate those, and we'll never get them.