### PR TITLE
Implements the `ProfileHeaderCompactView` layout

### DIFF
--- a/Ello.xcodeproj/project.pbxproj
+++ b/Ello.xcodeproj/project.pbxproj
@@ -650,6 +650,7 @@
 		1DA18DFE1DAC3B64000231CC /* ProfileStatsViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA18DFD1DAC3B64000231CC /* ProfileStatsViewSpec.swift */; };
 		1DA18E001DAC3B73000231CC /* ProfileStatsPresenterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA18DFF1DAC3B73000231CC /* ProfileStatsPresenterSpec.swift */; };
 		1DA18E021DAC3B8D000231CC /* ProfileStatsSizeCalculatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA18E011DAC3B8D000231CC /* ProfileStatsSizeCalculatorSpec.swift */; };
+		1DA18E121DB187DF000231CC /* CalculatedCellHeights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA18E111DB187DF000231CC /* CalculatedCellHeights.swift */; };
 		1DA809C21B8F6DE9000BB590 /* OmnibarScreenSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA809C11B8F6DE9000BB590 /* OmnibarScreenSpec.swift */; };
 		1DA8FD701B98A63600472B1E /* reorder_normal.svg in Resources */ = {isa = PBXBuildFile; fileRef = 1DA8FD6E1B98A63600472B1E /* reorder_normal.svg */; };
 		1DA8FD711B98A63600472B1E /* reorder_selected.svg in Resources */ = {isa = PBXBuildFile; fileRef = 1DA8FD6F1B98A63600472B1E /* reorder_selected.svg */; };
@@ -1578,6 +1579,7 @@
 		1DA18DFD1DAC3B64000231CC /* ProfileStatsViewSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileStatsViewSpec.swift; sourceTree = "<group>"; };
 		1DA18DFF1DAC3B73000231CC /* ProfileStatsPresenterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProfileStatsPresenterSpec.swift; path = Specs/Controllers/Stream/CellDequeing/ProfileStatsPresenterSpec.swift; sourceTree = SOURCE_ROOT; };
 		1DA18E011DAC3B8D000231CC /* ProfileStatsSizeCalculatorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileStatsSizeCalculatorSpec.swift; sourceTree = "<group>"; };
+		1DA18E111DB187DF000231CC /* CalculatedCellHeights.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalculatedCellHeights.swift; sourceTree = "<group>"; };
 		1DA809C11B8F6DE9000BB590 /* OmnibarScreenSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OmnibarScreenSpec.swift; sourceTree = "<group>"; };
 		1DA8FD6E1B98A63600472B1E /* reorder_normal.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = reorder_normal.svg; sourceTree = "<group>"; };
 		1DA8FD6F1B98A63600472B1E /* reorder_selected.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = reorder_selected.svg; sourceTree = "<group>"; };
@@ -2408,6 +2410,7 @@
 				7666C95D1B10055C009AC019 /* AddFriendsViewController.swift */,
 				1D1BCA531BACBAAE009075E8 /* Calculators */,
 				128D36A81A95192300622833 /* CellDequeing */,
+				1DA18E111DB187DF000231CC /* CalculatedCellHeights.swift */,
 				122B18CC1A867BCE00247A05 /* Cells */,
 				1266E50C1A9E2B9E00270E1C /* ContentFlagger.swift */,
 				1D1AF61E1A83ED6600E06C93 /* Detail */,
@@ -2419,10 +2422,10 @@
 				121700B51A78428D00EBACA5 /* StreamCollectionViewLayout.swift */,
 				121E46BC1A6B2798004AEAB7 /* StreamContainerViewController.swift */,
 				1217008F1A7841C400EBACA5 /* StreamDataSource.swift */,
+				1245ED371D1C772400929DD4 /* StreamGenerator.swift */,
 				121700B81A7891B300EBACA5 /* StreamImageViewer.swift */,
 				128D36A51A95174C00622833 /* StreamKind.swift */,
 				121700981A7841C400EBACA5 /* StreamViewController.swift */,
-				1245ED371D1C772400929DD4 /* StreamGenerator.swift */,
 			);
 			path = Stream;
 			sourceTree = "<group>";
@@ -4973,6 +4976,7 @@
 				1DB286E61B96021F00D03516 /* OmnibarErrorCell.swift in Sources */,
 				12F6AE6A1A4339EF00493660 /* ElloButton.swift in Sources */,
 				1D5F97751A9696E700AEEB5F /* AttributedStringExtensions.swift in Sources */,
