### PR TITLE
Consistent naming for 'buy button link'

### DIFF
--- a/Sources/Controllers/Stream/Cells/StreamImageCell.swift
+++ b/Sources/Controllers/Stream/Cells/StreamImageCell.swift
@@ -236,7 +236,7 @@ public class StreamImageCell: StreamRegionableCell {
         guard let buyButtonURL = buyButtonURL else {
             return
         }
-        Tracker.sharedTracker.affiliateLinkVisited(buyButtonURL.URLString)
+        Tracker.sharedTracker.buyButtonLinkVisited(buyButtonURL.URLString)
         postNotification(ExternalWebNotification, value: buyButtonURL.URLString)
     }
 

--- a/Sources/Model/Tracker.swift
+++ b/Sources/Model/Tracker.swift
@@ -390,10 +390,10 @@ public extension Tracker {
         log("Deep Link Visited, [path: \(path)]")
         agent.track("Deep Link Visited", properties: ["path": path])
     }
-    
-    func affiliateLinkVisited(path: String) {
-        log("Affliliate Link Visited, [link: \(path)]")
-        agent.track("Affiliate Link Visited", properties: ["link": path])
+
+    func buyButtonLinkVisited(path: String) {
+        log("Buy Button Link Visited, [link: \(path)]")
+        agent.track("Buy Button Link Visited", properties: ["link": path])
     }
 
 }


### PR DESCRIPTION
Use "Buy Button Link Visited" event, as it is in segment.