### PR TITLE
Fixes the category card black opacity

### DIFF
--- a/Sources/Controllers/Stream/Cells/CategoryCardCell.swift
+++ b/Sources/Controllers/Stream/Cells/CategoryCardCell.swift
@@ -52,7 +52,7 @@ public class CategoryCardCell: UICollectionViewCell {
             selectedImageView.hidden = !selected
         }
         else {
-            colorFillView.alpha = 0
+            colorFillView.alpha = 0.4
             label.font = UIFont.defaultFont()
             selectedImageView.hidden = true
         }


### PR DESCRIPTION
Was supposed to be `0.4`, this got lost when we fixed selection.