### PR TITLE
Wire up bio and links views to open external links

### DIFF
--- a/Sources/Controllers/Profile/ProfileHeaderCell.swift
+++ b/Sources/Controllers/Profile/ProfileHeaderCell.swift
@@ -38,7 +38,14 @@ public class ProfileHeaderCell: UICollectionViewCell {
     var bioView: ProfileBioView { get { return headerView.bioView } }
     var linksView: ProfileLinksView { get { return headerView.linksView } }
 
-    weak var webLinkDelegate: WebLinkDelegate?
+    weak var webLinkDelegate: WebLinkDelegate? {
+        set {
+            bioView.webLinkDelegate = newValue
+            linksView.webLinkDelegate = newValue
+        }
+        get { return bioView.webLinkDelegate }
+    }
+
     weak var simpleStreamDelegate: SimpleStreamDelegate?
     weak var userDelegate: UserDelegate?
 

--- a/Sources/Controllers/Profile/Views/ProfileBioView.swift
+++ b/Sources/Controllers/Profile/Views/ProfileBioView.swift
@@ -22,6 +22,8 @@ public class ProfileBioView: ProfileBaseView {
         set { grayLine.hidden = !newValue }
     }
 
+    weak var webLinkDelegate: WebLinkDelegate?
+
     typealias OnBioHeightMismatch = (CGFloat) -> Void
     var onHeightMismatch: OnBioHeightMismatch?
 }
@@ -61,6 +63,7 @@ extension ProfileBioView {
     func prepareForReuse() {
         self.bio = ""
         grayLine.hidden = false
+        webLinkDelegate = nil
     }
 }
 
@@ -80,6 +83,9 @@ extension ProfileBioView: UIWebViewDelegate {
         }
     }
 
+    public func webView(webView: UIWebView, shouldStartLoadWithRequest request: NSURLRequest, navigationType: UIWebViewNavigationType) -> Bool {
+         return ElloWebViewHelper.handleRequest(request, webLinkDelegate: webLinkDelegate)
+    }
 }
 
 extension ProfileBioView: ProfileViewProtocol {}

--- a/Sources/Controllers/Profile/Views/ProfileLinksView.swift
+++ b/Sources/Controllers/Profile/Views/ProfileLinksView.swift
@@ -21,10 +21,13 @@ public class ProfileLinksView: ProfileBaseView {
         }
     }
 
+    weak var webLinkDelegate: WebLinkDelegate?
+
     private var linksBox = UIView()
     private var iconsBox = UIView()
     private var linkButtons: [UIButton] = []
     private var iconButtons: [UIButton] = []
+    private var buttonLinks: [UIButton: ExternalLink] = [:]
 
     private var iconsWidthConstraint: Constraint!
 
@@ -63,6 +66,7 @@ extension ProfileLinksView {
 extension ProfileLinksView {
     func prepareForReuse() {
         externalLinks = []
+        webLinkDelegate = nil
     }
 }
 
@@ -108,6 +112,9 @@ extension ProfileLinksView {
 
     private func addIconButton(externalLink: ExternalLink, iconsCount: Int, prevIcon: UIButton?, prevRow: UIView?) -> UIButton {
         let button = UIButton()
+        button.addTarget(self, action: #selector(buttonTapped(_:)), forControlEvents: .TouchUpInside)
+        buttonLinks[button] = externalLink
+
         iconsBox.addSubview(button)
         iconButtons.append(button)
 
@@ -135,8 +142,20 @@ extension ProfileLinksView {
         return button
     }
 
+    func buttonTapped(button: UIButton) {
+        guard let
+            externalLink = buttonLinks[button]
+        else { return }
+
+        let request = NSURLRequest(URL: externalLink.url)
+        ElloWebViewHelper.handleRequest(request, webLinkDelegate: webLinkDelegate)
+    }
+
     private func addLinkButton(externalLink: ExternalLink, prevLink: UIButton?) -> UIButton {
         let button = UIButton()
+        button.addTarget(self, action: #selector(buttonTapped(_:)), forControlEvents: .TouchUpInside)
+        buttonLinks[button] = externalLink
+
         linksBox.addSubview(button)
         linkButtons.append(button)
 

--- a/Sources/Controllers/Stream/StreamDataSource.swift
+++ b/Sources/Controllers/Stream/StreamDataSource.swift
@@ -327,9 +327,9 @@ public class StreamDataSource: NSObject, UICollectionViewDataSource {
             (cell as! NotificationCell).webLinkDelegate = webLinkDelegate
             (cell as! NotificationCell).userDelegate = userDelegate
             (cell as! NotificationCell).delegate = notificationDelegate
-//        case .ProfileHeader:
+        case .ProfileHeader:
 //            (cell as! ProfileHeaderCell).simpleStreamDelegate = simpleStreamDelegate
-//            (cell as! ProfileHeaderCell).webLinkDelegate = webLinkDelegate
+            (cell as! ProfileHeaderCell).webLinkDelegate = webLinkDelegate
 //            (cell as! ProfileHeaderCell).userDelegate = userDelegate
         case .Search:
             (cell as! SearchStreamCell).delegate = searchStreamDelegate


### PR DESCRIPTION
Unfortunately we weren't easily able to use the responder chain in this case. `WebLinkDelegate` uses non Objective-C parameters in it's single function (`ElloAPI`). That prevents us from using a selector which must be exposed to Objective-C. Instead we're using the old `webLinkDelegate` pattern of assignment in `StreamDataSource` via a passthrough into both `ProfileBioView` and `ProfileLinksView`.