### PR TITLE
Adds categories card list view to CategoryViewController

### DIFF
--- a/Ello.xcodeproj/project.pbxproj
+++ b/Ello.xcodeproj/project.pbxproj
@@ -686,6 +686,7 @@
 		1DA18E521DCCF70E000231CC /* PagePromotionalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA18E511DCCF70E000231CC /* PagePromotionalService.swift */; };
 		1DA18E541DCCFB8A000231CC /* PagePromotionalHeaderCellPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA18E531DCCFB8A000231CC /* PagePromotionalHeaderCellPresenter.swift */; };
 		1DA18E561DD0E2C2000231CC /* CategoryHeaderCellSizeCalculatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA18E551DD0E2C2000231CC /* CategoryHeaderCellSizeCalculatorSpec.swift */; };
+		1DA18E581DD12FE8000231CC /* CategoryCardListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA18E571DD12FE8000231CC /* CategoryCardListView.swift */; };
 		1DA809C21B8F6DE9000BB590 /* OmnibarScreenSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA809C11B8F6DE9000BB590 /* OmnibarScreenSpec.swift */; };
 		1DA8FD701B98A63600472B1E /* reorder_normal.svg in Resources */ = {isa = PBXBuildFile; fileRef = 1DA8FD6E1B98A63600472B1E /* reorder_normal.svg */; };
 		1DA8FD711B98A63600472B1E /* reorder_selected.svg in Resources */ = {isa = PBXBuildFile; fileRef = 1DA8FD6F1B98A63600472B1E /* reorder_selected.svg */; };
@@ -1649,6 +1650,7 @@
 		1DA18E511DCCF70E000231CC /* PagePromotionalService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagePromotionalService.swift; sourceTree = "<group>"; };
 		1DA18E531DCCFB8A000231CC /* PagePromotionalHeaderCellPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagePromotionalHeaderCellPresenter.swift; sourceTree = "<group>"; };
 		1DA18E551DD0E2C2000231CC /* CategoryHeaderCellSizeCalculatorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CategoryHeaderCellSizeCalculatorSpec.swift; sourceTree = "<group>"; };
+		1DA18E571DD12FE8000231CC /* CategoryCardListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CategoryCardListView.swift; sourceTree = "<group>"; };
 		1DA809C11B8F6DE9000BB590 /* OmnibarScreenSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OmnibarScreenSpec.swift; sourceTree = "<group>"; };
 		1DA8FD6E1B98A63600472B1E /* reorder_normal.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = reorder_normal.svg; sourceTree = "<group>"; };
 		1DA8FD6F1B98A63600472B1E /* reorder_selected.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = reorder_selected.svg; sourceTree = "<group>"; };
@@ -3038,6 +3040,7 @@
 		12F6AE641A4339D100493660 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				1DA18E571DD12FE8000231CC /* CategoryCardListView.swift */,
 				762EE9EA1A840E4A00A3B805 /* AvatarButton.swift */,
 				1289F3971AF17937008A938C /* BasicIcon.swift */,
 				1D2B50BA1D272A6400F6CE90 /* BlackBar.swift */,
@@ -5035,6 +5038,7 @@
 				122C66331B424DB20035F4CD /* AutoCompleteCell.swift in Sources */,
 				12F6AE451A43397400493660 /* Colors.swift in Sources */,
 				12F6AE6D1A4339EF00493660 /* ElloUnderlinedTextButton.swift in Sources */,