+				1DA18E121DB187DF000231CC /* CalculatedCellHeights.swift in Sources */,
 				1D5933751D10BC8100EAF03D /* CategoryLevel.swift in Sources */,
 				125F28881B1D165700BA501E /* DrawerCellPresenter.swift in Sources */,
 				122B30C71C6A3FBC00C1B9D8 /* AmazonCredentials.swift in Sources */,

--- a/Sources/Controllers/Profile/Calculators/ProfileHeaderCellSizeCalculator.swift
+++ b/Sources/Controllers/Profile/Calculators/ProfileHeaderCellSizeCalculator.swift
@@ -70,9 +70,9 @@ private extension ProfileHeaderCellSizeCalculator {
 
         if let cellItem = cellItems.safeValue(0) {
             self.cellItems.removeAtIndex(0)
-            cellItem.calculatedWebHeight = height
-            cellItem.calculatedOneColumnCellHeight = height
-            cellItem.calculatedMultiColumnCellHeight = height
+            cellItem.calculatedCellHeights.webContent = height
+            cellItem.calculatedCellHeights.oneColumn = height
+            cellItem.calculatedCellHeights.multiColumn = height
         }
         loadNext()
     }

--- a/Sources/Controllers/Profile/Calculators/ProfileStatsSizeCalculator.swift
+++ b/Sources/Controllers/Profile/Calculators/ProfileStatsSizeCalculator.swift
@@ -9,7 +9,7 @@ public struct ProfileStatsSizeCalculator {
 
     public func calculate(item: StreamCellItem) -> Future<CGFloat> {
         let promise = Promise<CGFloat>()
-        promise.completeWithSuccess(70)
+        promise.completeWithSuccess(ProfileStatsView.Size.height)
         return promise.future
     }
 }

--- a/Sources/Controllers/Profile/ProfileHeaderCompactView.swift
+++ b/Sources/Controllers/Profile/ProfileHeaderCompactView.swift
@@ -22,12 +22,12 @@ public class ProfileHeaderCompactView: ProfileBaseView {
 
     var calculatedCellHeights: CalculatedCellHeights? {
         didSet {
-            if let calculatedCellHeights = calculatedCellHeights {
-                if let namesHeight = calculatedCellHeights.profileNames { namesHeightConstraint.updateOffset(namesHeight) }
-                if let bioHeight = calculatedCellHeights.profileBio { bioHeightConstraint.updateOffset(bioHeight) }
-                if let linksHeight = calculatedCellHeights.profileLinks { linksHeightConstraint.updateOffset(linksHeight) }
-                setNeedsLayout()
-            }
+            guard let calculatedCellHeights = calculatedCellHeights else { return }
+
+            if let namesHeight = calculatedCellHeights.profileNames { namesHeightConstraint.updateOffset(namesHeight) }
+            if let bioHeight = calculatedCellHeights.profileBio { bioHeightConstraint.updateOffset(bioHeight) }
+            if let linksHeight = calculatedCellHeights.profileLinks { linksHeightConstraint.updateOffset(linksHeight) }
+            setNeedsLayout()
         }
     }
 
@@ -57,41 +57,40 @@ extension ProfileHeaderCompactView {
         addSubview(linksView)
 
         avatarView.snp_makeConstraints { make in
-            make.top.equalTo(self.snp_top)
-            make.width.equalTo(self.snp_width)
+            make.top.width.centerX.equalTo(self)
             make.height.equalTo(Size.avatarHeight)
         }
 
         namesView.snp_makeConstraints { make in
-            make.width.equalTo(self.snp_width)
-            namesHeightConstraint = make.height.equalTo(0).constraint
             make.top.equalTo(self.avatarView.snp_bottom)
+            make.width.centerX.equalTo(self)
+            namesHeightConstraint = make.height.equalTo(101).constraint
         }
 
         totalCountView.snp_makeConstraints { make in
-            make.width.equalTo(self.snp_width)
-            make.height.equalTo(Size.totalCountHeight)
             make.top.equalTo(self.namesView.snp_bottom)
+            make.width.centerX.equalTo(self)
+            make.height.equalTo(Size.totalCountHeight)
         }
 
         statsView.snp_makeConstraints { make in
-            make.width.equalTo(self.snp_width)
-            make.height.equalTo(Size.activityHeight)
             make.top.equalTo(self.totalCountView.snp_bottom)
+            make.width.centerX.equalTo(self)
+            make.height.equalTo(Size.activityHeight)
         }
 
         bioView.snp_makeConstraints { make in
-            make.width.equalTo(self.snp_width)
-            bioHeightConstraint = make.height.equalTo(0).constraint
             make.top.equalTo(self.statsView.snp_bottom)
+            make.width.centerX.equalTo(self)
+            bioHeightConstraint = make.height.equalTo(102).constraint
         }
+        bioHeightConstraint.updateOffset(103)
 
         linksView.snp_makeConstraints { make in
-            make.width.equalTo(self.snp_width)
-            linksHeightConstraint = make.height.equalTo(0).constraint
             make.top.equalTo(self.bioView.snp_bottom)
+            make.width.centerX.equalTo(self)
+            linksHeightConstraint = make.height.equalTo(103).constraint
         }
-
-        layoutIfNeeded()
+        linksHeightConstraint.updateOffset(104)
     }
 }

