### PR TITLE
Don’t redraw rightBarButtonItems

### DIFF
--- a/Ello.xcodeproj/project.pbxproj
+++ b/Ello.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		121D92591A5CACEA004F0455 /* JoinViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121D92581A5CACEA004F0455 /* JoinViewControllerSpec.swift */; };
 		121E46BD1A6B2798004AEAB7 /* StreamContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121E46BC1A6B2798004AEAB7 /* StreamContainerViewController.swift */; };
 		12224E581A72CEC300D087EC /* PostbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12224E571A72CEC300D087EC /* PostbarController.swift */; };
+		122454AE1D9F1BC700D930E0 /* ElloCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 122454AD1D9F1BC700D930E0 /* ElloCollectionView.swift */; };
 		122943271C6BF465003FCD20 /* ShareViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1291CE2D1C6A91C600EB5A55 /* ShareViewControllerSpec.swift */; };
 		122943281C6BF509003FCD20 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 124CFB991C5976E500727D11 /* ShareViewController.swift */; };
 		122943291C6BF534003FCD20 /* ExtensionItemPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127D26531C655C87001F2E3E /* ExtensionItemPreview.swift */; };
@@ -1073,6 +1074,7 @@
 		121D92581A5CACEA004F0455 /* JoinViewControllerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JoinViewControllerSpec.swift; sourceTree = "<group>"; };
 		121E46BC1A6B2798004AEAB7 /* StreamContainerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StreamContainerViewController.swift; sourceTree = "<group>"; };
 		12224E571A72CEC300D087EC /* PostbarController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostbarController.swift; sourceTree = "<group>"; };
+		122454AD1D9F1BC700D930E0 /* ElloCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElloCollectionView.swift; sourceTree = "<group>"; };
 		1229432D1C6C101E003FCD20 /* ExtensionItemPreviewSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionItemPreviewSpec.swift; sourceTree = "<group>"; };
 		1229432F1C6C355A003FCD20 /* NSItemProviderExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSItemProviderExtensionsSpec.swift; sourceTree = "<group>"; };
 		122B18EE1A867C7D00247A05 /* StreamFooterButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StreamFooterButton.swift; sourceTree = "<group>"; };
@@ -2817,7 +2819,7 @@
 				1D9B74C91BB1E3EF00ACD028 /* CommentsIcon.swift */,
 				1D22C8251AAFAD760048D415 /* CreateCommentBackgroundView.swift */,
 				12F6AE651A4339EF00493660 /* ElloButton.swift */,
-				12DB1CA81D9C84B4007E3E4C /* ElloCollectionView.swift */,
+				122454AD1D9F1BC700D930E0 /* ElloCollectionView.swift */,
 				EA587A9E1ACDC6F4002AF389 /* ElloEditableTextView.swift */,
 				12F6AE661A4339EF00493660 /* ElloHUD.swift */,
 				122D1BBD1C641188001386CE /* ElloHUDWindowExtensions.swift */,
@@ -4787,7 +4789,7 @@
 				1D15C2781C7D12890013B192 /* InterfaceImage.swift in Sources */,
 				122B30F01C6A3FC500C1B9D8 /* ImageRegion.swift in Sources */,
 				EAF43D941AB0DE080016E110 /* ObjectCache.swift in Sources */,
-				12DB1CA91D9C84B4007E3E4C /* ElloCollectionView.swift in Sources */,
+				122454AE1D9F1BC700D930E0 /* ElloCollectionView.swift in Sources */,
 				76FF80551A966B6300617A1E /* RelationshipController.swift in Sources */,
 				122B190D1A86894400247A05 /* StreamCellType.swift in Sources */,
 				122B30C41C6A3FBC00C1B9D8 /* Activity.swift in Sources */,

--- a/Ello.xcodeproj/project.pbxproj
+++ b/Ello.xcodeproj/project.pbxproj
@@ -366,7 +366,7 @@
 		12D24A5A1A9F765300F53D44 /* AddFriendsViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12D24A591A9F765300F53D44 /* AddFriendsViewControllerSpec.swift */; };
 		12D43A461AC864CC0039F54F /* StreamToggleCellPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12D43A451AC864CC0039F54F /* StreamToggleCellPresenter.swift */; };
 		12D43A491AC865540039F54F /* StreamToggleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12D43A481AC865540039F54F /* StreamToggleCell.swift */; };
