### PR TITLE
WIP: Serialize collection view cell reloads

### DIFF
--- a/Ello.xcodeproj/project.pbxproj
+++ b/Ello.xcodeproj/project.pbxproj
@@ -366,6 +366,7 @@
 		12D24A5A1A9F765300F53D44 /* AddFriendsViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12D24A591A9F765300F53D44 /* AddFriendsViewControllerSpec.swift */; };
 		12D43A461AC864CC0039F54F /* StreamToggleCellPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12D43A451AC864CC0039F54F /* StreamToggleCellPresenter.swift */; };
 		12D43A491AC865540039F54F /* StreamToggleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12D43A481AC865540039F54F /* StreamToggleCell.swift */; };
+		12DB1CA91D9C84B4007E3E4C /* ElloCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12DB1CA81D9C84B4007E3E4C /* ElloCollectionView.swift */; };
 		12DD85C61B015A76004D3EEF /* UITabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12DD85C51B015A76004D3EEF /* UITabBarItem.swift */; };
 		12DEB2491C5BED4000D4CDCE /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A3B6441AC457CA00806224 /* Array.swift */; };
 		12DEB24A1C5BED4600D4CDCE /* RegexExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB474FA1BAB5584000AA9DC /* RegexExtensions.swift */; };
@@ -1254,6 +1255,7 @@
 		12D43A451AC864CC0039F54F /* StreamToggleCellPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StreamToggleCellPresenter.swift; path = sources/controllers/stream/CellDequeing/StreamToggleCellPresenter.swift; sourceTree = SOURCE_ROOT; };
 		12D43A481AC865540039F54F /* StreamToggleCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StreamToggleCell.swift; path = sources/controllers/stream/Cells/StreamToggleCell.swift; sourceTree = SOURCE_ROOT; };
 		12D56B661A8C6BC000671280 /* Asset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Asset.swift; sourceTree = "<group>"; };
+		12DB1CA81D9C84B4007E3E4C /* ElloCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElloCollectionView.swift; sourceTree = "<group>"; };
 		12DD85C51B015A76004D3EEF /* UITabBarItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UITabBarItem.swift; path = sources/Extensions/UITabBarItem.swift; sourceTree = SOURCE_ROOT; };
 		12DEB24D1C5BFA9200D4CDCE /* libcommonCrypto.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libcommonCrypto.tbd; path = usr/lib/system/libcommonCrypto.tbd; sourceTree = SDKROOT; };
 		12DEB24F1C5BFB3100D4CDCE /* CryptoStringExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CryptoStringExtensions.swift; path = sources/Extensions/CryptoStringExtensions.swift; sourceTree = SOURCE_ROOT; };
@@ -2811,6 +2813,7 @@
 				1D9B74C91BB1E3EF00ACD028 /* CommentsIcon.swift */,
 				1D22C8251AAFAD760048D415 /* CreateCommentBackgroundView.swift */,
 				12F6AE651A4339EF00493660 /* ElloButton.swift */,
+				12DB1CA81D9C84B4007E3E4C /* ElloCollectionView.swift */,
 				EA587A9E1ACDC6F4002AF389 /* ElloEditableTextView.swift */,
 				12F6AE661A4339EF00493660 /* ElloHUD.swift */,
 				122D1BBD1C641188001386CE /* ElloHUDWindowExtensions.swift */,
@@ -4778,6 +4781,7 @@
 				1D15C2781C7D12890013B192 /* InterfaceImage.swift in Sources */,
 				122B30F01C6A3FC500C1B9D8 /* ImageRegion.swift in Sources */,
 				EAF43D941AB0DE080016E110 /* ObjectCache.swift in Sources */,
+				12DB1CA91D9C84B4007E3E4C /* ElloCollectionView.swift in Sources */,
 				76FF80551A966B6300617A1E /* RelationshipController.swift in Sources */,
 				122B190D1A86894400247A05 /* StreamCellType.swift in Sources */,
 				122B30C41C6A3FBC00C1B9D8 /* Activity.swift in Sources */,