--- a/Sources/Controllers/Profile/ProfileHeaderCompactView.swift
+++ b/Sources/Controllers/Profile/ProfileHeaderCompactView.swift
@@ -2,24 +2,15 @@
 ///  ProfileHeaderCompactView.swift
 //
 
+import SnapKit
+
+
 public class ProfileHeaderCompactView: ProfileBaseView {
 
     public struct Size {
         static let avatarHeight: CGFloat = 255
-
-        static let nameWidth: CGFloat = 122
-        static let nameHeight: CGFloat = 122
-
         static let totalCountHeight: CGFloat = 60
-
-        static let activityWidth: CGFloat = 122
         static let activityHeight: CGFloat = 122
-
-        static let bioWidth: CGFloat = 122
-        static let bioHeight: CGFloat = 122
-
-        static let linksWidth: CGFloat = 122
-        static let linksHeight: CGFloat = 122
     }
 
     let avatarView = ProfileAvatarView()
@@ -28,6 +19,21 @@ public class ProfileHeaderCompactView: ProfileBaseView {
     let statsView = ProfileStatsView()
     let bioView = ProfileBioView()
     let linksView = ProfileLinksView()
+
+    var calculatedCellHeights: CalculatedCellHeights? {
+        didSet {
+            if let calculatedCellHeights = calculatedCellHeights {
+                if let namesHeight = calculatedCellHeights.profileNames { namesHeightConstraint.updateOffset(namesHeight) }
+                if let bioHeight = calculatedCellHeights.profileBio { bioHeightConstraint.updateOffset(bioHeight) }
+                if let linksHeight = calculatedCellHeights.profileLinks { linksHeightConstraint.updateOffset(linksHeight) }
+                setNeedsLayout()
+            }
+        }
+    }
+
+    var namesHeightConstraint: Constraint!
+    var bioHeightConstraint: Constraint!
+    var linksHeightConstraint: Constraint!
 }
 
 extension ProfileHeaderCompactView {
@@ -58,7 +64,7 @@ extension ProfileHeaderCompactView {
 
         namesView.snp_makeConstraints { make in
             make.width.equalTo(self.snp_width)
-            make.height.equalTo(Size.nameHeight)
+            namesHeightConstraint = make.height.equalTo(0).constraint
             make.top.equalTo(self.avatarView.snp_bottom)
         }
 
@@ -76,13 +82,13 @@ extension ProfileHeaderCompactView {
 
         bioView.snp_makeConstraints { make in
             make.width.equalTo(self.snp_width)
-            make.height.equalTo(Size.bioHeight)
+            bioHeightConstraint = make.height.equalTo(0).constraint
             make.top.equalTo(self.statsView.snp_bottom)
         }
 
         linksView.snp_makeConstraints { make in
             make.width.equalTo(self.snp_width)
-            make.height.equalTo(Size.linksHeight)
+            linksHeightConstraint = make.height.equalTo(0).constraint
             make.top.equalTo(self.bioView.snp_bottom)
         }
 

--- a/Sources/Controllers/Profile/ProfileHeaderCompactView.swift
+++ b/Sources/Controllers/Profile/ProfileHeaderCompactView.swift
@@ -6,11 +6,9 @@ import SnapKit
 
 
 public class ProfileHeaderCompactView: ProfileBaseView {
-
     public struct Size {
         static let avatarHeight: CGFloat = 255
         static let totalCountHeight: CGFloat = 60
-        static let activityHeight: CGFloat = 122
     }
 
     let avatarView = ProfileAvatarView()
@@ -76,7 +74,7 @@ extension ProfileHeaderCompactView {
         statsView.snp_makeConstraints { make in
             make.top.equalTo(self.totalCountView.snp_bottom)
             make.width.centerX.equalTo(self)
-            make.height.equalTo(Size.activityHeight)
+            make.height.equalTo(ProfileStatsView.Size.height)
         }
 
         bioView.snp_makeConstraints { make in

--- a/Sources/Controllers/Profile/ProfileHeaderCompactView.swift
+++ b/Sources/Controllers/Profile/ProfileHeaderCompactView.swift
@@ -62,7 +62,7 @@ extension ProfileHeaderCompactView {
         namesView.snp_makeConstraints { make in
             make.top.equalTo(self.avatarView.snp_bottom)
             make.width.centerX.equalTo(self)
-            namesHeightConstraint = make.height.equalTo(101).constraint
+            namesHeightConstraint = make.height.equalTo(0).constraint
         }
 
         totalCountView.snp_makeConstraints { make in
@@ -80,15 +80,13 @@ extension ProfileHeaderCompactView {
         bioView.snp_makeConstraints { make in
             make.top.equalTo(self.statsView.snp_bottom)
             make.width.centerX.equalTo(self)
-            bioHeightConstraint = make.height.equalTo(102).constraint
+            bioHeightConstraint = make.height.equalTo(0).constraint
         }
-        bioHeightConstraint.updateOffset(103)
 
         linksView.snp_makeConstraints { make in
             make.top.equalTo(self.bioView.snp_bottom)
             make.width.centerX.equalTo(self)
-            linksHeightConstraint = make.height.equalTo(103).constraint
+            linksHeightConstraint = make.height.equalTo(0).constraint
         }
-        linksHeightConstraint.updateOffset(104)
     }
 }

--- a/Sources/Controllers/Profile/Views/ProfileBaseView.swift
+++ b/Sources/Controllers/Profile/Views/ProfileBaseView.swift
@@ -9,7 +9,6 @@ public class ProfileBaseView: UIView {
 
     convenience init() {
         self.init(frame: .zero)
-        privateInit()
     }
 
     override init(frame: CGRect) {

--- a/Sources/Controllers/Profile/Views/ProfileStatsView.swift
+++ b/Sources/Controllers/Profile/Views/ProfileStatsView.swift
@@ -4,6 +4,7 @@
 
 public class ProfileStatsView: ProfileBaseView {
     public struct Size {
+        static let height: CGFloat = 70
         static let verticalMargin: CGFloat = 1
         static let countVerticalOffset: CGFloat = 20
         static let captionVerticalOffset: CGFloat = 5

--- a/Sources/Controllers/Profile/Views/ProfileStatsView.swift
+++ b/Sources/Controllers/Profile/Views/ProfileStatsView.swift
@@ -143,8 +143,6 @@ extension ProfileStatsView {
                 make.trailing.equalTo(self)
             }
         }
-
-        layoutIfNeeded()
     }
 
     func prepareForReuse() {

--- a/Sources/Controllers/Stream/CalculatedCellHeights.swift
+++ b/Sources/Controllers/Stream/CalculatedCellHeights.swift
@@ -1,0 +1,21 @@
+////
+///  CalculatedCellHeights.swift
+//
+
+public struct CalculatedCellHeights {
+    public enum Prop {
+        case OneColumn
+        case MultiColumn
+        case WebContent
+        case ProfileNames
+        case ProfileBio
+        case ProfileLinks
+    }
+
+    public var oneColumn: CGFloat?
+    public var multiColumn: CGFloat?
+    public var webContent: CGFloat?
+    public var profileNames: CGFloat?
+    public var profileBio: CGFloat?
+    public var profileLinks: CGFloat?
+}

--- a/Sources/Controllers/Stream/CellDequeing/CategoryCardCellPresenter.swift
+++ b/Sources/Controllers/Stream/CellDequeing/CategoryCardCellPresenter.swift
@@ -15,9 +15,9 @@ public struct CategoryCardCellPresenter {
             category = streamCellItem.jsonable as? Category
         {
             let desiredHeight: CGFloat = ceil(cell.frame.width / 1.5)
-            if streamCellItem.calculatedOneColumnCellHeight != desiredHeight || streamCellItem.calculatedMultiColumnCellHeight != desiredHeight {
-                streamCellItem.calculatedOneColumnCellHeight = desiredHeight
-                streamCellItem.calculatedMultiColumnCellHeight = desiredHeight
+            if streamCellItem.calculatedCellHeights.oneColumn != desiredHeight || streamCellItem.calculatedCellHeights.multiColumn != desiredHeight {
+                streamCellItem.calculatedCellHeights.oneColumn = desiredHeight
+                streamCellItem.calculatedCellHeights.multiColumn = desiredHeight
                 postNotification(StreamNotification.UpdateCellHeightNotification, value: cell)
             }
 

--- a/Sources/Controllers/Stream/CellDequeing/NotificationCellPresenter.swift
+++ b/Sources/Controllers/Stream/CellDequeing/NotificationCellPresenter.swift
@@ -18,14 +18,14 @@ public struct NotificationCellPresenter {
 
         cell.onWebContentReady { webView in
             if let actualHeight = webView.windowContentSize()?.height
-            where actualHeight != streamCellItem.calculatedWebHeight {
+            where actualHeight != streamCellItem.calculatedCellHeights.webContent {
                 StreamNotificationCellSizeCalculator.assignTotalHeight(actualHeight, cellItem: streamCellItem, cellWidth: cell.frame.width)
                 postNotification(StreamNotification.UpdateCellHeightNotification, value: cell)
             }
         }
         cell.onHeightMismatch = { height in
-            streamCellItem.calculatedOneColumnCellHeight = height
-            streamCellItem.calculatedMultiColumnCellHeight = height
+            streamCellItem.calculatedCellHeights.oneColumn = height
+            streamCellItem.calculatedCellHeights.multiColumn = height
             postNotification(StreamNotification.UpdateCellHeightNotification, value: cell)
         }
 

--- a/Sources/Controllers/Stream/CellDequeing/ProfileHeaderCellPresenter.swift
+++ b/Sources/Controllers/Stream/CellDequeing/ProfileHeaderCellPresenter.swift
@@ -19,6 +19,8 @@ public struct ProfileHeaderCellPresenter {
             user = streamCellItem.jsonable as? User
         else { return }
 
+        cell.headerView.calculatedCellHeights = streamCellItem.calculatedCellHeights
+
         ProfileNamesPresenter.configure(cell.namesView, user: user, currentUser: currentUser)
         ProfileAvatarPresenter.configure(cell.avatarView, user: user, currentUser: currentUser)
         ProfileStatsPresenter.configure(cell.statsView, user: user, currentUser: currentUser)

--- a/Sources/Controllers/Stream/CellDequeing/StreamImageCellPresenter.swift
+++ b/Sources/Controllers/Stream/CellDequeing/StreamImageCellPresenter.swift
@@ -83,9 +83,9 @@ public struct StreamImageCellPresenter {
         }
 
         cell.onHeightMismatch = { actualHeight in
-            streamCellItem.calculatedWebHeight = actualHeight
-            streamCellItem.calculatedOneColumnCellHeight = actualHeight
-            streamCellItem.calculatedMultiColumnCellHeight = actualHeight
+            streamCellItem.calculatedCellHeights.webContent = actualHeight
+            streamCellItem.calculatedCellHeights.oneColumn = actualHeight
+            streamCellItem.calculatedCellHeights.multiColumn = actualHeight
             postNotification(StreamNotification.UpdateCellHeightNotification, value: cell)
         }
 

--- a/Sources/Controllers/Stream/CellDequeing/StreamTextCellPresenter.swift
+++ b/Sources/Controllers/Stream/CellDequeing/StreamTextCellPresenter.swift
@@ -16,10 +16,10 @@ public struct StreamTextCellPresenter {
     {
         if let cell = cell as? StreamTextCell {
             cell.onWebContentReady { webView in
-                if let actualHeight = webView.windowContentSize()?.height where actualHeight != streamCellItem.calculatedWebHeight {
-                    streamCellItem.calculatedWebHeight = actualHeight
-                    streamCellItem.calculatedOneColumnCellHeight = actualHeight
-                    streamCellItem.calculatedMultiColumnCellHeight = actualHeight
+                if let actualHeight = webView.windowContentSize()?.height where actualHeight != streamCellItem.calculatedCellHeights.webContent {
+                    streamCellItem.calculatedCellHeights.webContent = actualHeight
+                    streamCellItem.calculatedCellHeights.oneColumn = actualHeight
+                    streamCellItem.calculatedCellHeights.multiColumn = actualHeight
                     postNotification(StreamNotification.UpdateCellHeightNotification, value: cell)
                 }
             }

--- a/Sources/Controllers/Stream/Cells/StreamImageCellSizeCalculator.swift
+++ b/Sources/Controllers/Stream/Cells/StreamImageCellSizeCalculator.swift
@@ -74,8 +74,8 @@ public class StreamImageCellSizeCalculator: NSObject {
             }
 
             if let imageRegion = item.type.data as? ImageRegion {
-                item.calculatedOneColumnCellHeight = StreamImageCell.Size.bottomMargin + oneColumnImageHeight(imageRegion)
-                item.calculatedMultiColumnCellHeight = StreamImageCell.Size.bottomMargin + multiColumnImageHeight(imageRegion)
+                item.calculatedCellHeights.oneColumn = StreamImageCell.Size.bottomMargin + oneColumnImageHeight(imageRegion)
+                item.calculatedCellHeights.multiColumn = StreamImageCell.Size.bottomMargin + multiColumnImageHeight(imageRegion)
             }
             else if let embedRegion = item.type.data as? EmbedRegion {
                 var ratio: CGFloat
@@ -85,8 +85,8 @@ public class StreamImageCellSizeCalculator: NSObject {
                 else {
                     ratio = 16.0/9.0
                 }
-                item.calculatedOneColumnCellHeight = StreamImageCell.Size.bottomMargin + maxWidth / ratio
-                item.calculatedMultiColumnCellHeight = StreamImageCell.Size.bottomMargin + calculateColumnWidth(screenWidth: maxWidth, columnCount: columnCount) / ratio
+                item.calculatedCellHeights.oneColumn = StreamImageCell.Size.bottomMargin + maxWidth / ratio
+                item.calculatedCellHeights.multiColumn = StreamImageCell.Size.bottomMargin + calculateColumnWidth(screenWidth: maxWidth, columnCount: columnCount) / ratio
             }
             loadNext()
         }

--- a/Sources/Controllers/Stream/Cells/StreamNotificationCellSizeCalculator.swift
+++ b/Sources/Controllers/Stream/Cells/StreamNotificationCellSizeCalculator.swift
@@ -113,10 +113,10 @@ public class StreamNotificationCellSizeCalculator: NSObject, UIWebViewDelegate {
 
         height += 2 * NotificationCell.Size.SideMargins
         if let webContentHeight = webContentHeight {
-            cellItem.calculatedWebHeight = webContentHeight
+            cellItem.calculatedCellHeights.webContent = webContentHeight
         }
-        cellItem.calculatedOneColumnCellHeight = height
-        cellItem.calculatedMultiColumnCellHeight = height
+        cellItem.calculatedCellHeights.oneColumn = height
+        cellItem.calculatedCellHeights.multiColumn = height
     }
 
     private func stripImageSrc(html: String) -> String {

--- a/Sources/Controllers/Stream/Cells/StreamTextCellSizeCalculator.swift
+++ b/Sources/Controllers/Stream/Cells/StreamTextCellSizeCalculator.swift
@@ -87,9 +87,9 @@ public class StreamTextCellSizeCalculator: NSObject, UIWebViewDelegate {
     private func assignCellHeight(height: CGFloat) {
         if let cellItem = self.cellItems.safeValue(0) {
             self.cellItems.removeAtIndex(0)
-            cellItem.calculatedWebHeight = height
-            cellItem.calculatedOneColumnCellHeight = height
-            cellItem.calculatedMultiColumnCellHeight = height
+            cellItem.calculatedCellHeights.webContent = height
+            cellItem.calculatedCellHeights.oneColumn = height
+            cellItem.calculatedCellHeights.multiColumn = height
         }
         loadNext()
     }

--- a/Sources/Controllers/Stream/StreamCellItem.swift
+++ b/Sources/Controllers/Stream/StreamCellItem.swift
@@ -26,9 +26,7 @@ public final class StreamCellItem: NSObject, NSCopying {
     public var jsonable: JSONAble
     public var type: StreamCellType
     public var placeholderType: StreamCellType.PlaceholderType?
-    public var calculatedWebHeight: CGFloat?
-    public var calculatedOneColumnCellHeight: CGFloat?
-    public var calculatedMultiColumnCellHeight: CGFloat?
+    public var calculatedCellHeights = CalculatedCellHeights()
     public var state: StreamCellState = .None
 
     public convenience init(type: StreamCellType) {
@@ -54,9 +52,9 @@ public final class StreamCellItem: NSObject, NSCopying {
             jsonable: self.jsonable,
             type: self.type
             )
-        copy.calculatedWebHeight = self.calculatedWebHeight
-        copy.calculatedOneColumnCellHeight = self.calculatedOneColumnCellHeight
-        copy.calculatedMultiColumnCellHeight = self.calculatedMultiColumnCellHeight
+        copy.calculatedCellHeights.webContent = self.calculatedCellHeights.webContent
+        copy.calculatedCellHeights.oneColumn = self.calculatedCellHeights.oneColumn
+        copy.calculatedCellHeights.multiColumn = self.calculatedCellHeights.multiColumn
         return copy
     }
 

--- a/Sources/Controllers/Stream/StreamDataSource.swift
+++ b/Sources/Controllers/Stream/StreamDataSource.swift
@@ -249,8 +249,8 @@ public class StreamDataSource: NSObject, UICollectionViewDataSource {
 
     public func updateHeightForIndexPath(indexPath: NSIndexPath, height: CGFloat) {
         if indexPath.item < visibleCellItems.count {
-            visibleCellItems[indexPath.item].calculatedOneColumnCellHeight = height
-            visibleCellItems[indexPath.item].calculatedMultiColumnCellHeight = height
+            visibleCellItems[indexPath.item].calculatedCellHeights.oneColumn = height
+            visibleCellItems[indexPath.item].calculatedCellHeights.multiColumn = height
         }
     }
 
@@ -259,7 +259,7 @@ public class StreamDataSource: NSObject, UICollectionViewDataSource {
 
         // always try to return a calculated value before the default
         if numberOfColumns == 1 {
-            if let height = visibleCellItems[indexPath.item].calculatedOneColumnCellHeight {
+            if let height = visibleCellItems[indexPath.item].calculatedCellHeights.oneColumn {
                 return height
             }
             else {
@@ -267,7 +267,7 @@ public class StreamDataSource: NSObject, UICollectionViewDataSource {
             }
         }
         else {
-            if let height = visibleCellItems[indexPath.item].calculatedMultiColumnCellHeight {
+            if let height = visibleCellItems[indexPath.item].calculatedCellHeights.multiColumn {
                 return height
             }
             else {

--- a/Specs/Controllers/Stream/StreamDataSourceSpec.swift
+++ b/Specs/Controllers/Stream/StreamDataSourceSpec.swift
@@ -114,7 +114,7 @@ class StreamDataSourceSpec: QuickSpec {
                 }
                 it("sizes the items") {
                     for item in cellItems {
-                        expect(item.calculatedOneColumnCellHeight!) == AppSetup.Size.calculatorHeight
+                        expect(item.calculatedCellHeights.oneColumn!) == AppSetup.Size.calculatorHeight
                     }
                 }
             }
@@ -133,7 +133,7 @@ class StreamDataSourceSpec: QuickSpec {
                 }
                 it("does not size the items") {
                     for item in cellItems {
-                        expect(item.calculatedOneColumnCellHeight).to(beNil())
+                        expect(item.calculatedCellHeights.oneColumn).to(beNil())
                     }
                 }
             }
@@ -1146,8 +1146,8 @@ class StreamDataSourceSpec: QuickSpec {
                     subject.updateHeightForIndexPath(indexPath, height: 256)
 
                     let cellItem = subject.visibleStreamCellItem(at: indexPath)
-                    expect(cellItem!.calculatedOneColumnCellHeight!) == 256
-                    expect(cellItem!.calculatedMultiColumnCellHeight!) == 256
+                    expect(cellItem!.calculatedCellHeights.oneColumn!) == 256
+                    expect(cellItem!.calculatedCellHeights.multiColumn!) == 256
                 }
 
                 it("handles non-existent index paths") {

--- a/Specs/Controllers/Stream/StreamNotificationCellSizeCalculatorSpec.swift
+++ b/Specs/Controllers/Stream/StreamNotificationCellSizeCalculatorSpec.swift
@@ -45,43 +45,43 @@ class StreamNotificationCellSizeCalculatorSpec : QuickSpec {
                 let notification: Notification = stub(["activity": activity])
                 let item = StreamCellItem(jsonable: notification, type: .Notification)
                 subject.processCells([item], withWidth: 320, columnCount: 1) { }
-                expect(item.calculatedWebHeight) == 0
-                expect(item.calculatedOneColumnCellHeight) == 69
-                expect(item.calculatedMultiColumnCellHeight) == 69
+                expect(item.calculatedCellHeights.webContent) == 0
+                expect(item.calculatedCellHeights.oneColumn) == 69
+                expect(item.calculatedCellHeights.multiColumn) == 69
             }
             it("should return size that accounts for a message") {
                 let activity: Activity = stub(["kind": "repost_notification", "subject": postWithText])
                 let notification: Notification = stub(["activity": activity])
                 let item = StreamCellItem(jsonable: notification, type: .Notification)
                 subject.processCells([item], withWidth: 320, columnCount: 1) { }
-                expect(item.calculatedOneColumnCellHeight) == 119
-                expect(item.calculatedMultiColumnCellHeight) == 119
+                expect(item.calculatedCellHeights.oneColumn) == 119
+                expect(item.calculatedCellHeights.multiColumn) == 119
             }
             it("should return size that accounts for an image") {
                 let activity: Activity = stub(["kind": "repost_notification", "subject": postWithImage])
                 let notification: Notification = stub(["activity": activity])
                 let item = StreamCellItem(jsonable: notification, type: .Notification)
                 subject.processCells([item], withWidth: 320, columnCount: 1) { }
-                expect(item.calculatedOneColumnCellHeight) == 136
-                expect(item.calculatedMultiColumnCellHeight) == 136
+                expect(item.calculatedCellHeights.oneColumn) == 136
+                expect(item.calculatedCellHeights.multiColumn) == 136
             }
             it("should return size that accounts for an image with text") {
                 let activity: Activity = stub(["kind": "repost_notification", "subject": postWithTextAndImage])
                 let notification: Notification = stub(["activity": activity])
                 let item = StreamCellItem(jsonable: notification, type: .Notification)
                 subject.processCells([item], withWidth: 320, columnCount: 1) { }
-                expect(item.calculatedWebHeight) == 50
-                expect(item.calculatedOneColumnCellHeight) == 136
-                expect(item.calculatedMultiColumnCellHeight) == 136
+                expect(item.calculatedCellHeights.webContent) == 50
+                expect(item.calculatedCellHeights.oneColumn) == 136
+                expect(item.calculatedCellHeights.multiColumn) == 136
             }
             it("should return size that accounts for a reply button") {
                 let activity: Activity = stub(["kind": "comment_notification", "subject": commentWithText])
                 let notification: Notification = stub(["activity": activity])
                 let item = StreamCellItem(jsonable: notification, type: .Notification)
                 subject.processCells([item], withWidth: 320, columnCount: 1) { }
-                expect(item.calculatedWebHeight) == 50
-                expect(item.calculatedOneColumnCellHeight) == 159
-                expect(item.calculatedMultiColumnCellHeight) == 159
+                expect(item.calculatedCellHeights.webContent) == 50
+                expect(item.calculatedCellHeights.oneColumn) == 159
+                expect(item.calculatedCellHeights.multiColumn) == 159
             }
         }
     }

--- a/Specs/Fakes/FakeProfileHeaderCellSizeCalculator.swift
+++ b/Specs/Fakes/FakeProfileHeaderCellSizeCalculator.swift
@@ -9,8 +9,8 @@ public class FakeProfileHeaderCellSizeCalculator: ProfileHeaderCellSizeCalculato
 
     override public func processCells(cellItems: [StreamCellItem], withWidth: CGFloat, columnCount: Int, completion: ElloEmptyCompletion) {
         for item in cellItems {
-            item.calculatedOneColumnCellHeight = AppSetup.Size.calculatorHeight
-            item.calculatedMultiColumnCellHeight = AppSetup.Size.calculatorHeight
+            item.calculatedCellHeights.oneColumn = AppSetup.Size.calculatorHeight
+            item.calculatedCellHeights.multiColumn = AppSetup.Size.calculatorHeight
         }
         completion()
     }

--- a/Specs/Fakes/FakeStreamNotificationCellSizeCalculator.swift
+++ b/Specs/Fakes/FakeStreamNotificationCellSizeCalculator.swift
@@ -10,8 +10,8 @@ public class FakeStreamNotificationCellSizeCalculator: StreamNotificationCellSiz
 
     override public func processCells(cellItems: [StreamCellItem], withWidth: CGFloat, columnCount: Int, completion: ElloEmptyCompletion) {
         for item in cellItems {
-            item.calculatedOneColumnCellHeight = AppSetup.Size.calculatorHeight
-            item.calculatedMultiColumnCellHeight = AppSetup.Size.calculatorHeight
+            item.calculatedCellHeights.oneColumn = AppSetup.Size.calculatorHeight
+            item.calculatedCellHeights.multiColumn = AppSetup.Size.calculatorHeight
         }
         completion()
     }

--- a/Specs/Fakes/FakeStreamTextCellSizeCalculator.swift
+++ b/Specs/Fakes/FakeStreamTextCellSizeCalculator.swift
@@ -9,8 +9,8 @@ public class FakeStreamTextCellSizeCalculator: StreamTextCellSizeCalculator {
 
     override public func processCells(cellItems: [StreamCellItem], withWidth: CGFloat, columnCount: Int, completion: ElloEmptyCompletion) {
         for item in cellItems {
-            item.calculatedOneColumnCellHeight = AppSetup.Size.calculatorHeight
-            item.calculatedMultiColumnCellHeight = AppSetup.Size.calculatorHeight
+            item.calculatedCellHeights.oneColumn = AppSetup.Size.calculatorHeight
+            item.calculatedCellHeights.multiColumn = AppSetup.Size.calculatorHeight
         }
         completion()
     }


### PR DESCRIPTION
Introduces `CalculatedCellHeights` struct to store all the calculated sizes.  Lots of red/green noise around this change.

Some refactors to constraints in `ProfileHeaderCompactView` (added `centerX` constraints, otherwise just moved some things around).

Fixed `ProfileBaseView` so that it doesn't call `privateInit` twice.