### PR TITLE
Fixes the per-page param name

### DIFF
--- a/Sources/Controllers/Profile/ProfileGenerator.swift
+++ b/Sources/Controllers/Profile/ProfileGenerator.swift
@@ -102,7 +102,6 @@ private extension ProfileGenerator {
     }
 
     func loadUserPosts(doneOperation: AsyncOperation) {
-        guard loadingToken.isValidInitialPageLoadingToken(localToken) else { return }
         let displayPostsOperation = AsyncOperation()
         displayPostsOperation.addDependency(doneOperation)
         queue.addOperation(displayPostsOperation)

--- a/Sources/Networking/ElloAPI.swift
+++ b/Sources/Networking/ElloAPI.swift
@@ -683,7 +683,7 @@ extension ElloAPI: Moya.TargetType {
             ]
         case .UserStreamPosts:
             return [
-                "post_count": 10
+                "per_page": 10
             ]
         default:
             return nil


### PR DESCRIPTION
- `/users/id` returns posts, and the number is determined by `post_count`
- `/users/id/posts` returns posts, and the number is determined by `per_page`

😐 