### PR TITLE
Tapping text in grid should *always* opens detail

### DIFF
--- a/Sources/Controllers/Stream/StreamKind.swift
+++ b/Sources/Controllers/Stream/StreamKind.swift
@@ -97,12 +97,10 @@ public enum StreamKind {
 
     public var tappingTextOpensDetail: Bool {
         switch self {
-        case .Following, .Starred:
-            return isGridView
-        case .PostDetail, .CurrentUserStream, .UserStream:
+        case .PostDetail:
             return false
         default:
-            return true
+            return isGridView
         }
     }
 


### PR DESCRIPTION
Not just in `Following/Starred` - and never from Post Detail.