### PR TITLE
Changes to Onboarding

### DIFF
--- a/Ello.xcodeproj/project.pbxproj
+++ b/Ello.xcodeproj/project.pbxproj
@@ -640,7 +640,6 @@
 		1DBF85C11AF8022E00889349 /* ElloWebBrowserViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBF85C01AF8022E00889349 /* ElloWebBrowserViewControllerSpec.swift */; };
 		1DC10FA51C3DEB7600846ED6 /* availability__error.json in Resources */ = {isa = PBXBuildFile; fileRef = 1DC10FA31C3DEB7600846ED6 /* availability__error.json */; };
 		1DC10FA61C3DEB7600846ED6 /* availability.json in Resources */ = {isa = PBXBuildFile; fileRef = 1DC10FA41C3DEB7600846ED6 /* availability.json */; };
-		1DC29BB51D3824720041B1DC /* Onboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3128BF1B557BD500E3D5B6 /* Onboarding.swift */; };
 		1DC29BB71D3824D30041B1DC /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC29BB61D3824D30041B1DC /* Defaults.swift */; };
 		1DC29BB81D3824DE0041B1DC /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC29BB61D3824D30041B1DC /* Defaults.swift */; };
 		1DC309FC1B03F29300EAD920 /* communities.json in Resources */ = {isa = PBXBuildFile; fileRef = 1DC309FB1B03F29300EAD920 /* communities.json */; };
@@ -4077,7 +4076,6 @@
 				1207C9A11C752F1300939ADB /* ElloURI.swift in Sources */,
 				122B30B61C6A3FBB00C1B9D8 /* DynamicSetting.swift in Sources */,
 				1D2F65AA1D185B120099D036 /* DiscoverType.swift in Sources */,
-				1DC29BB51D3824720041B1DC /* Onboarding.swift in Sources */,
 				122B30FA1C6A429E00C1B9D8 /* AttributedStringExtensions.swift in Sources */,
 				122D1BA61C6134D5001386CE /* UIViewNibLoading.swift in Sources */,
 				1D5A901E1D3D749B00C2AEFF /* ElloAPISharingHeaders.swift in Sources */,

--- a/Sources/Controllers/App/AppViewController.swift
+++ b/Sources/Controllers/App/AppViewController.swift
@@ -100,25 +100,17 @@ public class AppViewController: BaseElloViewController {
             }
         }
 
