### PR TITLE
Fixes the "error" when showing a user with no posts

### DIFF
--- a/Sources/Controllers/Profile/ProfileGenerator.swift
+++ b/Sources/Controllers/Profile/ProfileGenerator.swift
@@ -120,8 +120,13 @@ private extension ProfileGenerator {
                 let userPostItems = sself.parse(posts)
                 displayPostsOperation.run {
                     inForeground {
-                        sself.destination?.replacePlaceholder(.ProfilePosts, items: userPostItems) {
-                            sself.destination?.pagingEnabled = true
+                        if userPostItems.count == 0 {
+                            sself.destination?.secondaryJSONAbleNotFound()
+                        }
+                        else {
+                            sself.destination?.replacePlaceholder(.ProfilePosts, items: userPostItems) {
+                                sself.destination?.pagingEnabled = true
+                            }
                         }
                     }
                 }

--- a/Sources/Controllers/Profile/ProfileViewController.swift
+++ b/Sources/Controllers/Profile/ProfileViewController.swift
@@ -234,6 +234,7 @@ public final class ProfileViewController: StreamableViewController {
     private func reloadEntireProfile() {
         coverImage.pin_cancelImageDownload()
         coverImage.image = nil
+        updateNoPostsView(show: false)
         generator?.load(reload: true)
     }
 

--- a/Sources/Controllers/Profile/ProfileViewController.swift
+++ b/Sources/Controllers/Profile/ProfileViewController.swift
@@ -87,7 +87,7 @@ public final class ProfileViewController: StreamableViewController {
         }
         postChangedNotification = NotificationObserver(notification: PostChangedNotification) { [unowned self] (post, change) in
             if post.authorId == self.currentUser?.id && change == .Create {
-                self.updateNoPostsView(false)
+                self.updateNoPostsView(show: false)
             }
         }
     }
@@ -249,7 +249,6 @@ public final class ProfileViewController: StreamableViewController {
     }
 
     private func setupNoPosts() {
-
         var noPostsHeaderText: String
         var noPostsBodyText: String
         if user?.id == currentUser?.id {
@@ -378,7 +377,7 @@ public final class ProfileViewController: StreamableViewController {
     }
 
 
-    private func updateNoPostsView(show: Bool) {
+    private func updateNoPostsView(show show: Bool) {
         guard isViewLoaded() else { return }
 
         if show {
@@ -504,7 +503,6 @@ extension ProfileViewController:  StreamDestination {
 
     public func setPlaceholders(items: [StreamCellItem]) {
         streamViewController.clearForInitialLoad()
-        updateNoPostsView(items.count < 2)
         streamViewController.appendUnsizedCellItems(items, withWidth: view.frame.width) { _ in }
         assignRightButtons()
     }
@@ -538,6 +536,10 @@ extension ProfileViewController:  StreamDestination {
 
     public func setPagingConfig(responseConfig: ResponseConfig) {
         streamViewController.responseConfig = responseConfig
+    }
+
+    public func secondaryJSONAbleNotFound() {
+        updateNoPostsView(show: true)
     }
 
     public func primaryJSONAbleNotFound() {

--- a/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
+++ b/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
@@ -267,6 +267,9 @@ extension PostDetailViewController: StreamDestination {
         streamViewController.responseConfig = responseConfig
     }
 
+    public func secondaryJSONAbleNotFound() {
+    }
+
     public func primaryJSONAbleNotFound() {
         if let deeplinkPath = self.deeplinkPath,
             deeplinkURL = NSURL(string: deeplinkPath)

--- a/Sources/Controllers/Stream/StreamGenerator.swift
+++ b/Sources/Controllers/Stream/StreamGenerator.swift
@@ -21,6 +21,7 @@ public protocol StreamDestination: class {
     func replacePlaceholder(type: StreamCellType.PlaceholderType, @autoclosure items: () -> [StreamCellItem], completion: ElloEmptyCompletion)
     func setPrimaryJSONAble(jsonable: JSONAble)
     func primaryJSONAbleNotFound()
+    func secondaryJSONAbleNotFound()
     func setPagingConfig(responseConfig: ResponseConfig)
     var pagingEnabled: Bool { get set }
 }

--- a/Sources/Networking/ElloProvider.swift
+++ b/Sources/Networking/ElloProvider.swift
@@ -364,8 +364,7 @@ extension ElloProvider {
             }
         }
         else if isEmptySuccess(data, statusCode: statusCode) {
-            let emptyString = ""
-            success(data: emptyString, responseConfig: responseConfig)
+            success(data: "", responseConfig: responseConfig)
         }
         else {
             ElloProvider.failedToMapObjects(failure)

--- a/Sources/Networking/StreamService.swift
+++ b/Sources/Networking/StreamService.swift
@@ -74,7 +74,18 @@ public class StreamService: NSObject {
         ElloProvider.shared.elloRequest(
             ElloAPI.UserStreamPosts(userId: userId),
             success: { (data, responseConfig) in
-                if let posts = data as? [Post] {
+                let posts: [Post]?
+                if data as? String == "" {
+                    posts = []
+                }
+                else if let foundPosts = data as? [Post] {
+                    posts = foundPosts
+                }
+                else {
+                    posts = nil
+                }
+
+                if let posts = posts {
                     Preloader().preloadImages(posts)
                     success(posts: posts, responseConfig: responseConfig)
                 }
@@ -97,7 +108,6 @@ public class StreamService: NSObject {
             .PostComments(postId: postId),
             success: { (data, responseConfig) in
                 if let comments: [ElloComment] = data as? [ElloComment] {
-
                     for comment in comments {
                         comment.loadedFromPostId = postId
                     }
@@ -105,7 +115,7 @@ public class StreamService: NSObject {
                     Preloader().preloadImages(comments)
                     success(jsonables: comments, responseConfig: responseConfig)
                 }
-                else if let noContent = noContent {
+                else if let noContent = noContent where (data as? String) == "" {
                     noContent()
                 }
                 else {

--- a/Specs/Controllers/Profile/ProfileGeneratorSpec.swift
+++ b/Specs/Controllers/Profile/ProfileGeneratorSpec.swift
@@ -93,8 +93,10 @@ class ProfileDestination: StreamDestination {
         self.user = user
     }
 
-    func primaryJSONAbleNotFound() {
+    func secondaryJSONAbleNotFound() {
+    }
 
+    func primaryJSONAbleNotFound() {
     }
 
     func setPagingConfig(responseConfig: ResponseConfig) {

--- a/Specs/Controllers/Stream/Detail/PostDetailGeneratorSpec.swift
+++ b/Specs/Controllers/Stream/Detail/PostDetailGeneratorSpec.swift
@@ -117,8 +117,10 @@ class PostDetailDestination: StreamDestination {
         self.post = post
     }
 
-    func primaryJSONAbleNotFound() {
+    func secondaryJSONAbleNotFound() {
+    }
 
+    func primaryJSONAbleNotFound() {
     }
 
     func setPagingConfig(responseConfig: ResponseConfig) {

--- a/Specs/Helpers/ElloSpecHelper.swift
+++ b/Specs/Helpers/ElloSpecHelper.swift
@@ -29,6 +29,10 @@ class ElloConfiguration: QuickConfiguration {
             ElloProvider.shared.authState = .Authenticated
             ElloProvider.shared.queue = nil
             ElloProvider.sharedProvider = ElloProvider.StubbingProvider()
+
+            ElloLinkedStore.sharedInstance.writeConnection.readWriteWithBlock { transaction in
+                transaction.removeAllObjectsInAllCollections()
+            }
         }
         config.afterEach {
             ElloProvider_Specs.errorStatusCode = .Status404

--- a/Specs/Model/PostSpec.swift
+++ b/Specs/Model/PostSpec.swift
@@ -62,6 +62,8 @@ class PostSpec: QuickSpec {
 
                 let createdAtString = "2015-12-14T17:01:48.122Z"
                 let post = Post.fromJSON(parsedPost) as! Post
+                let author: User = stub(["id": post.authorId, "username": "archer"])
+                ElloLinkedStore.sharedInstance.setObject(author, forKey: post.authorId, inCollection: "users")
                 var createdAt: NSDate = createdAtString.toNSDate()!
                 // active record
                 expect(post.createdAt) == createdAt


### PR DESCRIPTION
The cast to `[Post]` was failing because "no content" is returned as `data: ""`.  This checks for `""` and the service replies with an empty posts array in that case.  The ProfileGenerator then calls `secondaryJSONAbleNotFound` on the destination, which shows the "This person hasn't posted yet" UI.