-		12DB1CA91D9C84B4007E3E4C /* ElloCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12DB1CA81D9C84B4007E3E4C /* ElloCollectionView.swift */; };
+		12DB1CA71D9C6B9E007E3E4C /* UINavigationItemSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12DB1CA61D9C6B9E007E3E4C /* UINavigationItemSpec.swift */; };
 		12DD85C61B015A76004D3EEF /* UITabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12DD85C51B015A76004D3EEF /* UITabBarItem.swift */; };
 		12DEB2491C5BED4000D4CDCE /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A3B6441AC457CA00806224 /* Array.swift */; };
 		12DEB24A1C5BED4600D4CDCE /* RegexExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB474FA1BAB5584000AA9DC /* RegexExtensions.swift */; };
@@ -1256,7 +1256,7 @@
 		12D43A451AC864CC0039F54F /* StreamToggleCellPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StreamToggleCellPresenter.swift; path = sources/controllers/stream/CellDequeing/StreamToggleCellPresenter.swift; sourceTree = SOURCE_ROOT; };
 		12D43A481AC865540039F54F /* StreamToggleCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StreamToggleCell.swift; path = sources/controllers/stream/Cells/StreamToggleCell.swift; sourceTree = SOURCE_ROOT; };
 		12D56B661A8C6BC000671280 /* Asset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Asset.swift; sourceTree = "<group>"; };
-		12DB1CA81D9C84B4007E3E4C /* ElloCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElloCollectionView.swift; sourceTree = "<group>"; };
+		12DB1CA61D9C6B9E007E3E4C /* UINavigationItemSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UINavigationItemSpec.swift; sourceTree = "<group>"; };
 		12DD85C51B015A76004D3EEF /* UITabBarItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UITabBarItem.swift; path = sources/Extensions/UITabBarItem.swift; sourceTree = SOURCE_ROOT; };
 		12DEB24D1C5BFA9200D4CDCE /* libcommonCrypto.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libcommonCrypto.tbd; path = usr/lib/system/libcommonCrypto.tbd; sourceTree = SDKROOT; };
 		12DEB24F1C5BFB3100D4CDCE /* CryptoStringExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CryptoStringExtensions.swift; path = sources/Extensions/CryptoStringExtensions.swift; sourceTree = SOURCE_ROOT; };
@@ -2386,6 +2386,7 @@
 				1D5933811D14635B00EAF03D /* UIEdgeInsetsSpec.swift */,
 				1DF50C8C1C61452D00C62D89 /* UIImagePickerControllerSpec.swift */,
 				1D1C88AA1AC9B71600AFC56D /* UIImageSpecs.swift */,
+				12DB1CA61D9C6B9E007E3E4C /* UINavigationItemSpec.swift */,
 				1D9D170E1AE72372009841A4 /* UIViewControllerExtensionSpec.swift */,
 				12384EBC1C56C8B200608BD8 /* UIViewExtensionsSpec.swift */,
 				1D2D18671AC322170078AA05 /* UIWebViewSpecs.swift */,
@@ -4378,6 +4379,7 @@
 				76FF805D1A96A87A00617A1E /* BlockUserModalViewControllerSpec.swift in Sources */,
 				762ABBA51A8ACB7700B19E34 /* JSONAbleSpec.swift in Sources */,
 				1DF50C8D1C61452D00C62D89 /* UIImagePickerControllerSpec.swift in Sources */,
+				12DB1CA71D9C6B9E007E3E4C /* UINavigationItemSpec.swift in Sources */,
 				12B093661A6D87C000BF104E /* StreamContainerViewControllerSpec.swift in Sources */,
 				12D14C721A43762400C6F8E8 /* PostSpec.swift in Sources */,
 				122C663C1B4253250035F4CD /* AutoCompleteDataSourceSpec.swift in Sources */,

