### PR TITLE
Removes `addToView` helper

### DIFF
--- a/Sources/Controllers/Search/SearchScreen.swift
+++ b/Sources/Controllers/Search/SearchScreen.swift
@@ -150,17 +150,17 @@ public class SearchScreen: UIView, SearchScreenProtocol {
 
     private func setupToggleButtons() {
         searchControlsContainer.frame.size.height += 43
-        self.postsToggleButton = OutlineElloButton(frame: CGRect(x: 0, y: buttonY, width: btnWidth, height: 33))
-        postsToggleButton?.setTitle(InterfaceString.Search.Posts, forState: .Normal)
-        postsToggleButton?.addTarget(self, action: #selector(SearchScreen.onPostsTapped), forControlEvents: .TouchUpInside)
+        let postsToggleButton = OutlineElloButton(frame: CGRect(x: 0, y: buttonY, width: btnWidth, height: 33))
+        postsToggleButton.setTitle(InterfaceString.Search.Posts, forState: .Normal)
+        postsToggleButton.addTarget(self, action: #selector(SearchScreen.onPostsTapped), forControlEvents: .TouchUpInside)
+        searchControlsContainer.addSubview(postsToggleButton)
+        self.postsToggleButton = postsToggleButton
 
-        postsToggleButton?.addToView(searchControlsContainer)
-
-        self.peopleToggleButton = OutlineElloButton(frame: CGRect(x: postsToggleButton?.frame.maxX ?? 0, y: buttonY, width: btnWidth, height: 33))
-        peopleToggleButton?.setTitle(InterfaceString.Search.People, forState: .Normal)
-        peopleToggleButton?.addTarget(self, action: #selector(SearchScreen.onPeopleTapped), forControlEvents: .TouchUpInside)
-
-        peopleToggleButton?.addToView(searchControlsContainer)
+        let peopleToggleButton = OutlineElloButton(frame: CGRect(x: postsToggleButton.frame.maxX ?? 0, y: buttonY, width: btnWidth, height: 33))
+        peopleToggleButton.setTitle(InterfaceString.Search.People, forState: .Normal)
+        peopleToggleButton.addTarget(self, action: #selector(SearchScreen.onPeopleTapped), forControlEvents: .TouchUpInside)
+        searchControlsContainer.addSubview(peopleToggleButton)
+        self.peopleToggleButton = peopleToggleButton
 
         onPostsTapped()
     }

--- a/Sources/Extensions/UIViewExtensions.swift
+++ b/Sources/Extensions/UIViewExtensions.swift
@@ -3,7 +3,4 @@
 //
 
 extension UIView {
-    public func addToView(view: UIView) {
-        view.addSubview(self)
-    }
 }

--- a/Specs/Extensions/UIViewExtensionsSpec.swift
+++ b/Specs/Extensions/UIViewExtensionsSpec.swift
@@ -10,16 +10,6 @@ import Nimble
 class UIViewSpec: QuickSpec {
     override func spec() {
         describe("UIView") {
-            describe("addToView(:_)") {
-                it("adds self to parent") {
-                    let parent = UIView(frame: CGRectZero)
-                    var subject: UIView?
-
-                    subject = UIView(frame: CGRectZero)
-                    subject?.addToView(parent)
-                    expect(subject?.superview) == parent
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Only used in the `SearchScreen` to avoid `if let`, but easily avoided by using local vars & `self.prop = prop`.