### PR TITLE
Fix iOS 10 push notification routing

### DIFF
--- a/Sources/Controllers/Notifications/NotificationsViewController.swift
+++ b/Sources/Controllers/Notifications/NotificationsViewController.swift
@@ -61,7 +61,7 @@ public class NotificationsViewController: StreamableViewController, Notification
         }
         fromTabBar = false
 
-        PushNotificationController.sharedController.updateBadgeCount(0)
+        PushNotificationController.sharedController.updateBadgeNumber(0)
     }
 
     func reload() {

--- a/Support/ElloDev.entitlements
+++ b/Support/ElloDev.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:staging.ello.co</string>


### PR DESCRIPTION
iOS 10 introduced new api for subscribing to and handling push notifications. See https://developer.apple.com/reference/usernotifications.

This caused devices running iOS 10 to be unable to route Ello push notifications to the correct screen in app. The app now handles both iOS 10 and pre iOS 10 push notifications correctly.

*Note - needs to be tested on an iOS 9 device.