--- a/Sources/Controllers/Profile/ProfileViewController.swift
+++ b/Sources/Controllers/Profile/ProfileViewController.swift
@@ -24,6 +24,7 @@ public final class ProfileViewController: StreamableViewController {
     var deeplinkPath: String?
     var generator: ProfileGenerator?
     private var isSetup = false
+    private var rightButtonsInitialized = false
 
     @IBOutlet weak var navigationBar: ElloNavigationBar!
     @IBOutlet weak var whiteSolidView: UIView!
@@ -270,6 +271,9 @@ public final class ProfileViewController: StreamableViewController {
     }
 
     func assignRightButtons() {
+        guard !rightButtonsInitialized else { return }
+        rightButtonsInitialized = true
+
         if let currentUser = currentUser where userParam == currentUser.id || userParam == "~\(currentUser.username)" {
             elloNavigationItem.rightBarButtonItems = [
                 UIBarButtonItem(image: .Search, target: self, action: #selector(BaseElloViewController.searchButtonTapped)),

--- a/Sources/Controllers/Profile/ProfileViewController.swift
+++ b/Sources/Controllers/Profile/ProfileViewController.swift
@@ -24,7 +24,6 @@ public final class ProfileViewController: StreamableViewController {
     var deeplinkPath: String?
     var generator: ProfileGenerator?
     private var isSetup = false
-    private var rightButtonsInitialized = false
 
     @IBOutlet weak var navigationBar: ElloNavigationBar!
     @IBOutlet weak var whiteSolidView: UIView!
@@ -271,8 +270,6 @@ public final class ProfileViewController: StreamableViewController {
     }
 
     func assignRightButtons() {
-        guard !rightButtonsInitialized else { return }
-        rightButtonsInitialized = true
 
         if let currentUser = currentUser where userParam == currentUser.id || userParam == "~\(currentUser.username)" {
             elloNavigationItem.rightBarButtonItems = [
@@ -296,8 +293,17 @@ public final class ProfileViewController: StreamableViewController {
             rightBarButtonItems.append(UIBarButtonItem(image: .Share, target: self, action: #selector(ProfileViewController.sharePostTapped(_:))))
         }
         rightBarButtonItems.append(UIBarButtonItem(image: .Dots, target: self, action: #selector(ProfileViewController.moreButtonTapped)))
-        elloNavigationItem.rightBarButtonItems = rightBarButtonItems
+
+        guard elloNavigationItem.rightBarButtonItems != nil else {
+            elloNavigationItem.rightBarButtonItems = rightBarButtonItems
+            return
+        }
+
+        if !elloNavigationItem.areRightButtonsTheSame(rightBarButtonItems) {
+            elloNavigationItem.rightBarButtonItems = rightBarButtonItems
+        }
     }
+
 
     @IBAction func mentionButtonTapped() {
         guard let user = user else { return }

--- a/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
+++ b/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
@@ -11,8 +11,6 @@ public final class PostDetailViewController: StreamableViewController {
     var deeplinkPath: String?
     var generator: PostDetailGenerator?
 
-    private var rightButtonsInitialized = false
-
     required public init(postParam: String) {
         self.postParam = postParam
         super.init(nibName: nil, bundle: nil)
@@ -114,20 +112,28 @@ public final class PostDetailViewController: StreamableViewController {
             return
         }
 
-        guard !rightButtonsInitialized else { return }
-        rightButtonsInitialized = true
+        var rightBarButtonItems: [UIBarButtonItem] = []
 
         if isOwnPost() {
-            elloNavigationItem.rightBarButtonItems = [
+            rightBarButtonItems = [
                 UIBarButtonItem(image: .XBox, target: self, action: #selector(PostDetailViewController.deletePost)),
                 UIBarButtonItem(image: .Pencil, target: self, action: #selector(PostDetailViewController.editPostAction)),
             ]
         }
         else {
-            elloNavigationItem.rightBarButtonItems = [
+            rightBarButtonItems = [
                 UIBarButtonItem(image: .Search, target: self, action: #selector(BaseElloViewController.searchButtonTapped)),
                 UIBarButtonItem(image: .Dots, target: self, action: #selector(PostDetailViewController.flagPost)),
             ]
+        }
+
+        guard elloNavigationItem.rightBarButtonItems != nil else {
+            elloNavigationItem.rightBarButtonItems = rightBarButtonItems
+            return
+        }
+
+        if !elloNavigationItem.areRightButtonsTheSame(rightBarButtonItems) {
+            elloNavigationItem.rightBarButtonItems = rightBarButtonItems
         }
     }
 

--- a/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
+++ b/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
@@ -11,6 +11,8 @@ public final class PostDetailViewController: StreamableViewController {
     var deeplinkPath: String?
     var generator: PostDetailGenerator?
 
+    private var rightButtonsInitialized = false
+
     required public init(postParam: String) {
         self.postParam = postParam
         super.init(nibName: nil, bundle: nil)
@@ -111,6 +113,9 @@ public final class PostDetailViewController: StreamableViewController {
             elloNavigationItem.rightBarButtonItems = []
             return
         }
+
+        guard !rightButtonsInitialized else { return }
+        rightButtonsInitialized = true
 
         if isOwnPost() {
             elloNavigationItem.rightBarButtonItems = [

--- a/Sources/Extensions/UINavigationItem.swift
+++ b/Sources/Extensions/UINavigationItem.swift
@@ -22,4 +22,10 @@ extension UINavigationItem {
         }
     }
 
+    public func areRightButtonsTheSame(newItems: [UIBarButtonItem]) -> Bool {
+        guard let rightItems = self.rightBarButtonItems else { return false }
+        guard newItems.count == rightItems.count else { return false }
+        return newItems.map({ $0.action }) == rightItems.map({ $0.action })
+    }
+
 }

--- a/Specs/Extensions/UINavigationItemSpec.swift
+++ b/Specs/Extensions/UINavigationItemSpec.swift
@@ -1,0 +1,76 @@
+////
+///  UINavigationItemSpec.swift
+//
+
+import Quick
+import Nimble
+
+
+public class NavItemResponder: NSObject {
+    static public func a() {}
+    static public func b() {}
+    static public func c() {}
+    static public func d() {}
+}
+
+class UINavigationItemSpec: QuickSpec {
+    override func spec() {
+        describe("UINavigationItem") {
+            let subject = UINavigationItem()
+
+            describe("areRightButtonsTheSame(_:)") {
+                let target = NavItemResponder()
+
+                let newItemsSame = [
+                    UIBarButtonItem(
+                        barButtonSystemItem: .Camera,
+                        target: target,
+                        action: #selector(NavItemResponder.a)
+                    ),
+                    UIBarButtonItem(
+                        barButtonSystemItem: .Camera,
+                        target: target,
+                        action: #selector(NavItemResponder.b)
+                    )
+                ]
+
+                let newItemsDifferent = [
+                    UIBarButtonItem(
+                        barButtonSystemItem: .Camera,
+                        target: target,
+                        action: #selector(NavItemResponder.c)
+                    ),
+                    UIBarButtonItem(
+                        barButtonSystemItem: .Camera,
+                        target: target,
+                        action: #selector(NavItemResponder.c)
+                    )
+                ]
+
+                let rightItems = [
+                    UIBarButtonItem(
+                        barButtonSystemItem: .Camera,
+                        target: target,
+                        action: #selector(NavItemResponder.a)
+                    ),
+                        UIBarButtonItem(
+                            barButtonSystemItem: .Camera,
+                            target: target,
+                            action: #selector(NavItemResponder.b)
+                        )
+                ]
+
+                it("returns true when the arrays have similar value semantics") {
+                    subject.rightBarButtonItems = rightItems
+                    expect(subject.areRightButtonsTheSame(newItemsSame)) == true
+                }
+
+                it("returns fale when the arrays have disimilar value semantics") {
+                    subject.rightBarButtonItems = rightItems
+                    expect(subject.areRightButtonsTheSame(newItemsDifferent)) == false
+                }
+
+            }
+        }
+    }
+}

--- a/Specs/Extensions/UINavigationItemSpec.swift
+++ b/Specs/Extensions/UINavigationItemSpec.swift
@@ -65,7 +65,7 @@ class UINavigationItemSpec: QuickSpec {
                     expect(subject.areRightButtonsTheSame(newItemsSame)) == true
                 }
 
-                it("returns fale when the arrays have disimilar value semantics") {
+                it("returns false when the arrays have disimilar value semantics") {
                     subject.rightBarButtonItems = rightItems
                     expect(subject.areRightButtonsTheSame(newItemsDifferent)) == false
                 }

--- a/Specs/Model/NotificationAttributedTitleSpec.swift
+++ b/Specs/Model/NotificationAttributedTitleSpec.swift
@@ -28,9 +28,9 @@ class NotificationAttributedTitleSpec: QuickSpec {
                     (.LoveNotification, post, "@ello loved your post."),
                     (.LoveOnRepostNotification, post, "@ello loved your repost."),
                     (.LoveOnOriginalPostNotification, post, "@ello loved a repost of your post."),
-                    (.WatchNotification, post, "@ello watched your post."),
-                    (.WatchOnRepostNotification, post, "@ello watched your repost."),
-                    (.WatchOnOriginalPostNotification, post, "@ello watched a repost of your post."),
+                    (.WatchNotification, post, "@ello is watching your post."),
+                    (.WatchOnRepostNotification, post, "@ello is watching your repost."),
+                    (.WatchOnOriginalPostNotification, post, "@ello is watching a repost of your post."),
                     (.WelcomeNotification, nil, "Welcome to Ello!"),
                 ]
                 for (activityKind, subject, string) in expectations {


### PR DESCRIPTION
iOS 10 is animating `rightBarButtonItems` when they're assigned during a pull-to-refresh on both Post Details and Profiles. Rather than reassigning the buttons on pull to refresh we'll show what's already there.

@colinta, this feels harmless enough to me, any negative side effects you can think of?

[fixes #131181209](https://www.pivotaltracker.com/story/show/131181209)