--- a/Resources/Main.storyboard
+++ b/Resources/Main.storyboard
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Ello Tab Bar Controller-->
@@ -14,8 +14,8 @@
                     <tabBar key="tabBar" contentMode="scaleToFill" translucent="NO" id="W28-zg-YXA" customClass="ElloTabBar" customModule="Ello" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="975" width="768" height="49"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                        <color key="backgroundColor" red="0.85294646024703979" green="0.0019912233110517263" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                        <color key="barTintColor" red="0.94117647058823528" green="0.94117647058823528" blue="0.94117647058823528" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" red="0.80710989236831665" green="0.0" blue="0.018801622092723846" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="barTintColor" red="0.94117647058823528" green="0.94117647058823528" blue="0.94117647058823528" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </tabBar>
                     <connections>
                         <segue destination="rfd-p2-XSV" kind="relationship" relationship="viewControllers" id="u7Y-xg-7CH"/>
@@ -38,21 +38,21 @@
                         <viewControllerLayoutGuide type="bottom" id="Cu5-ro-RnE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="b3f-dm-11N">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" directionalLockEnabled="YES" bounces="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sxq-dN-l1X">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" directionalLockEnabled="YES" bounces="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sxq-dN-l1X">
+                                <frame key="frameInset" width="600" height="600"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </scrollView>
-                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BcZ-aZ-i5r" customClass="ElloNavigationBar" customModule="Ello" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="20" width="600" height="44"/>
+                            <navigationBar contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BcZ-aZ-i5r" customClass="ElloNavigationBar" customModule="Ello" customModuleProvider="target">
+                                <frame key="frameInset" minY="20" width="600" height="44"/>
                                 <items>
                                     <navigationItem title="Title" id="N7N-z9-gvV"/>
                                 </items>
                             </navigationBar>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="Sxq-dN-l1X" firstAttribute="top" secondItem="b3f-dm-11N" secondAttribute="top" id="3a0-nd-GXS"/>
                             <constraint firstAttribute="centerX" secondItem="BcZ-aZ-i5r" secondAttribute="centerX" id="4cK-kW-zHF" userLabel="navBarCentered"/>
@@ -85,22 +85,22 @@
                         <viewControllerLayoutGuide type="bottom" id="gFv-e7-ahl"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="x9i-Ne-hXf">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="556"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="hOT-bT-dJV">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="556"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="hOT-bT-dJV" customClass="ElloCollectionView" customModule="Ello" customModuleProvider="target">
+                                <frame key="frameInset" width="600" height="556"/>
+                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <collectionViewLayout key="collectionViewLayout" id="RLZ-Kl-cg7" customClass="StreamCollectionViewLayout" customModule="Ello" customModuleProvider="target"/>
                                 <cells/>
                             </collectionView>
-                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mm7-D5-eh7" userLabel="noResultsLabel">
-                                <rect key="frame" x="15" y="113" width="570" height="0.0"/>
+                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mm7-D5-eh7" userLabel="noResultsLabel">
+                                <frame key="frameInset" minX="15" minY="113" width="570"/>
                                 <attributedString key="attributedText"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="hOT-bT-dJV" firstAttribute="top" secondItem="x9i-Ne-hXf" secondAttribute="top" id="1HK-ru-RpT"/>
                             <constraint firstItem="mm7-D5-eh7" firstAttribute="top" secondItem="x9i-Ne-hXf" secondAttribute="top" constant="113" id="BCR-Qk-2Gm" userLabel="noResultsTopConstraint"/>
@@ -136,7 +136,7 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="Tgb-bf-SEj">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="Qz1-hz-MJ9">
@@ -239,5 +239,5 @@
             <point key="canvasLocation" x="422" y="1776"/>
         </scene>
     </scenes>
-    <color key="tintColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+    <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
 </document>

--- a/Sources/Controllers/Stream/StreamDataSource.swift
+++ b/Sources/Controllers/Stream/StreamDataSource.swift
@@ -401,7 +401,7 @@ public class StreamDataSource: NSObject, UICollectionViewDataSource {
         return nil
     }
 
