### PR TITLE
Fixes pagination, user loading, performance

### DIFF
--- a/Sources/Controllers/Profile/ProfileGenerator.swift
+++ b/Sources/Controllers/Profile/ProfileGenerator.swift
@@ -115,7 +115,9 @@ private extension ProfileGenerator {
                 sself.posts = posts
                 let userPostItems = sself.parse(posts)
                 displayPostsOperation.run {
-                    sself.destination?.replacePlaceholder(.ProfilePosts, items: userPostItems)
+                    inForeground {
+                        sself.destination?.replacePlaceholder(.ProfilePosts, items: userPostItems)
+                    }
                 }
             },
             failure: { [weak self] _ in

--- a/Sources/Controllers/Profile/ProfileGenerator.swift
+++ b/Sources/Controllers/Profile/ProfileGenerator.swift
@@ -83,7 +83,7 @@ private extension ProfileGenerator {
         StreamService().loadUser(
             streamKind.endpoint,
             streamKind: streamKind,
-            success: { [weak self] (user, responseConfig) in
+            success: { [weak self] (user, _) in
                 guard let sself = self else { return }
                 guard sself.loadingToken.isValidInitialPageLoadingToken(sself.localToken) else { return }
 

--- a/Sources/Controllers/Profile/ProfileGenerator.swift
+++ b/Sources/Controllers/Profile/ProfileGenerator.swift
@@ -54,7 +54,7 @@ public final class ProfileGenerator: StreamGenerator {
 
     public func toggleGrid() {
         guard let posts = posts else { return }
-        destination?.replacePlaceholder(.ProfilePosts, items: parse(posts))
+        destination?.replacePlaceholder(.ProfilePosts, items: parse(posts)) {}
     }
 
 }
@@ -72,7 +72,7 @@ private extension ProfileGenerator {
         guard let user = user else { return }
 
         destination?.setPrimaryJSONAble(user)
-        destination?.replacePlaceholder(.ProfileHeader, items: headerItems())
+        destination?.replacePlaceholder(.ProfileHeader, items: headerItems()) {}
         doneOperation.run()
     }
 
@@ -89,7 +89,7 @@ private extension ProfileGenerator {
 
                 sself.user = user
                 sself.destination?.setPrimaryJSONAble(user)
-                sself.destination?.replacePlaceholder(.ProfileHeader, items: sself.headerItems())
+                sself.destination?.replacePlaceholder(.ProfileHeader, items: sself.headerItems()) {}
                 doneOperation.run()
             },
             failure: { [weak self] _ in
@@ -116,7 +116,9 @@ private extension ProfileGenerator {
                 let userPostItems = sself.parse(posts)
                 displayPostsOperation.run {
                     inForeground {
-                        sself.destination?.replacePlaceholder(.ProfilePosts, items: userPostItems)
+                        sself.destination?.replacePlaceholder(.ProfilePosts, items: userPostItems) {
+                            sself.destination?.pagingEnabled = true
+                        }
                     }
                 }
             },

--- a/Sources/Controllers/Profile/ProfileViewController.swift
+++ b/Sources/Controllers/Profile/ProfileViewController.swift
@@ -474,8 +474,13 @@ extension ProfileViewController {
 // MARK: ProfileViewController: StreamDestination
 extension ProfileViewController:  StreamDestination {
 
-    public func replacePlaceholder(type: StreamCellType.PlaceholderType, @autoclosure items: () -> [StreamCellItem]) {
-        streamViewController.replacePlaceholder(type, with: items)
+    public var pagingEnabled: Bool {
+        get { return streamViewController.pagingEnabled }
+        set { streamViewController.pagingEnabled = newValue }
+    }
+
+    public func replacePlaceholder(type: StreamCellType.PlaceholderType, @autoclosure items: () -> [StreamCellItem], completion: ElloEmptyCompletion) {
+        streamViewController.replacePlaceholder(type, with: items, completion: completion)
     }
 
     public func setPlaceholders(items: [StreamCellItem]) {

--- a/Sources/Controllers/Stream/Detail/PostDetailGenerator.swift
+++ b/Sources/Controllers/Stream/Detail/PostDetailGenerator.swift
@@ -65,7 +65,7 @@ private extension PostDetailGenerator {
         destination?.setPrimaryJSONAble(post)
         if post.content?.count > 0 || post.repostContent?.count > 0 {
             let postItems = parse([post])
-            destination?.replacePlaceholder(.PostHeader, items: postItems)
+            destination?.replacePlaceholder(.PostHeader, items: postItems) {}
             doneOperation.run()
         }
     }
@@ -83,7 +83,7 @@ private extension PostDetailGenerator {
                 sself.post = post
                 sself.destination?.setPrimaryJSONAble(post)
                 let postItems = sself.parse([post])
-                sself.destination?.replacePlaceholder(.PostHeader, items: postItems)
+                sself.destination?.replacePlaceholder(.PostHeader, items: postItems) {}
                 doneOperation.run()
             },
             failure: { [weak self] _ in
@@ -107,14 +107,14 @@ private extension PostDetailGenerator {
 
             let barItems = [StreamCellItem(jsonable: ElloComment.newCommentForPost(post, currentUser: currentUser), type: .CreateComment)]
             inForeground {
-                sself.destination?.replacePlaceholder(.PostCommentBar, items: barItems)
+                sself.destination?.replacePlaceholder(.PostCommentBar, items: barItems) {}
             }
         }
     }
 
     func displaySocialPadding() {
         let padding = [StreamCellItem(jsonable: JSONAble.fromJSON([:], fromLinked: false), type: .Spacer(height: 8.0))]
-        destination?.replacePlaceholder(.PostSocialPadding, items: padding)
+        destination?.replacePlaceholder(.PostSocialPadding, items: padding) {}
     }
 
     func loadPostComments(doneOperation: AsyncOperation) {
@@ -134,7 +134,9 @@ private extension PostDetailGenerator {
                 displayCommentsOperation.run {
                     sself.destination?.setPagingConfig(responseConfig)
                     inForeground {
-                        sself.destination?.replacePlaceholder(.PostComments, items: commentItems)
+                        sself.destination?.replacePlaceholder(.PostComments, items: commentItems) {
+                            sself.destination?.pagingEnabled = true
+                        }
                     }
                 }
             },
@@ -164,7 +166,7 @@ private extension PostDetailGenerator {
                 )
                 displayLoversOperation.run {
                     inForeground {
-                        sself.destination?.replacePlaceholder(.PostLovers, items: loversItems)
+                        sself.destination?.replacePlaceholder(.PostLovers, items: loversItems) {}
                     }
                 }
             },
@@ -194,7 +196,7 @@ private extension PostDetailGenerator {
                 )
                 displayRepostersOperation.run {
                     inForeground {
-                        sself.destination?.replacePlaceholder(.PostReposters, items: repostersItems)
+                        sself.destination?.replacePlaceholder(.PostReposters, items: repostersItems) {}
                     }
                 }
             },

--- a/Sources/Controllers/Stream/Detail/PostDetailGenerator.swift
+++ b/Sources/Controllers/Stream/Detail/PostDetailGenerator.swift
@@ -77,7 +77,7 @@ private extension PostDetailGenerator {
         PostService().loadPost(
             postParam,
             needsComments: false,
-            success: { [weak self] (post, responseConfig) in
+            success: { [weak self] (post, _) in
                 guard let sself = self else { return }
                 guard sself.loadingToken.isValidInitialPageLoadingToken(sself.localToken) else { return }
                 sself.post = post

--- a/Sources/Controllers/Stream/Detail/PostDetailGenerator.swift
+++ b/Sources/Controllers/Stream/Detail/PostDetailGenerator.swift
@@ -106,7 +106,9 @@ private extension PostDetailGenerator {
             guard let currentUser = sself.currentUser where commentingEnabled else { return }
 
             let barItems = [StreamCellItem(jsonable: ElloComment.newCommentForPost(post, currentUser: currentUser), type: .CreateComment)]
-            sself.destination?.replacePlaceholder(.PostCommentBar, items: barItems)
+            inForeground {
+                sself.destination?.replacePlaceholder(.PostCommentBar, items: barItems)
+            }
         }
     }
 
@@ -131,7 +133,9 @@ private extension PostDetailGenerator {
                 let commentItems = sself.parse(comments)
                 displayCommentsOperation.run {
                     sself.destination?.setPagingConfig(responseConfig)
-                    sself.destination?.replacePlaceholder(.PostComments, items: commentItems)
+                    inForeground {
+                        sself.destination?.replacePlaceholder(.PostComments, items: commentItems)
+                    }
                 }
             },
             failure: { _ in
@@ -159,7 +163,9 @@ private extension PostDetailGenerator {
                     seeMoreTitle: InterfaceString.Post.LovedByList
                 )
                 displayLoversOperation.run {
-                    sself.destination?.replacePlaceholder(.PostLovers, items: loversItems)
+                    inForeground {
+                        sself.destination?.replacePlaceholder(.PostLovers, items: loversItems)
+                    }
                 }
             },
             failure: { _ in
@@ -187,7 +193,9 @@ private extension PostDetailGenerator {
                     seeMoreTitle: InterfaceString.Post.RepostedByList
                 )
                 displayRepostersOperation.run {
-                    sself.destination?.replacePlaceholder(.PostReposters, items: repostersItems)
+                    inForeground {
+                        sself.destination?.replacePlaceholder(.PostReposters, items: repostersItems)
+                    }
                 }
             },
             failure: { _ in

--- a/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
+++ b/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
@@ -211,8 +211,13 @@ public final class PostDetailViewController: StreamableViewController {
 // MARK: PostDetailViewController: StreamDestination
 extension PostDetailViewController: StreamDestination {
 
-    public func replacePlaceholder(type: StreamCellType.PlaceholderType, @autoclosure items: () -> [StreamCellItem]) {
-        streamViewController.replacePlaceholder(type, with: items)
+    public var pagingEnabled: Bool {
+        get { return streamViewController.pagingEnabled }
+        set { streamViewController.pagingEnabled = newValue }
+    }
+
+    public func replacePlaceholder(type: StreamCellType.PlaceholderType, @autoclosure items: () -> [StreamCellItem], completion: ElloEmptyCompletion) {
+        streamViewController.replacePlaceholder(type, with: items, completion: completion)
     }
 
     public func setPlaceholders(items: [StreamCellItem]) {

--- a/Sources/Controllers/Stream/StreamGenerator.swift
+++ b/Sources/Controllers/Stream/StreamGenerator.swift
@@ -18,8 +18,9 @@ extension StreamGenerator {
 
 public protocol StreamDestination: class {
     func setPlaceholders(items: [StreamCellItem])
-    func replacePlaceholder(type: StreamCellType.PlaceholderType, @autoclosure items: () -> [StreamCellItem])
+    func replacePlaceholder(type: StreamCellType.PlaceholderType, @autoclosure items: () -> [StreamCellItem], completion: ElloEmptyCompletion)
     func setPrimaryJSONAble(jsonable: JSONAble)
     func primaryJSONAbleNotFound()
     func setPagingConfig(responseConfig: ResponseConfig)
+    var pagingEnabled: Bool { get set }
 }

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -71,7 +71,6 @@ public final class StreamViewController: BaseElloViewController {
     @IBOutlet weak public var noResultsLabel: UILabel!
     @IBOutlet weak public var noResultsTopConstraint: NSLayoutConstraint!
     private let defaultNoResultsTopConstant: CGFloat = 113
-    var canLoadNext = false
 
     var currentJSONables = [JSONAble]()
 
@@ -107,6 +106,8 @@ public final class StreamViewController: BaseElloViewController {
     public var postbarController: PostbarController?
     var relationshipController: RelationshipController?
     public var responseConfig: ResponseConfig?
+    private var scrollToPaginateGuard = false
+
     public let streamService = StreamService()
     lazy public var loadingToken: LoadingToken = {
         var token = LoadingToken()
@@ -645,9 +646,9 @@ extension StreamViewController: ColumnToggleDelegate {
 
         self.streamKind.setIsGridView(isGridView)
         if let toggleClosure = toggleClosure {
-            // setting 'canLoadNext' to false will prevent pagination from triggering when this profile has no posts
+            // setting 'scrollToPaginateGuard' to false will prevent pagination from triggering when this profile has no posts
             // triggering pagination at this time will, inexplicably, cause the cells to disappear
-            canLoadNext = false
+            scrollToPaginateGuard = false
             setupCollectionViewLayout()
 
             toggleClosure(isGridView)
@@ -1093,13 +1094,13 @@ extension StreamViewController: UIScrollViewDelegate {
             self.view.layoutIfNeeded()
         }
 
-        if canLoadNext {
+        if scrollToPaginateGuard {
             self.loadNextPage(scrollView)
         }
     }
 
     public func scrollViewWillBeginDragging(scrollView: UIScrollView) {
-        canLoadNext = true
+        scrollToPaginateGuard = true
         streamViewDelegate?.streamViewWillBeginDragging(scrollView)
     }
 
@@ -1108,7 +1109,7 @@ extension StreamViewController: UIScrollViewDelegate {
     }
 
     public func scrollViewDidEndDecelerating(scrollView: UIScrollView) {
-        canLoadNext = false
+        scrollToPaginateGuard = false
     }
 
     private func loadNextPage(scrollView: UIScrollView) {
@@ -1133,7 +1134,7 @@ extension StreamViewController: UIScrollViewDelegate {
         let placeholderType = lastCellItem.placeholderType
         appendStreamCellItems([StreamLoadingCell.streamCellItem()])
 
-        canLoadNext = false
+        scrollToPaginateGuard = false
 
         let scrollAPI = ElloAPI.InfiniteScroll(queryItems: nextQueryItems) { return self.streamKind.endpoint }
         streamService.loadStream(scrollAPI,

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -106,6 +106,7 @@ public final class StreamViewController: BaseElloViewController {
     public var postbarController: PostbarController?
     var relationshipController: RelationshipController?
     public var responseConfig: ResponseConfig?
+    public var pagingEnabled = false
     private var scrollToPaginateGuard = false
 
     public let streamService = StreamService()
@@ -302,8 +303,9 @@ public final class StreamViewController: BaseElloViewController {
     }
 
     public func loadInitialPage(reload reload: Bool = false) {
-
         if let reloadClosure = reloadClosure where reload {
+            responseConfig = nil
+            pagingEnabled = false
             reloadClosure()
         }
         else if let initialLoadClosure = initialLoadClosure {
@@ -346,6 +348,7 @@ public final class StreamViewController: BaseElloViewController {
 
         let items = self.generateStreamCellItems(jsonables)
         self.appendUnsizedCellItems(items, withWidth: nil, completion: { indexPaths in
+            self.pagingEnabled = true
             if self.streamKind.gridViewPreferenceSet {
                 self.collectionView.layoutIfNeeded()
                 self.collectionView.setContentOffset(self.streamKind.gridPreferenceSetOffset, animated: false)
@@ -1114,6 +1117,7 @@ extension StreamViewController: UIScrollViewDelegate {
 
     private func loadNextPage(scrollView: UIScrollView) {
         guard
+            pagingEnabled &&
             scrollView.contentOffset.y + (self.view.frame.height * 1.666)
             > scrollView.contentSize.height
         else { return }

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -281,7 +281,12 @@ public final class StreamViewController: BaseElloViewController {
         }
     }
 
-    public func replacePlaceholder(placeholderType: StreamCellType.PlaceholderType, @autoclosure with streamCellItemsGenerator: () -> [StreamCellItem]) {
+    public func replacePlaceholder(
+        placeholderType: StreamCellType.PlaceholderType,
+        @autoclosure with streamCellItemsGenerator: () -> [StreamCellItem],
+        completion: ElloEmptyCompletion = {}
+        )
+    {
         let streamCellItems = streamCellItemsGenerator()
         for item in streamCellItems {
             item.placeholderType = placeholderType
@@ -296,8 +301,9 @@ public final class StreamViewController: BaseElloViewController {
             self.collectionView.performBatchUpdates({
                 self.collectionView.deleteItemsAtIndexPaths(indexPathsToReplace)
                 self.collectionView.insertItemsAtIndexPaths(newIndexPaths)
-                }, completion: { finished in
-                    UIView.setAnimationsEnabled(true)
+            }, completion: { finished in
+                UIView.setAnimationsEnabled(true)
+                completion()
             })
         }
     }

--- a/Sources/Networking/AsyncOperation.swift
+++ b/Sources/Networking/AsyncOperation.swift
@@ -12,6 +12,9 @@ public class AsyncOperation: NSOperation {
         set {
             guard _block == nil else { return }
             _block = newValue
+            if AppSetup.sharedState.isTesting {
+                usleep(1000)
+            }
             if cancelled && _executing {
                 executing = false
             }

--- a/Sources/Networking/ElloAPI.swift
+++ b/Sources/Networking/ElloAPI.swift
@@ -677,9 +677,13 @@ extension ElloAPI: Moya.TargetType {
             return [
                 "terms": terms
             ]
+        case .UserStream:
+            return [
+                "post_count": "false"
+            ]
         case .UserStreamPosts:
             return [
-                "per_page": 10
+                "post_count": 10
             ]
         default:
             return nil

--- a/Sources/Utilities/FreeMethods.swift
+++ b/Sources/Utilities/FreeMethods.swift
@@ -126,7 +126,7 @@ public func once(block: BasicBlock) -> BasicBlock {
 }
 
 public func inBackground(block: BasicBlock) {
-    if AppSetup.sharedState.isTesting && NSThread.isMainThread() {
+    if AppSetup.sharedState.isTesting {
         block()
     }
     else {
@@ -139,8 +139,13 @@ public func inForeground(block: BasicBlock) {
 }
 
 public func nextTick(block: BasicBlock) {
-    if AppSetup.sharedState.isTesting && NSThread.isMainThread() {
-        block()
+    if AppSetup.sharedState.isTesting {
+        if NSThread.isMainThread() {
+            block()
+        }
+        else {
+            dispatch_sync(dispatch_get_main_queue(), block)
+        }
     }
     else {
         nextTick(on: dispatch_get_main_queue(), block: block)

--- a/Specs/Controllers/Profile/ProfileGeneratorSpec.swift
+++ b/Specs/Controllers/Profile/ProfileGeneratorSpec.swift
@@ -54,7 +54,7 @@ class ProfileGeneratorSpec: QuickSpec {
     }
 }
 
-class ProfileDestination: NSObject, StreamDestination {
+class ProfileDestination: StreamDestination {
 
     var placeholderItems: [StreamCellItem] = []
     var headerItems: [StreamCellItem] = []
@@ -63,8 +63,6 @@ class ProfileDestination: NSObject, StreamDestination {
     var user: User?
     var responseConfig: ResponseConfig?
     var pagingEnabled: Bool = false
-
-    override init(){ super.init() }
 
     func reset() {
         placeholderItems = []

--- a/Specs/Controllers/Profile/ProfileGeneratorSpec.swift
+++ b/Specs/Controllers/Profile/ProfileGeneratorSpec.swift
@@ -78,7 +78,7 @@ class ProfileDestination: NSObject, StreamDestination {
         placeholderItems = items
     }
 
-    func replacePlaceholder(type: StreamCellType.PlaceholderType, @autoclosure items: () -> [StreamCellItem]) {
+    func replacePlaceholder(type: StreamCellType.PlaceholderType, @autoclosure items: () -> [StreamCellItem], completion: ElloEmptyCompletion) {
         switch type {
         case .ProfileHeader:
             headerItems = items()

--- a/Specs/Controllers/Profile/ProfileGeneratorSpec.swift
+++ b/Specs/Controllers/Profile/ProfileGeneratorSpec.swift
@@ -62,6 +62,7 @@ class ProfileDestination: NSObject, StreamDestination {
     var otherPlaceHolderLoaded = false
     var user: User?
     var responseConfig: ResponseConfig?
+    var pagingEnabled: Bool = false
 
     override init(){ super.init() }
 

--- a/Specs/Controllers/Stream/Detail/PostDetailGeneratorSpec.swift
+++ b/Specs/Controllers/Stream/Detail/PostDetailGeneratorSpec.swift
@@ -9,33 +9,34 @@ import Nimble
 class PostDetailGeneratorSpec: QuickSpec {
     override func spec() {
         describe("PostDetailGenerator") {
-            let destination = PostDetailDestination()
-
-            beforeEach {
-                destination.reset()
-            }
-
             let currentUser: User = stub(["id": "42"])
             let post: Post = stub(["id": "123"])
             let streamKind: StreamKind = .CurrentUserStream
+            var destination: PostDetailDestination!
+            var subject: PostDetailGenerator!
 
-            let subject = PostDetailGenerator(
-                currentUser: currentUser,
-                postParam: "123",
-                post: post,
-                streamKind: streamKind,
-                destination: destination
-            )
+            beforeEach {
+                destination = PostDetailDestination()
+                subject = PostDetailGenerator(
+                    currentUser: currentUser,
+                    postParam: "123",
+                    post: post,
+                    streamKind: streamKind,
+                    destination: destination
+                )
+            }
 
             describe("load()") {
 
-                it("sets 4 placeholders") {
+                beforeEach {
                     subject.load()
+                }
+
+                it("sets placeholders") {
                     expect(destination.placeholderItems.count) == 6
                 }
 
-                it("replaces only PostHeader, PostLovers, PostReposters and PostComment") {
-                    subject.load()
+                it("replaces the appropriate placeholders") {
                     expect(destination.headerItems.count) > 0
                     expect(destination.postLoverItems.count) > 0
                     expect(destination.postReposterItems.count) > 0
@@ -46,12 +47,11 @@ class PostDetailGeneratorSpec: QuickSpec {
                 }
 
                 it("sets the primary jsonable") {
-                    subject.load()
                     expect(destination.post).toNot(beNil())
+                    expect(destination.post?.id) == "123"
                 }
 
                 it("sets the config response") {
-                    subject.load()
                     expect(destination.responseConfig).toNot(beNil())
                 }
             }
@@ -59,7 +59,7 @@ class PostDetailGeneratorSpec: QuickSpec {
     }
 }
 
-class PostDetailDestination: NSObject, StreamDestination {
+class PostDetailDestination: StreamDestination {
 
     var placeholderItems: [StreamCellItem] = []
     var headerItems: [StreamCellItem] = []
@@ -72,8 +72,6 @@ class PostDetailDestination: NSObject, StreamDestination {
     var post: Post?
     var responseConfig: ResponseConfig?
     var pagingEnabled: Bool = false
-
-    override init(){ super.init() }
 
     func reset() {
         placeholderItems = []

--- a/Specs/Controllers/Stream/Detail/PostDetailGeneratorSpec.swift
+++ b/Specs/Controllers/Stream/Detail/PostDetailGeneratorSpec.swift
@@ -71,6 +71,7 @@ class PostDetailDestination: NSObject, StreamDestination {
     var otherPlaceHolderLoaded = false
     var post: Post?
     var responseConfig: ResponseConfig?
+    var pagingEnabled: Bool = false
 
     override init(){ super.init() }
 

--- a/Specs/Controllers/Stream/Detail/PostDetailGeneratorSpec.swift
+++ b/Specs/Controllers/Stream/Detail/PostDetailGeneratorSpec.swift
@@ -26,7 +26,7 @@ class PostDetailGeneratorSpec: QuickSpec {
                 streamKind: streamKind,
                 destination: destination
             )
-            
+
             describe("load()") {
 
                 it("sets 4 placeholders") {
@@ -91,7 +91,7 @@ class PostDetailDestination: NSObject, StreamDestination {
         placeholderItems = items
     }
 
-    func replacePlaceholder(type: StreamCellType.PlaceholderType, @autoclosure items: () -> [StreamCellItem]) {
+    func replacePlaceholder(type: StreamCellType.PlaceholderType, @autoclosure items: () -> [StreamCellItem], completion: ElloEmptyCompletion) {
         switch type {
         case .PostHeader:
             headerItems = items()

--- a/Specs/Networking/AsyncOperationSpec.swift
+++ b/Specs/Networking/AsyncOperationSpec.swift
@@ -78,11 +78,16 @@ class AsyncOperationSpec: QuickSpec {
                     var executed = false
                     let subject = AsyncOperation()
                     queue.addOperation(subject)
-                    queue.cancelAllOperations()
-                    subject.run {
-                        executed = true
+                    waitUntil { done in
+                        delay(0.1) {
+                            expect(subject.executing) == true
+                            queue.cancelAllOperations()
+                            subject.run {
+                                executed = true
+                            }
+                            done()
+                        }
                     }
-                    queue.waitUntilAllOperationsAreFinished()
 
                     expect(executed) == false
                 }


### PR DESCRIPTION
- [x] pagination could be triggered *immediately* after pulling to refresh - introduced `pagingEnabled` to prevent this
- [x] work on `UIWebView` that could only be performed on the main queue was being done on a worker queue
- [x] users were being loaded with 25 posts, now `loadUser` loads 0 posts, and `loadUserPosts` loads 10 posts