-
         ProfileService().loadCurrentUser(
             success: { user in
                 self.screen.stopAnimatingLogo()
                 self.currentUser = user
 
                 let shouldShowOnboarding = Onboarding.shared().showOnboarding(user)
-                let shouldSaveOnboarding = Onboarding.shared().saveOnboarding(user)
-
                 if shouldShowOnboarding {
                     self.showOnboardingScreen(user)
                 }
                 else {
-                    Onboarding.shared().updateVersionToLatest()
                     self.showMainScreen(user)
-                }
-
-                if shouldSaveOnboarding {
-                    ProfileService().updateUserProfile(["web_onboarding_version": Onboarding.currentVersion], success: { _ in }, failure: { _ in })
                 }
             },
             failure: { (error, _) in
@@ -223,8 +215,6 @@ extension AppViewController {
 
     public func doneOnboarding() {
         Onboarding.shared().updateVersionToLatest()
-        ProfileService().updateUserProfile(["web_onboarding_version": Onboarding.currentVersion], success: { _ in }, failure: { _ in })
-
         self.showMainScreen(currentUser!)
     }
 

--- a/Sources/Controllers/App/DebugTodoController.swift
+++ b/Sources/Controllers/App/DebugTodoController.swift
@@ -100,9 +100,6 @@ class DebugTodoController: UIViewController, UITableViewDataSource, UITableViewD
         addAction("Reset Intro") {
             GroupDefaults["IntroDisplayed"] = nil
         }
-        addAction("Reset Onboarding") {
-            Onboarding.shared().reset()
-        }
         addAction("Crash the app") {
             Crashlytics.sharedInstance().crash()
         }

--- a/Sources/Controllers/Join/JoinScreen.swift
+++ b/Sources/Controllers/Join/JoinScreen.swift
@@ -67,14 +67,17 @@ public class JoinScreen: CredentialsScreen {
     }
 
     let emailField = ClearTextField()
+    let activateEmailButton = UIButton()
     let emailErrorLabel = ElloSizeableLabel()
     var emailMarginConstraint: Constraint!
 
     let usernameField = ClearTextField()
+    let activateUsernameButton = UIButton()
     let usernameErrorLabel = ElloSizeableLabel()
     var usernameMarginConstraint: Constraint!
 
     let passwordField = ClearTextField()
+    let activatePasswordButton = UIButton()
     let passwordErrorLabel = ElloSizeableLabel()
     var passwordMarginConstraint: Constraint!
 
@@ -97,6 +100,9 @@ public class JoinScreen: CredentialsScreen {
         termsButtonNormal.addTarget(self, action: #selector(termsAction), forControlEvents: .TouchUpInside)
         termsButtonKeyboard.addTarget(self, action: #selector(termsAction), forControlEvents: .TouchUpInside)
         passwordField.onePasswordButton.addTarget(self, action: #selector(onePasswordAction(_:)), forControlEvents: .TouchUpInside)
+        activateEmailButton.addTarget(self, action: #selector(activateEmail), forControlEvents: .TouchUpInside)
+        activateUsernameButton.addTarget(self, action: #selector(activateUsername), forControlEvents: .TouchUpInside)
+        activatePasswordButton.addTarget(self, action: #selector(activatePassword), forControlEvents: .TouchUpInside)
     }
 
     override func style() {
@@ -148,14 +154,16 @@ public class JoinScreen: CredentialsScreen {
     override func arrange() {
         super.arrange()
 
+        scrollView.addSubview(activateEmailButton)
         scrollView.addSubview(emailField)
         scrollView.addSubview(emailErrorLabel)
+        scrollView.addSubview(activateUsernameButton)
         scrollView.addSubview(usernameField)
         scrollView.addSubview(usernameErrorLabel)
         scrollView.addSubview(messageLabel)
+        scrollView.addSubview(activatePasswordButton)
         scrollView.addSubview(passwordField)
         scrollView.addSubview(passwordErrorLabel)
-
         scrollView.addSubview(termsButtonKeyboard)
 
         addSubview(termsButtonNormal)
@@ -175,6 +183,11 @@ public class JoinScreen: CredentialsScreen {
             scrollViewWidthConstraint = make.width.equalTo(frame.size.width).priorityRequired().constraint
         }
 
+        activateEmailButton.snp_makeConstraints { make in
+            make.leading.trailing.equalTo(scrollView)
+            make.centerY.equalTo(emailField)
+            make.height.equalTo(emailField).offset(Size.fieldsInnerMargin)
+        }
         emailField.snp_makeConstraints { make in
             make.top.equalTo(titleLabel.snp_bottom).offset(Size.fieldsTopMargin)
             make.leading.trailing.equalTo(scrollView).inset(CredentialsScreen.Size.inset)
@@ -186,6 +199,11 @@ public class JoinScreen: CredentialsScreen {
         }
         emailMarginConstraint.deactivate()
 
+        activateUsernameButton.snp_makeConstraints { make in
+            make.leading.trailing.equalTo(scrollView)
+            make.centerY.equalTo(usernameField)
+            make.height.equalTo(usernameField).offset(Size.fieldsInnerMargin)
+        }
         usernameField.snp_makeConstraints { make in
             make.top.equalTo(emailErrorLabel.snp_bottom).offset(Size.fieldsInnerMargin)
             make.leading.trailing.equalTo(scrollView).inset(CredentialsScreen.Size.inset)
@@ -204,6 +222,11 @@ public class JoinScreen: CredentialsScreen {
         }
         messageMarginConstraint.deactivate()
 
+        activatePasswordButton.snp_makeConstraints { make in
+            make.leading.trailing.equalTo(scrollView)
+            make.centerY.equalTo(passwordField)
+            make.height.equalTo(passwordField).offset(Size.fieldsInnerMargin)
+        }
         passwordField.snp_makeConstraints { make in
             make.top.equalTo(messageLabel.snp_bottom).offset(Size.fieldsInnerMargin)
             make.leading.trailing.equalTo(scrollView).inset(CredentialsScreen.Size.inset)
@@ -275,6 +298,18 @@ extension JoinScreen {
 }
 
 extension JoinScreen {
+    public func activateEmail() {
+      emailField.becomeFirstResponder()
+    }
+
+    public func activateUsername() {
+      usernameField.becomeFirstResponder()
+    }
+
+    public func activatePassword() {
+      passwordField.becomeFirstResponder()
+    }
+
     override public func backAction() {
         delegate?.backAction()
     }

--- a/Sources/Controllers/Onboarding/CategoriesSelectionViewController.swift
+++ b/Sources/Controllers/Onboarding/CategoriesSelectionViewController.swift
@@ -74,6 +74,9 @@ extension CategoriesSelectionViewController: OnboardingStepController {
 
             UserService().setUserCategories(categories)
                 .onSuccess { _ in
+                    // onboarding can be considered "done", even if they abort the app
+                    Onboarding.shared().updateVersionToLatest()
+
                     self.onboardingData.categories = categories
                     proceedClosure(success: true)
                 }

--- a/Sources/Controllers/Onboarding/OnboardingProtocols.swift
+++ b/Sources/Controllers/Onboarding/OnboardingProtocols.swift
@@ -6,10 +6,6 @@ public enum OnboardingStep: Int {
     case Categories = 0
     case CreateProfile
     case InviteFriends
-
-    public var nextStep: OnboardingStep? {
-        return OnboardingStep(rawValue: rawValue + 1)
-    }
 }
 
 public protocol OnboardingDelegate: class {

--- a/Sources/Controllers/Onboarding/OnboardingScreen.swift
+++ b/Sources/Controllers/Onboarding/OnboardingScreen.swift
@@ -40,12 +40,11 @@ public class OnboardingScreen: EmptyScreen {
     override func style() {
         buttonContainer.backgroundColor = .greyE5()
         abortButton.hidden = true
-
         nextButton.hidden = true
     }
 
     override func bindActions() {
-        promptButton.addTarget(self, action: #selector(nextAction), forControlEvents: .TouchUpInside)
+        promptButton.enabled = false
         nextButton.addTarget(self, action: #selector(nextAction), forControlEvents: .TouchUpInside)
         abortButton.addTarget(self, action: #selector(abortAction), forControlEvents: .TouchUpInside)
     }

--- a/Sources/Utilities/Onboarding.swift
+++ b/Sources/Utilities/Onboarding.swift
@@ -6,25 +6,15 @@ import SwiftyUserDefaults
 
 
 private let _sharedInstance = Onboarding()
-private let _currentVersion = 1
+private let _currentVersion = 2
 
 public class Onboarding {
-    public private(set) var version: Int {
-        didSet {
-            GroupDefaults["ViewedOnboardingVersion"] = version
-        }
-    }
-
     public static var currentVersion: Int {
         return _currentVersion
     }
 
     public func updateVersionToLatest() {
-        version = _currentVersion
-    }
-
-    public func reset() {
-        version = 0
+        ProfileService().updateUserProfile(["web_onboarding_version": _currentVersion], success: { _ in }, failure: { _ in })
     }
 
     public class func shared() -> Onboarding {
@@ -32,30 +22,11 @@ public class Onboarding {
     }
 
     init() {
-        version = GroupDefaults["ViewedOnboardingVersion"].int ?? 0
     }
 
-    // only show if webVersion is set and
-    // localVersion < currentVersion and
-    // webVersion < currentVersion
+    // only show if webVersion is nil
     public func showOnboarding(user: User) -> Bool {
-        guard let webVersion = user.onboardingVersion else {
-            return false
-        }
-        return version < _currentVersion && webVersion < _currentVersion
-    }
-
-    // never save if onboarding is being presented.
-    // save to API if webVersion is nil,
-    // or less than currentVersion
-    public func saveOnboarding(user: User) -> Bool {
-        guard !showOnboarding(user) else {
-            return false
-        }
-        guard let webVersion = user.onboardingVersion else {
-            return true
-        }
-        return webVersion < _currentVersion
+        return user.onboardingVersion == nil
     }
 
 }

--- a/Sources/Views/StyledButton.swift
+++ b/Sources/Views/StyledButton.swift
@@ -194,9 +194,9 @@ extension StyledButton.Style {
         cornerRadius: nil
         )
     public static let RoundedGray = StyledButton.Style(
-        backgroundColor: .clearColor(), disabledBackgroundColor: .greyF2(),
-        titleColor: .greyA(), highlightedTitleColor: .blackColor(), disabledTitleColor: .greyC(),
-        borderColor: .greyA(), disabledBorderColor: .greyF2(),
+        backgroundColor: .clearColor(),
+        titleColor: .greyA(), highlightedTitleColor: .blackColor(),
+        borderColor: .greyA(),
         cornerRadius: 5
         )
     public static let InviteFriend = StyledButton.Style(

--- a/Specs/Utilities/OnboardingSpec.swift
+++ b/Specs/Utilities/OnboardingSpec.swift
@@ -12,20 +12,15 @@ import Ello
 class OnboardingSpec: QuickSpec {
     override func spec() {
         describe("Onboarding") {
-            let currentVersion: Int? = GroupDefaults["ViewedOnboardingVersion"].int
-            afterSuite {
-                GroupDefaults["ViewedOnboardingVersion"] = currentVersion
-            }
-
-            let expectations: [(localIsCurrent: Bool, webIsCurrent: Bool?, showOnboarding: Bool, saveOnboarding: Bool)] = [
-                (localIsCurrent: true, webIsCurrent: nil, showOnboarding: false, saveOnboarding: true),
-                (localIsCurrent: true, webIsCurrent: false, showOnboarding: false, saveOnboarding: true),
-                (localIsCurrent: true, webIsCurrent: true, showOnboarding: false, saveOnboarding: false),
-                (localIsCurrent: false, webIsCurrent: nil, showOnboarding: false, saveOnboarding: true),
-                (localIsCurrent: false, webIsCurrent: false, showOnboarding: true, saveOnboarding: true),
-                (localIsCurrent: false, webIsCurrent: true, showOnboarding: false, saveOnboarding: false),
+            let expectations: [(localIsCurrent: Bool, webIsCurrent: Bool?, showOnboarding: Bool)] = [
+                (localIsCurrent: true, webIsCurrent: nil, showOnboarding: true),
+                (localIsCurrent: true, webIsCurrent: false, showOnboarding: false),
+                (localIsCurrent: true, webIsCurrent: true, showOnboarding: false),
+                (localIsCurrent: false, webIsCurrent: nil, showOnboarding: true),
+                (localIsCurrent: false, webIsCurrent: false, showOnboarding: false),
+                (localIsCurrent: false, webIsCurrent: true, showOnboarding: false),
             ]
-            for (localIsCurrent, webIsCurrent, showOnboarding, saveOnboarding) in expectations {
+            for (localIsCurrent, webIsCurrent, showOnboarding) in expectations {
                 let title1: String
                 if localIsCurrent { title1 = "localVersion is currentVersion" }
                 else { title1 = "localVersion less than currentVersion" }
@@ -36,7 +31,7 @@ class OnboardingSpec: QuickSpec {
                 case .Some(false): title2 = "webVersion less than currentVersion"
                 }
                 describe("\(title1) and \(title2)") {
-                    it("showOnboarding should be \(showOnboarding), saveOnboarding should be \(saveOnboarding)") {
+                    it("showOnboarding should be \(showOnboarding)") {
                         if localIsCurrent {
                             GroupDefaults["ViewedOnboardingVersion"] = 1
                         }
@@ -59,7 +54,6 @@ class OnboardingSpec: QuickSpec {
                             expect(user.onboardingVersion).to(beNil())
                         }
                         expect(onboarding.showOnboarding(user)) == showOnboarding
-                        expect(onboarding.saveOnboarding(user)) == saveOnboarding
                     }
                 }
             }

--- a/Specs/Utilities/OnboardingSpec.swift
+++ b/Specs/Utilities/OnboardingSpec.swift
@@ -46,7 +46,6 @@ class OnboardingSpec: QuickSpec {
                         }
                         let user: User = stub(props)
 
-                        expect(onboarding.version) == (localIsCurrent ? 1 : 0)
                         if let webIsCurrent = webIsCurrent {
                             expect(user.onboardingVersion ?? -1) == (webIsCurrent ? 1 : 0)
                         }


### PR DESCRIPTION
- disables the 'Pick 3/2/1' and 'Invite People' buttons until they're green
- makes text fields easier to tap in Sign Up
- changes onboarding logic: show if version is `nil`, otherwise ignore.
- changes onboarding saving logic: updates version after setting the categories (even if you force quit the app)