### PR TITLE
Validation fixes during onboarding

### DIFF
--- a/Resources/Settings.storyboard
+++ b/Resources/Settings.storyboard
@@ -487,7 +487,7 @@
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
                                                 </textField>
-                                                <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h0e-7m-r6C" customClass="ElloButton" customModule="Ello" customModuleProvider="target">
+                                                <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h0e-7m-r6C" customClass="ElloButton" customModule="Ello" customModuleProvider="target">
                                                     <rect key="frame" x="515" y="45" width="70" height="50"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="70" id="gHW-2S-08U"/>

--- a/Sources/Controllers/Join/JoinProtocols.swift
+++ b/Sources/Controllers/Join/JoinProtocols.swift
@@ -19,8 +19,7 @@ protocol JoinScreenProtocol: class {
     var passwordValid: Bool? { get set }
     var onePasswordAvailable: Bool { get set }
 
-    func enableInputs()
-    func disableInputs()
+    func loadingHUD(visible visible: Bool)
 
     func showMessage(text: String)
     func showUsernameSuggestions(usernames: [String])

--- a/Sources/Controllers/Join/JoinScreen.swift
+++ b/Sources/Controllers/Join/JoinScreen.swift
@@ -380,18 +380,17 @@ extension JoinScreen: UITextFieldDelegate {
 }
 
 extension JoinScreen: JoinScreenProtocol {
-    func enableInputs() {
-        emailField.enabled = true
-        usernameField.enabled = true
-        passwordField.enabled = true
-        userInteractionEnabled = true
-    }
-
-    func disableInputs() {
-        emailField.enabled = false
-        usernameField.enabled = false
-        passwordField.enabled = false
-        userInteractionEnabled = false
+    func loadingHUD(visible visible: Bool) {
+        if visible {
+            ElloHUD.showLoadingHudInView(self)
+        }
+        else {
+            ElloHUD.hideLoadingHudInView(self)
+        }
+        emailField.enabled = !visible
+        usernameField.enabled = !visible
+        passwordField.enabled = !visible
+        userInteractionEnabled = !visible
     }
 
     func showUsernameSuggestions(usernames: [String]) {

--- a/Sources/Controllers/Join/JoinViewController.swift
+++ b/Sources/Controllers/Join/JoinViewController.swift
@@ -65,11 +65,11 @@ extension JoinViewController: JoinDelegate {
             screen.hideEmailError()
             screen.hideUsernameError()
             screen.hidePasswordError()
-            screen.disableInputs()
+            screen.loadingHUD(visible: true)
 
             var joinSuccessful = true
             let joinAborted: () -> Void = {
-                self.screen.enableInputs()
+                self.screen.loadingHUD(visible: false)
             }
             let joinContinue = after(2) {
                 guard joinSuccessful else {

--- a/Sources/Controllers/Onboarding/CategoriesSelectionViewController.swift
+++ b/Sources/Controllers/Onboarding/CategoriesSelectionViewController.swift
@@ -60,7 +60,7 @@ extension CategoriesSelectionViewController: OnboardingStepController {
         onboardingViewController?.prompt = prompt
     }
 
-    public func onboardingWillProceed(abort: Bool, proceedClosure: (success: Bool?) -> Void) {
+    public func onboardingWillProceed(abort: Bool, proceedClosure: (success: OnboardingViewController.OnboardingProceed) -> Void) {
         if let
             selection = streamViewController.collectionView.indexPathsForSelectedItems()
         where selection.count > 0 {
@@ -78,16 +78,13 @@ extension CategoriesSelectionViewController: OnboardingStepController {
                     Onboarding.shared().updateVersionToLatest()
 
                     self.onboardingData.categories = categories
-                    proceedClosure(success: true)
+                    proceedClosure(success: .Continue)
                 }
                 .onFail { _ in
                     let alertController = AlertViewController(error: InterfaceString.GenericError)
                     self.parentAppController?.presentViewController(alertController, animated: true, completion: nil)
-                    proceedClosure(success: nil)
+                    proceedClosure(success: .Error)
                 }
-        }
-        else {
-            proceedClosure(success: true)
         }
     }
 }

--- a/Sources/Controllers/Onboarding/CreateProfileProtocols.swift
+++ b/Sources/Controllers/Onboarding/CreateProfileProtocols.swift
@@ -17,6 +17,7 @@ protocol CreateProfileScreenProtocol: class {
     var name: String? { get set }
     var bio: String? { get set }
     var links: String? { get set }
+    var linksValid: Bool? { get set }
     var coverImage: ImageRegionData? { get set }
     var avatarImage: ImageRegionData? { get set }
 }

--- a/Sources/Controllers/Onboarding/CreateProfileScreen.swift
+++ b/Sources/Controllers/Onboarding/CreateProfileScreen.swift
@@ -46,6 +46,17 @@ public class CreateProfileScreen: Screen, CreateProfileScreenProtocol {
             linksTextView.validationState = (newValue?.isEmpty == false) ? .OKSmall : .None
         }
     }
+    var linksValid: Bool? = nil {
+        didSet {
+            let newState: ValidationState
+            switch linksValid {
+            case .None: newState = .None
+            case .Some(true): newState = .OKSmall
+            case .Some(false): newState = .Error
+            }
+            linksTextView.validationState = newState
+        }
+    }
     var coverImage: ImageRegionData? {
         didSet {
             setImage(coverImage, target: .CoverImage, updateDelegate: false)

--- a/Sources/Controllers/Onboarding/CreateProfileViewController.swift
+++ b/Sources/Controllers/Onboarding/CreateProfileViewController.swift
@@ -15,7 +15,13 @@ public class CreateProfileViewController: UIViewController, HasAppController {
     var didSetLinks = false
     var didUploadCoverImage = false
     var didUploadAvatarImage = false
-    var didSetAnything = false
+    var didSetAnything: Bool {
+        return didSetName ||
+            didSetBio ||
+            didSetLinks ||
+            didUploadCoverImage ||
+            didUploadAvatarImage
+    }
 
     override public func loadView() {
         let screen = CreateProfileScreen()
@@ -35,50 +41,43 @@ extension CreateProfileViewController: CreateProfileDelegate {
 
     func assignName(name: String?) {
         onboardingData.name = name
-        didSetAnything = didSetAnything || (name?.isEmpty == false)
-        didSetName = true
+        didSetName = (name?.isEmpty == false)
         onboardingViewController?.canGoNext = didSetAnything
     }
 
     func assignBio(bio: String?) {
         onboardingData.bio = bio
-        didSetAnything = didSetAnything || (bio?.isEmpty == false)
-        didSetBio = true
+        didSetBio = (bio?.isEmpty == false)
         onboardingViewController?.canGoNext = didSetAnything
     }
 
     func assignLinks(links: String?) {
         onboardingData.links = links
-        didSetAnything = didSetAnything || (links?.isEmpty == false)
-        didSetLinks = true
+        didSetLinks = (links?.isEmpty == false)
         onboardingViewController?.canGoNext = didSetAnything
     }
 
     func assignCoverImage(image: ImageRegionData) {
         didUploadCoverImage = true
         onboardingData.coverImage = image
-        didSetAnything = true
         onboardingViewController?.canGoNext = didSetAnything
     }
     func assignAvatar(image: ImageRegionData) {
         didUploadAvatarImage = true
         onboardingData.avatarImage = image
-        didSetAnything = true
         onboardingViewController?.canGoNext = didSetAnything
     }
 }
 
 extension CreateProfileViewController: OnboardingStepController {
     public func onboardingStepBegin() {
-        if onboardingData.name?.isEmpty == false ||
-            onboardingData.bio?.isEmpty == false ||
-            onboardingData.links?.isEmpty == false ||
-            onboardingData.coverImage != nil ||
-            onboardingData.avatarImage != nil
-        {
-            didSetAnything = true
-            onboardingViewController?.canGoNext = true
-        }
+        didSetName = (onboardingData.name?.isEmpty == false)
+        didSetBio = (onboardingData.bio?.isEmpty == false)
+        didSetLinks = (onboardingData.links?.isEmpty == false)
+        didUploadAvatarImage = (onboardingData.avatarImage != nil)
+        didUploadCoverImage = (onboardingData.coverImage != nil)
+        onboardingViewController?.canGoNext = didSetAnything
+
         screen.name = onboardingData.name
         screen.bio = onboardingData.bio
         screen.links = onboardingData.links

--- a/Sources/Controllers/Onboarding/CreateProfileViewController.swift
+++ b/Sources/Controllers/Onboarding/CreateProfileViewController.swift
@@ -86,7 +86,7 @@ extension CreateProfileViewController: OnboardingStepController {
         screen.avatarImage = onboardingData.avatarImage
     }
 
-    public func onboardingWillProceed(abort: Bool, proceedClosure: (success: Bool?) -> Void) {
+    public func onboardingWillProceed(abort: Bool, proceedClosure: (success: OnboardingViewController.OnboardingProceed) -> Void) {
         var properties: [String: AnyObject] = [:]
         if let name = onboardingData.name where didSetName {
             Tracker.sharedTracker.enteredOnboardName()
@@ -118,7 +118,7 @@ extension CreateProfileViewController: OnboardingStepController {
                 self.parentAppController?.currentUser = user
                 self.goToNextStep(abort, proceedClosure: proceedClosure) },
             failure: { error, _ in
-                proceedClosure(success: nil)
+                proceedClosure(success: .Error)
                 let message: String
                 if let elloError = error.elloError, messages = elloError.messages {
                     message = messages.joinWithSeparator("\n")
@@ -131,11 +131,11 @@ extension CreateProfileViewController: OnboardingStepController {
             })
     }
 
-    func goToNextStep(abort: Bool, proceedClosure: (success: Bool) -> Void) {
+    func goToNextStep(abort: Bool, proceedClosure: (success: OnboardingViewController.OnboardingProceed) -> Void) {
         guard let
             presenter = onboardingViewController?.parentAppController
         where !abort else {
-            proceedClosure(success: false)
+            proceedClosure(success: .Abort)
             return
         }
 
@@ -150,10 +150,10 @@ extension CreateProfileViewController: OnboardingStepController {
                 vc.onboardingViewController = self.onboardingViewController
                 self.onboardingViewController?.inviteFriendsController = vc
 
-                proceedClosure(success: true)
+                proceedClosure(success: .Continue)
             case let .Failure(addressBookError):
                 guard addressBookError != .Cancelled else {
-                    proceedClosure(success: false)
+                    proceedClosure(success: .Error)
                     return
                 }
 

--- a/Sources/Controllers/Onboarding/CreateProfileViewController.swift
+++ b/Sources/Controllers/Onboarding/CreateProfileViewController.swift
@@ -120,6 +120,9 @@ extension CreateProfileViewController: OnboardingStepController {
                 proceedClosure(success: .Error)
                 let message: String
                 if let elloError = error.elloError, messages = elloError.messages {
+                    if elloError.attrs?["links"] != nil {
+                        self.screen.linksValid = false
+                    }
                     message = messages.joinWithSeparator("\n")
                 }
                 else {

--- a/Sources/Controllers/Onboarding/InviteFriendsViewController.swift
+++ b/Sources/Controllers/Onboarding/InviteFriendsViewController.swift
@@ -80,8 +80,8 @@ extension InviteFriendsViewController: OnboardingStepController {
         onboardingViewController?.isLastOnboardingStep = true
     }
 
-    public func onboardingWillProceed(abort: Bool, proceedClosure: (success: Bool?) -> Void) {
-        proceedClosure(success: true)
+    public func onboardingWillProceed(abort: Bool, proceedClosure: (success: OnboardingViewController.OnboardingProceed) -> Void) {
+        proceedClosure(success: .Continue)
     }
 }
 

--- a/Sources/Controllers/Onboarding/OnboardingProtocols.swift
+++ b/Sources/Controllers/Onboarding/OnboardingProtocols.swift
@@ -29,6 +29,6 @@ public protocol OnboardingScreenProtocol: class {
 public protocol OnboardingStepController: class {
     var onboardingViewController: OnboardingViewController? { get set }
     var onboardingData: OnboardingData! { get set }
-    func onboardingWillProceed(abort: Bool, proceedClosure: (success: Bool?) -> Void)
+    func onboardingWillProceed(abort: Bool, proceedClosure: (success: OnboardingViewController.OnboardingProceed) -> Void)
     func onboardingStepBegin()
 }

--- a/Sources/Controllers/Onboarding/OnboardingViewController.swift
+++ b/Sources/Controllers/Onboarding/OnboardingViewController.swift
@@ -10,6 +10,11 @@ public class OnboardingViewController: BaseElloViewController, HasAppController 
         case Left = -1
         case Right = 1
     }
+    public enum OnboardingProceed {
+        case Continue
+        case Abort
+        case Error
+    }
 
     var mockScreen: OnboardingScreenProtocol?
     var screen: OnboardingScreenProtocol { return mockScreen ?? (self.view as! OnboardingScreenProtocol) }
@@ -172,7 +177,7 @@ extension OnboardingViewController {
             Tracker.sharedTracker.completedContactImport()
         }
 
-        let proceedClosure: (success: Bool?) -> Void
+        let proceedClosure: (success: OnboardingProceed) -> Void
         if abort {
             proceedClosure = { _ in
                 self.doneOnboarding()
@@ -181,10 +186,10 @@ extension OnboardingViewController {
         else {
             proceedClosure = { success in
                 ElloHUD.hideLoadingHudInView(self.view)
-                if success == true {
+                if success == .Continue {
                     self.goToNextStep()
                 }
-                else if success == false {
+                else if success == .Abort {
                     self.doneOnboarding()
                 }
             }

--- a/Specs/Controllers/Join/JoinViewControllerSpec.swift
+++ b/Specs/Controllers/Join/JoinViewControllerSpec.swift
@@ -15,7 +15,7 @@ class JoinViewControllerSpec: QuickSpec {
         var password: String = ""
         var onePasswordAvailable: Bool = false
 
-        var inputsEnabled = true
+        var loadingHUDVisible = false
         var message: String?
         var emailError: String?
         var usernameError: String?
@@ -27,11 +27,8 @@ class JoinViewControllerSpec: QuickSpec {
         var passwordValid: Bool?
         var resignedFirstResponder = false
 
-        func enableInputs() {
-            inputsEnabled = true
-        }
-        func disableInputs() {
-            inputsEnabled = false
+        func loadinHUD(visible visible: Bool) {
+            loadingHUDVisible = visible
         }
 
         func showMessage(text: String) {
@@ -211,8 +208,8 @@ class JoinViewControllerSpec: QuickSpec {
                         mockScreen.password = password
                         subject.submit(email: email, username: username, password: password)
                     }
-                    it("should disable inputs") {
-                        expect(mockScreen.inputsEnabled) == false
+                    it("should show loadingHUD") {
+                        expect(mockScreen.loadingHUDVisible) == true
                     }
                     it("should hide errors") {
                         expect(mockScreen.message) == ""
@@ -232,8 +229,8 @@ class JoinViewControllerSpec: QuickSpec {
                         mockScreen.password = password
                         subject.submit(email: email, username: username, password: password)
                     }
-                    it("should enable inputs") {
-                        expect(mockScreen.inputsEnabled) == true
+                    it("should hide loadingHUD") {
+                        expect(mockScreen.loadingHUDVisible) == true
                     }
                     it("should show errors") {
                         expect(mockScreen.emailError).notTo(beNil())


### PR DESCRIPTION
Solves remaining QA issues:

- [x] if you type a name, then delete it, the button will become disabled again
- [x] if you type an invalid link and the server rejects it, you will be presented with the error message

Also I added an `OnboardingProceed` enum, which is passed into the `proceed()` closure to make it clear what should happen next (`.Continue`, `.Abort`, `.Error`).  These used to be `true / false / nil`, which are not very clear.