+				1DA18E581DD12FE8000231CC /* CategoryCardListView.swift in Sources */,
 				1DB8C6AD1D7A26B1007E1447 /* SearchStreamCell.swift in Sources */,
 				EAED46DC1ADC13BF0081A9F7 /* DynamicSettingCategoryViewController.swift in Sources */,
 				1D59EF851D5CFC480029C106 /* InterpolatedLoadingView.swift in Sources */,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -96,7 +96,7 @@ public class AppDelegate: UIResponder, UIApplicationDelegate {
         manager.cache.diskCache.byteLimit = twoHundredFiftyMegaBytes
         manager.cache.diskCache.ageLimit = twoWeeks
 
-        CategoryService().loadCategories({ _ in })
+        CategoryService().loadCategories()
     }
 
     public func applicationDidEnterBackground(application: UIApplication) {

--- a/Sources/Controllers/Categories/CategoryProtocols.swift
+++ b/Sources/Controllers/Categories/CategoryProtocols.swift
@@ -3,6 +3,11 @@
 //
 
 public protocol CategoryScreenProtocol: StreamableScreenProtocol {
+    var topInsetView: UIView { get }
+    var navBarsVisible: Bool? { get }
+    func setCategoriesInfo(categoriesInfo: [CategoryCardListView.CategoryInfo], animated: Bool)
+    func animateCategoriesList(navBarVisible navBarVisible: Bool)
+    func scrollToCategoryIndex(index: Int)
 }
 
 public protocol CategoryScreenDelegate: class {

--- a/Sources/Controllers/Categories/CategoryScreen.swift
+++ b/Sources/Controllers/Categories/CategoryScreen.swift
@@ -2,6 +2,68 @@
 ///  CategoryScreen.swift
 //
 
+import SnapKit
+
+
 public class CategoryScreen: StreamableScreen, CategoryScreenProtocol {
     weak var delegate: CategoryScreenDelegate?
+
+    private let categoryCardList = CategoryCardListView()
+
+    public var topInsetView: UIView {
+        if categoryCardList.hidden {
+            return navigationBar
+        }
+        else {
+            return categoryCardList
+        }
+    }
+
+    public var navBarsVisible: Bool? {
+        if !categoryCardList.hidden {
+            return true
+        }
+        return nil
+    }
+
+    override func arrange() {
+        super.arrange()
+        addSubview(categoryCardList)
+        addSubview(navigationBar)
+        categoryCardList.hidden = true
+
+        categoryCardList.snp_makeConstraints { make in
+            make.top.equalTo(navigationBar.snp_bottom)
+            make.leading.trailing.equalTo(self)
+            make.height.equalTo(CategoryCardListView.Size.height)
+        }
+    }
+
+    public func setCategoriesInfo(newValue: [CategoryCardListView.CategoryInfo], animated: Bool) {
+        categoryCardList.hidden = newValue.isEmpty
+        categoryCardList.categoriesInfo = newValue
+
+        if !categoryCardList.hidden && animated {
+            let originalY = categoryCardList.frame.origin.y
+            categoryCardList.frame.origin.y = -categoryCardList.frame.size.height
+            animate {
+                self.categoryCardList.frame.origin.y = originalY
+            }
+        }
+    }
+
+    public func animateCategoriesList(navBarVisible navBarVisible: Bool) {
+        animate {
+            if navBarVisible {
+                self.categoryCardList.frame.origin.y = self.navigationBar.frame.height
+            }
+            else {
+                self.categoryCardList.frame.origin.y = 0
+            }
+        }
+    }
+
+    public func scrollToCategoryIndex(index: Int) {
+        self.categoryCardList.scrollToIndex(index, animated: false)
+    }
 }

--- a/Sources/Controllers/Categories/CategoryViewController.swift
+++ b/Sources/Controllers/Categories/CategoryViewController.swift
@@ -181,7 +181,6 @@ extension CategoryViewController: CategoryStreamDestination, StreamDestination {
         updateInsets()
 
         if !userDidScroll && streamViewController.dataSource.visibleCellItems.count > 0 {
-            // streamViewController.collectionView.scrollToItemAtIndexPath(NSIndexPath(forItem: 1, inSection: 0), atScrollPosition: [.Bottom], animated: true)
             var offset: CGFloat = CategoryCardListView.Size.height
             if navBarsVisible() {
                 offset += ElloNavigationBar.Size.height

--- a/Sources/Controllers/Discover/DiscoverAllCategoriesViewController.swift
+++ b/Sources/Controllers/Discover/DiscoverAllCategoriesViewController.swift
@@ -30,13 +30,13 @@ public class DiscoverAllCategoriesViewController: StreamableViewController {
     }
 
     func loadCategories() {
-        CategoryService().loadCategories({ [weak self] categories in
+        CategoryService().loadCategories().onSuccess { [weak self] categories in
             guard let sself = self else { return }
 
             let sortedCategories = CategoryList(categories: categories).categories
 
             sself.streamViewController.showInitialJSONAbles(sortedCategories)
-        })
+        }.ignoreFailures()
     }
 
     override public func viewDidLoad() {

--- a/Sources/Controllers/Discover/DiscoverViewController.swift
+++ b/Sources/Controllers/Discover/DiscoverViewController.swift
@@ -58,16 +58,17 @@ public class DiscoverViewController: StreamableViewController {
 
         addSearchButton()
 
-        CategoryService().loadCategories({ [weak self] categories in
-            guard let sself = self else { return }
+        CategoryService().loadCategories()
+            .onSuccess { [weak self] categories in
+                guard let sself = self else { return }
 
-            let categoriesPlusFeatured = [Category.featured] + categories
-            let categoryList = CategoryList(categories: categoriesPlusFeatured)
-            sself.categoryList = categoryList
-            sself.streamViewController.replacePlaceholder(.CategoryList, with: [
-                StreamCellItem(jsonable: categoryList, type: .CategoryList),
-            ])
-        })
+                let categoriesPlusFeatured = [Category.featured] + categories
+                let categoryList = CategoryList(categories: categoriesPlusFeatured)
+                sself.categoryList = categoryList
+                sself.streamViewController.replacePlaceholder(.CategoryList, with: [
+                    StreamCellItem(jsonable: categoryList, type: .CategoryList),
+                ])
+            }.ignoreFailures()
     }
 
     required public init?(coder aDecoder: NSCoder) {

--- a/Sources/Controllers/Stream/Cells/StreamCellType.swift
+++ b/Sources/Controllers/Stream/Cells/StreamCellType.swift
@@ -245,7 +245,7 @@ public enum StreamCellType: Equatable {
         case CategoryList:
             return 66
         case ColumnToggle:
-            return 40
+            return ColumnToggleCell.Size.height
         case CommentHeader,
              InviteFriends,
              OnboardingInviteFriends,

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -1112,6 +1112,7 @@ extension StreamViewController: UICollectionViewDelegate {
     public func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {
         let tappedCell = collectionView.cellForItemAtIndexPath(indexPath)
 
+        var keepSelected = false
         if tappedCell is StreamToggleCell {
             dataSource.toggleCollapsedForIndexPath(indexPath)
             reloadCells(now: true)
@@ -1152,6 +1153,7 @@ extension StreamViewController: UICollectionViewDelegate {
             category = dataSource.jsonableForIndexPath(indexPath) as? Category
         {
             if item.type == .SelectableCategoryCard {
+                keepSelected = true
                 let paths = collectionView.indexPathsForSelectedItems()
                 let selection = paths?.flatMap { dataSource.jsonableForIndexPath($0) as? Category }
                 selectedCategoryDelegate?.categoriesSelectionChanged(selection ?? [Category]())
@@ -1163,6 +1165,10 @@ extension StreamViewController: UICollectionViewDelegate {
         else if let cellItemType = dataSource.visibleStreamCellItem(at: indexPath)?.type
         where cellItemType == .SeeAllCategories {
             seeAllCategoriesTapped()
+        }
+
+        if !keepSelected {
+            collectionView.deselectItemAtIndexPath(indexPath, animated: false)
         }
     }
 

--- a/Sources/Networking/CategoryService.swift
+++ b/Sources/Networking/CategoryService.swift
@@ -9,15 +9,20 @@ public typealias CategoriesCompletion = (categories: [Category]) -> Void
 
 public class CategoryService {
 
-    public func loadCategories(success: CategoriesCompletion, failure: ElloFailureCompletion = { _ in }) {
+    public func loadCategories() -> Future<[Category]> {
+        let promise = Promise<[Category]>()
         ElloProvider.shared.elloRequest(.Categories, success: { (data, responseConfig) in
             if let categories = data as? [Category] {
                 Preloader().preloadImages(categories)
-                success(categories: categories)
+                promise.completeWithSuccess(categories)
             }
-        }, failure: { (error, statusCode) in
-            failure(error: error, statusCode: statusCode)
+            else {
+                promise.completeWithFail(NSError.uncastableJSONAble())
+            }
+        }, failure: { (error, _) in
+            promise.completeWithFail(error)
         })
+        return promise.future
     }
 
     public func loadCategory(categorySlug: String) -> Future<Category> {

--- a/Sources/Views/CategoryCardListView.swift
+++ b/Sources/Views/CategoryCardListView.swift
@@ -1,0 +1,145 @@
+////
+///  CategoryCardListView.swift
+//
+
+public class CategoryCardListView: UIView {
+    weak var discoverCategoryPickerDelegate: DiscoverCategoryPickerDelegate?
+
+    struct Size {
+        static let height: CGFloat = 70
+        static let cardSize: CGSize = CGSize(width: 100, height: 68)
+        static let spacing: CGFloat = 1
+    }
+
+    public struct CategoryInfo {
+        let title: String
+        let imageURL: NSURL?
+        let endpoint: ElloAPI
+        let selected: Bool
+    }
+
+    public var categoriesInfo: [CategoryInfo] = [] {
+        didSet {
+            let changed: Bool = (categoriesInfo.count != oldValue.count) || oldValue.enumerate().any { (index, info) in
+                return info.title != categoriesInfo[index].title || info.selected != categoriesInfo[index].selected || info.endpoint.path != categoriesInfo[index].endpoint.path
+            }
+            if changed {
+                updateCategoryViews()
+            }
+        }
+    }
+
+    private var buttonEndpointLookup: [UIButton: ElloAPI] = [:]
+    private var categoryViews: [UIView] = []
+    private var scrollView = UIScrollView()
+
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+
+        style()
+        bindActions()
+        arrange()
+    }
+
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func style() {
+        backgroundColor = .whiteColor()
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+    }
+
+    private func bindActions() {
+    }
+
+    private func arrange() {
+        self.addSubview(scrollView)
+
+        scrollView.snp_makeConstraints { make in
+            make.edges.equalTo(self)
+        }
+    }
+
+    @objc
+    func categoryButtonTapped(button: UIButton) {
+        guard let endpoint = buttonEndpointLookup[button] else { return }
+        discoverCategoryPickerDelegate?.discoverCategoryTapped(endpoint)
+    }
+
+    @objc
+    func allButtonTapped() {
+        discoverCategoryPickerDelegate?.discoverAllCategoriesTapped()
+    }
+
+    public func scrollToIndex(index: Int, animated: Bool) {
+        guard let view = categoryViews.safeValue(index) else { return }
+
+        let x = max(min(view.frame.minX, scrollView.contentSize.width - frame.width), 0)
+        scrollView.setContentOffset(CGPoint(x: x, y: 0), animated: animated)
+    }
+
+    private func updateCategoryViews() {
+        for view in categoryViews {
+            view.removeFromSuperview()
+        }
+
+        buttonEndpointLookup = [:]
+        categoryViews = categoriesInfo.map { info in
+            let view = UIView()
+            view.backgroundColor = .blackColor()
+
+            if let url = info.imageURL {
+                let image = UIImageView()
+                image.pin_setImageFromURL(url)
+                view.addSubview(image)
+                image.snp_makeConstraints { $0.edges.equalTo(view) }
+            }
+
+            let overlay = UIView()
+            overlay.backgroundColor = .blackColor()
+            overlay.alpha = 0.6
+            view.addSubview(overlay)
+            overlay.snp_makeConstraints { $0.edges.equalTo(view) }
+
+            let button = UIButton()
+            button.addTarget(self, action: #selector(categoryButtonTapped(_:)), forControlEvents: .TouchUpInside)
+            let attributedString = NSAttributedString(info.title, color: .whiteColor())
+            button.setAttributedTitle(attributedString, forState: UIControlState.Normal)
+            view.addSubview(button)
+            button.snp_makeConstraints { $0.edges.equalTo(view) }
+
+            buttonEndpointLookup[button] = info.endpoint
+            return view
+        }
+
+        var prevView: UIView? = nil
+        for view in categoryViews {
+            scrollView.addSubview(view)
+
+            view.snp_makeConstraints { make in
+                make.size.equalTo(Size.cardSize)
+                make.centerY.equalTo(scrollView)
+
+                if let prevView = prevView {
+                    make.leading.equalTo(prevView.snp_trailing).offset(Size.spacing)
+                }
+                else {
+                    make.leading.equalTo(scrollView.snp_leading)
+                }
+            }
+
+            prevView = view
+        }
+
+        if let prevView = prevView {
+            prevView.snp_makeConstraints { make in
+                make.trailing.equalTo(scrollView.snp_trailing)
+            }
+        }
+
+        layoutIfNeeded()
+    }
+
+}

--- a/Sources/Views/Screens/StreamableScreen.swift
+++ b/Sources/Views/Screens/StreamableScreen.swift
@@ -2,7 +2,7 @@
 ///  StreamableScreen.swift
 //
 
-public protocol StreamableScreenProtocol {
+public protocol StreamableScreenProtocol: class {
     var navigationBarTopConstraint: NSLayoutConstraint! { get }
     var navigationBar: ElloNavigationBar { get }
     var navigationItem: UINavigationItem? { get set }

--- a/Sources/controllers/stream/Cells/ColumnToggleCell.swift
+++ b/Sources/controllers/stream/Cells/ColumnToggleCell.swift
@@ -3,8 +3,10 @@
 //
 
 public class ColumnToggleCell: UICollectionViewCell {
-
     static let reuseIdentifier = "ColumnToggleCell"
+    public struct Size {
+        static let height: CGFloat = 40
+    }
 
     public var isGridView: Bool = false {
         didSet {


### PR DESCRIPTION
In order to get the "fetch all categories" request into the `CategoryViewController`, I added a protocol `CategoryStreamDestination` which extends `StreamDestination`.  It's a private var on `CategoryGenerator`, and the `destination` returns that object, cast as a `StreamDestination`.  The swift compiler isn't quite smart enough to see that `CategoryStreamDestination` *satisfies* the `StreamDestination` type requirement, so this little handshake is required there.  Not a big fan, I wish we could just use `var destination: CategoryStreamDestination?`, but oh well.

Once the categories are loaded, we check for "did the user scroll?", and if not it adjusts the content inset so that the grid/list toggle is hidden.  The toggle doesn't start out hidden, but that enhancement probably wouldn't be terribly hard to add (in the "primary jsonable loaded" code?).

No specs yet, need @steam's work on specs to add specs to this feature.