-    public func modifyItems(jsonable: JSONAble, change: ContentChange, collectionView: UICollectionView) {
+    public func modifyItems(jsonable: JSONAble, change: ContentChange, collectionView: ElloCollectionView) {
         // get items that match id and type -> [IndexPath]
         // based on change decide to update/remove those items
         switch change {
@@ -507,7 +507,7 @@ public class StreamDataSource: NSObject, UICollectionViewDataSource {
                 for item in items {
                     item.jsonable = item.jsonable.merge(jsonable)
                 }
-                collectionView.reloadItemsAtIndexPaths(indexPaths)
+                collectionView.reload(indexPaths)
             }
         case .Loved:
             let (_, items) = elementsForJSONAble(jsonable, change: change)
@@ -519,12 +519,12 @@ public class StreamDataSource: NSObject, UICollectionViewDataSource {
                 }
                 item.jsonable = item.jsonable.merge(jsonable)
             }
-            collectionView.reloadItemsAtIndexPaths(indexPaths)
+            collectionView.reload(indexPaths)
         default: break
         }
     }
 
-    public func modifyUserRelationshipItems(user: User, collectionView: UICollectionView) {
+    public func modifyUserRelationshipItems(user: User, collectionView: ElloCollectionView) {
         let (changedPaths, changedItems) = elementsForJSONAble(user, change: .Update)
 
         for item in changedItems {
@@ -568,7 +568,7 @@ public class StreamDataSource: NSObject, UICollectionViewDataSource {
         else {
             reloadPaths = changedPaths
         }
-        collectionView.reloadItemsAtIndexPaths(reloadPaths)
+        collectionView.reload(reloadPaths)
 
         if user.relationshipPriority.isMutedOrBlocked {
             var shouldDelete = true
@@ -597,14 +597,14 @@ public class StreamDataSource: NSObject, UICollectionViewDataSource {
         }
     }
 
-    public func modifyUserSettingsItems(user: User, collectionView: UICollectionView) {
+    public func modifyUserSettingsItems(user: User, collectionView: ElloCollectionView) {
         let (changedPaths, changedItems) = elementsForJSONAble(user, change: .Update)
         for item in changedItems {
             if item.jsonable is User {
                 item.jsonable = user
             }
         }
-        collectionView.reloadItemsAtIndexPaths(changedPaths)
+        collectionView.reload(changedPaths)
     }
 
     public func removeItemsForJSONAble(jsonable: JSONAble, change: ContentChange) -> [NSIndexPath] {

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -77,7 +77,7 @@ public struct StreamNotification {
 // MARK: StreamViewController
 public final class StreamViewController: BaseElloViewController {
 
-    @IBOutlet weak public var collectionView: UICollectionView!
+    @IBOutlet weak public var collectionView: ElloCollectionView!
     @IBOutlet weak public var noResultsLabel: UILabel!
     @IBOutlet weak public var noResultsTopConstraint: NSLayoutConstraint!
     private let defaultNoResultsTopConstant: CGFloat = 113

--- a/Sources/Views/ElloCollectionView.swift
+++ b/Sources/Views/ElloCollectionView.swift
@@ -1,0 +1,27 @@
+////
+///  ElloCollectionView.swift
+//
+
+import UIKit
+
+
+public class ElloCollectionView: UICollectionView {
+
+    private let queue = NSOperationQueue()
+
+    public func reload(reloadPaths: [NSIndexPath]) {
+        queue.maxConcurrentOperationCount = 1
+
+        let operation = AsyncOperation(block: { [weak self] done in
+            guard let sself = self else { return }
+            inForeground {
+                sself.performBatchUpdates({
+                    sself.reloadItemsAtIndexPaths(reloadPaths)
+                    }, completion: { _ in
+                        done()
+                })
+            }
+        })
+        queue.addOperation(operation)
+    }
+}


### PR DESCRIPTION
The generators, [ProfileGenerator](https://github.com/ello/ello-ios/blob/master/Sources/Controllers/Profile/ProfileGenerator.swift) and [PostDetailGenerator](https://github.com/ello/ello-ios/blob/master/Sources/Controllers/Stream/Detail/PostDetailGenerator.swift) are great... except when they are not. They speed up concurrent network request loading but have inadvertently affected other UI updates that occur in app. [StreamDataSource](https://github.com/ello/ello-ios/blob/master/Sources/Controllers/Stream/StreamDataSource.swift) is responsible for updating cells by reloading them when user interactions occur. We believe that loading of data, updating collection views and updates based on user interaction results in our data sources and collection views getting out of sync. 

This PR is the first step towards resynchronizing these three pieces of the system. The hope is that calls to reload index paths on the collection view will not double up by forcing them into an operation queue with a `maxConcurrentOperationCount` of 1. 

Thoughts @colinta?