### PR TITLE
Fix `NotificationCell` sizing and calculator code

### DIFF
--- a/Sources/Controllers/Stream/CellDequeing/NotificationCellPresenter.swift
+++ b/Sources/Controllers/Stream/CellDequeing/NotificationCellPresenter.swift
@@ -21,8 +21,9 @@ public struct NotificationCellPresenter {
                     postNotification(StreamNotification.UpdateCellHeightNotification, value: cell)
                 }
             }
-            cell.onHeightMismatch = { _ in
-                StreamNotificationCellSizeCalculator.assignTotalHeight(streamCellItem.calculatedWebHeight, cellItem: streamCellItem, cellWidth: cell.frame.width)
+            cell.onHeightMismatch = { height in
+                streamCellItem.calculatedOneColumnCellHeight = height
+                streamCellItem.calculatedMultiColumnCellHeight = height
                 postNotification(StreamNotification.UpdateCellHeightNotification, value: cell)
             }
 

--- a/Sources/Controllers/Stream/Cells/StreamNotificationCellSizeCalculator.swift
+++ b/Sources/Controllers/Stream/Cells/StreamNotificationCellSizeCalculator.swift
@@ -98,17 +98,14 @@ public class StreamNotificationCellSizeCalculator: NSObject, UIWebViewDelegate {
         let titleWidth = NotificationCell.Size.messageHtmlWidth(forCellWidth: cellWidth, hasImage: notification.hasImage)
         let titleSize = textViewForSizing.sizeThatFits(CGSize(width: titleWidth, height: .max))
         var totalTextHeight = ceil(titleSize.height)
-        totalTextHeight += NotificationCell.Size.createdAtFixedHeight()
+        totalTextHeight += NotificationCell.Size.CreatedAtFixedHeight
 
         if let webContentHeight = webContentHeight where webContentHeight > 0 {
             totalTextHeight += webContentHeight - NotificationCell.Size.WebHeightCorrection + NotificationCell.Size.InnerMargin
         }
 
-        if notification.canReplyToComment {
-            totalTextHeight += NotificationCell.Size.ButtonHeight + NotificationCell.Size.ButtonMargin
-        }
-        else if notification.canBackFollow {
-            totalTextHeight += NotificationCell.Size.ButtonHeight + NotificationCell.Size.ButtonMargin
+        if notification.canReplyToComment || notification.canBackFollow {
+            totalTextHeight += NotificationCell.Size.ButtonHeight + NotificationCell.Size.InnerMargin
         }
 
         let totalImageHeight = NotificationCell.Size.imageHeight(imageRegion: notification.imageRegion)

--- a/Sources/Model/JSONAble.swift
+++ b/Sources/Model/JSONAble.swift
@@ -81,8 +81,7 @@ extension JSONAble {
     }
 
     public func addLinkObject(model: JSONAble, identifier: String, key: String, collection: String) {
-        if model.links == nil { links = [String: AnyObject]() }
-        model.links![identifier] = ["id": key, "type": collection]
+        addLinkObject(identifier, key: key, collection: collection)
         ElloLinkedStore.sharedInstance.setObject(model, forKey: key, inCollection: collection)
     }
 

--- a/Specs/Controllers/Stream/StreamNotificationCellSizeCalculatorSpec.swift
+++ b/Specs/Controllers/Stream/StreamNotificationCellSizeCalculatorSpec.swift
@@ -42,8 +42,8 @@ class StreamNotificationCellSizeCalculatorSpec : QuickSpec {
                 subject.processCells([item], withWidth: 320, columnCount: 1) {
                 }
                 expect(item.calculatedWebHeight) == 0
-                expect(item.calculatedOneColumnCellHeight) == 67
-                expect(item.calculatedMultiColumnCellHeight) == 67
+                expect(item.calculatedOneColumnCellHeight) == 69
+                expect(item.calculatedMultiColumnCellHeight) == 69
             }
             it("should return size that accounts for a message") {
                 let activity: Activity = stub(["kind": "repost_notification", "subject": postWithText])
@@ -52,8 +52,8 @@ class StreamNotificationCellSizeCalculatorSpec : QuickSpec {
                 subject.processCells([item], withWidth: 320, columnCount: 1) {
                 }
                 expect(item.calculatedWebHeight) == 50
-                expect(item.calculatedOneColumnCellHeight) == 112
-                expect(item.calculatedMultiColumnCellHeight) == 112
+                expect(item.calculatedOneColumnCellHeight) == 114
+                expect(item.calculatedMultiColumnCellHeight) == 114
             }
             it("should return size that accounts for an image") {
                 let activity: Activity = stub(["kind": "repost_notification", "subject": postWithImage])
@@ -61,8 +61,8 @@ class StreamNotificationCellSizeCalculatorSpec : QuickSpec {
                 let item = StreamCellItem(jsonable: notification, type: .Notification)
                 subject.processCells([item], withWidth: 320, columnCount: 1) {
                 }
-                expect(item.calculatedOneColumnCellHeight) == 129
-                expect(item.calculatedMultiColumnCellHeight) == 129
+                expect(item.calculatedOneColumnCellHeight) == 131
+                expect(item.calculatedMultiColumnCellHeight) == 131
             }
             it("should return size that accounts for an image with text") {
                 let activity: Activity = stub(["kind": "repost_notification", "subject": postWithTextAndImage])
@@ -71,8 +71,8 @@ class StreamNotificationCellSizeCalculatorSpec : QuickSpec {
                 subject.processCells([item], withWidth: 320, columnCount: 1) {
                 }
                 expect(item.calculatedWebHeight) == 50
-                expect(item.calculatedOneColumnCellHeight) == 129
-                expect(item.calculatedMultiColumnCellHeight) == 129
+                expect(item.calculatedOneColumnCellHeight) == 131
+                expect(item.calculatedMultiColumnCellHeight) == 131
             }
             xit("should return size that accounts for a follow button") {
                 // title and text and follow buton
@@ -84,8 +84,8 @@ class StreamNotificationCellSizeCalculatorSpec : QuickSpec {
                 subject.processCells([item], withWidth: 320, columnCount: 1) {
                 }
                 expect(item.calculatedWebHeight) == 50
-                expect(item.calculatedOneColumnCellHeight) == 157
-                expect(item.calculatedMultiColumnCellHeight) == 157
+                expect(item.calculatedOneColumnCellHeight) == 154
+                expect(item.calculatedMultiColumnCellHeight) == 154
             }
         }
     }


### PR DESCRIPTION
and only fire `onHeightMismatch` after everything (image & message HTMl) have loaded.  The `height` passed in is from `layoutSubviews`, so is guaranteed to be correct.