### PR TITLE
Re-enables "tap text to open" in grid view

### DIFF
--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -881,7 +881,7 @@ extension StreamViewController: CategoryDelegate {
 extension StreamViewController: UserDelegate {
 
     public func userTappedText(cell: UICollectionViewCell) {
-        guard !streamKind.tappingTextOpensDetail,
+        guard streamKind.tappingTextOpensDetail,
             let indexPath = collectionView.indexPathForCell(cell)
         else { return }
 


### PR DESCRIPTION
Easy fix - the refactor to using `guard` resulted in a flipped conditional.