### PR TITLE
Support new category deep linking

### DIFF
--- a/Ello.xcodeproj/project.pbxproj
+++ b/Ello.xcodeproj/project.pbxproj
@@ -426,6 +426,7 @@
 		12E06F3F1CE24AF00066E247 /* UsernameSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E06F3E1CE24AF00066E247 /* UsernameSpec.swift */; };
 		12E3A2751DBE811900D42599 /* Promotional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E3A2741DBE811900D42599 /* Promotional.swift */; };
 		12E810C21DCB91C4007094C1 /* NSAttributedStringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1289F3931AF1474B008A938C /* NSAttributedStringExtensions.swift */; };
+		12ECFFFE1DDA146A007F22C5 /* category.json in Resources */ = {isa = PBXBuildFile; fileRef = 12ECFFFD1DDA146A007F22C5 /* category.json */; };
 		12F0E3A81A4333150012CEA2 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 12F0E3A61A4333150012CEA2 /* LaunchScreen.xib */; };
 		12F0E3A91A4333150012CEA2 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 12F0E3A71A4333150012CEA2 /* Main.storyboard */; };
 		12F0E3AB1A4333260012CEA2 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 12F0E3AA1A4333260012CEA2 /* Images.xcassets */; };
@@ -1387,6 +1388,7 @@
 		12E06F3E1CE24AF00066E247 /* UsernameSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UsernameSpec.swift; sourceTree = "<group>"; };
 		12E3A2741DBE811900D42599 /* Promotional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Promotional.swift; sourceTree = "<group>"; };
 		12E83D9E1ADF12120074ECF6 /* ExperienceUpdate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ExperienceUpdate.swift; path = sources/model/ExperienceUpdate.swift; sourceTree = SOURCE_ROOT; };
+		12ECFFFD1DDA146A007F22C5 /* category.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = category.json; sourceTree = "<group>"; };
 		12F0E3A31A4332FB0012CEA2 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		12F0E3A61A4333150012CEA2 /* LaunchScreen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LaunchScreen.xib; sourceTree = "<group>"; };
 		12F0E3A71A4333150012CEA2 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
@@ -3412,6 +3414,9 @@
 				1DC10FA41C3DEB7600846ED6 /* availability.json */,
 				1D5A901B1D3991CC00C2AEFF /* buy-button-image-region.json */,
 				1D5933721D10BB5B00EAF03D /* categories.json */,
+				12ECFFFD1DDA146A007F22C5 /* category.json */,
+				1241EDB31DD3D07900426A17 /* page_promotionals.json */,
+				1DA18E4C1DC7DE07000231CC /* post_detail__watching.json */,
 				1DA9AA7B1C694F32000562E4 /* profile__no_sharing.json */,
 				1DD8299F1BD93D3600105CDE /* relationship_following.json */,
 				1DD829A01BD93D3600105CDE /* relationship_inactive.json */,
@@ -3419,8 +3424,6 @@
 				1D6C97F71CE179E600E7B929 /* usernames.json */,
 				123DEBF01D3D5F32007B5F86 /* users_posts.json */,
 				1DDC85181D91D4E400C29552 /* watches_creating_a_watch.json */,
-				1DA18E4C1DC7DE07000231CC /* post_detail__watching.json */,
-				1241EDB31DD3D07900426A17 /* page_promotionals.json */,
 			);
 			path = CustomResponses;
 			sourceTree = "<group>";
@@ -3994,6 +3997,7 @@
 				EA68A0EA1AADF62F003F0425 /* find-friends.json in Resources */,
 				126E052F1B152CF00036DFA6 /* AlertHeaderView.xib in Resources */,
 				1DF7416E1BFA65F0000F5349 /* link_normal.svg in Resources */,
+				12ECFFFE1DDA146A007F22C5 /* category.json in Resources */,
 				76F8DEAD1B6C0BC4009BCF61 /* abracket_selected.svg in Resources */,
 				1D405D9C1C47166D0059DAFD /* repost_disabled.svg in Resources */,
 				76F8DF061B6C0BC4009BCF61 /* xpmcirc_normal.svg in Resources */,

--- a/Resources/StubbedResponses/CustomResponses/category.json
+++ b/Resources/StubbedResponses/CustomResponses/category.json
@@ -1,0 +1,876 @@
+{
+	"categories": {
+		"id": "1",
+		"name": "Art",
+		"slug": "art",
+		"links": {
+			"recent": {
+				"related": "/api/v2/categories/art/posts/recent"
+			},
+			"promotionals": ["4", "17", "18", "19", "20", "66", "68"]
+		},
+		"level": "primary",
+		"order": null,
+		"allow_in_onboarding": true,
+		"description": "This is Art. This is Art on Drugs. That is all.",
+		"is_sponsored": true,
+		"header": "Art",
+		"cta_caption": "Click Here",
+		"cta_href": "http://vote.com",
+		"tile_image": {
+			"original": {
+				"url": "https://ello-stage2.herokuapp.com/images/fallback/category/tile_image/ello-default.png"
+			},
+			"large": {
+				"url": "https://ello-stage2.herokuapp.com/images/fallback/category/tile_image/ello-default-large.png",
+				"metadata": null
+			},
+			"regular": {
+				"url": "https://ello-stage2.herokuapp.com/images/fallback/category/tile_image/ello-default-regular.png",
+				"metadata": null
+			},
+			"small": {
+				"url": "https://ello-stage2.herokuapp.com/images/fallback/category/tile_image/ello-default-small.png",
+				"metadata": null
+			}
+		}
+	},
+	"linked": {
+		"promotionals": [{
+			"id": "4",
+			"user_id": "4",
+			"category_id": "1",
+			"image": {
+				"original": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/4/ello-xhdpi-a7909b5d.jpg"
+				},
+				"optimized": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/4/ello-optimized-15620058.jpg",
+					"metadata": {
+						"size": 233996,
+						"type": "image/jpeg",
+						"width": 650,
+						"height": 899
+					}
+				},
+				"xhdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/4/ello-xhdpi-15620058.jpg",
+					"metadata": {
+						"size": 299715,
+						"type": "image/jpeg",
+						"width": 605,
+						"height": 837
+					}
+				},
+				"hdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/4/ello-hdpi-15620058.jpg",
+					"metadata": {
+						"size": 88472,
+						"type": "image/jpeg",
+						"width": 299,
+						"height": 414
+					}
+				}
+			},
+			"links": {
+				"user": {
+					"type": "users",
+					"href": "/api/v2/users/4",
+					"id": "4"
+				}
+			}
+		}, {
+			"id": "17",
+			"user_id": "543",
+			"category_id": "1",
+			"image": {
+				"original": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/17/frogs-1347637_960_720.jpg"
+				},
+				"optimized": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/17/ello-optimized-a8f58779.jpg",
+					"metadata": {
+						"size": 310513,
+						"type": "image/jpeg",
+						"width": 914,
+						"height": 720
+					}
+				},
+				"xhdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/17/ello-xhdpi-a8f58779.jpg",
+					"metadata": {
+						"size": 311860,
+						"type": "image/jpeg",
+						"width": 914,
+						"height": 720
+					}
+				},
+				"hdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/17/ello-hdpi-a8f58779.jpg",
+					"metadata": {
+						"size": 138443,
+						"type": "image/jpeg",
+						"width": 526,
+						"height": 414
+					}
+				}
+			},
+			"links": {
+				"user": {
+					"type": "users",
+					"href": "/api/v2/users/543",
+					"id": "543"
+				}
+			}
+		}, {
+			"id": "18",
+			"user_id": "663",
+			"category_id": "1",
+			"image": {
+				"original": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/18/frogs-eat_81348f18f515b8fd_1hr1oD9DR3WClPbpRyN94A.jpg"
+				},
+				"optimized": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/18/ello-optimized-3595a983.jpg",
+					"metadata": {
+						"size": 69259,
+						"type": "image/jpeg",
+						"width": 700,
+						"height": 394
+					}
+				},
+				"xhdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/18/ello-xhdpi-3595a983.jpg",
+					"metadata": {
+						"size": 70341,
+						"type": "image/jpeg",
+						"width": 700,
+						"height": 394
+					}
+				},
+				"hdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/18/ello-hdpi-3595a983.jpg",
+					"metadata": {
+						"size": 70341,
+						"type": "image/jpeg",
+						"width": 700,
+						"height": 394
+					}
+				}
+			},
+			"links": {
+				"user": {
+					"type": "users",
+					"href": "/api/v2/users/663",
+					"id": "663"
+				}
+			}
+		}, {
+			"id": "19",
+			"user_id": "9",
+			"category_id": "1",
+			"image": {
+				"original": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/19/Art.jpg"
+				},
+				"optimized": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/19/ello-optimized-978d7d6b.jpg",
+					"metadata": {
+						"size": 667330,
+						"type": "image/jpeg",
+						"width": 1440,
+						"height": 600
+					}
+				},
+				"xhdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/19/ello-xhdpi-978d7d6b.jpg",
+					"metadata": {
+						"size": 624460,
+						"type": "image/jpeg",
+						"width": 1440,
+						"height": 600
+					}
+				},
+				"hdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/19/ello-hdpi-978d7d6b.jpg",
+					"metadata": {
+						"size": 243422,
+						"type": "image/jpeg",
+						"width": 750,
+						"height": 313
+					}
+				}
+			},
+			"links": {
+				"user": {
+					"type": "users",
+					"href": "/api/v2/users/9",
+					"id": "9"
+				}
+			}
+		}, {
+			"id": "20",
+			"user_id": "9",
+			"category_id": "1",
+			"image": {
+				"original": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/20/Art-portrait-collage_2.jpg"
+				},
+				"optimized": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/20/ello-optimized-3b82b840.jpg",
+					"metadata": {
+						"size": 387465,
+						"type": "image/jpeg",
+						"width": 800,
+						"height": 800
+					}
+				},
+				"xhdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/20/ello-xhdpi-3b82b840.jpg",
+					"metadata": {
+						"size": 357257,
+						"type": "image/jpeg",
+						"width": 800,
+						"height": 800
+					}
+				},
+				"hdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/20/ello-hdpi-3b82b840.jpg",
+					"metadata": {
+						"size": 145282,
+						"type": "image/jpeg",
+						"width": 414,
+						"height": 414
+					}
+				}
+			},
+			"links": {
+				"user": {
+					"type": "users",
+					"href": "/api/v2/users/9",
+					"id": "9"
+				}
+			}
+		}, {
+			"id": "66",
+			"user_id": "543",
+			"category_id": "1",
+			"image": {
+				"original": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/66/fart-e1363889285693.jpg"
+				},
+				"optimized": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/66/ello-optimized-7169143f.jpg",
+					"metadata": {
+						"size": 241367,
+						"type": "image/jpeg",
+						"width": 1399,
+						"height": 1399
+					}
+				},
+				"xhdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/66/ello-xhdpi-7169143f.jpg",
+					"metadata": {
+						"size": 133709,
+						"type": "image/jpeg",
+						"width": 837,
+						"height": 837
+					}
+				},
+				"hdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/66/ello-hdpi-7169143f.jpg",
+					"metadata": {
+						"size": 60280,
+						"type": "image/jpeg",
+						"width": 414,
+						"height": 414
+					}
+				}
+			},
+			"links": {
+				"user": {
+					"type": "users",
+					"href": "/api/v2/users/543",
+					"id": "543"
+				}
+			}
+		}, {
+			"id": "68",
+			"user_id": "27",
+			"category_id": "1",
+			"image": {
+				"original": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/68/860932.png"
+				},
+				"optimized": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/68/ello-optimized-17760cb3.jpg",
+					"metadata": {
+						"size": 55878,
+						"type": "image/jpeg",
+						"width": 600,
+						"height": 407
+					}
+				},
+				"xhdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/68/ello-xhdpi-17760cb3.jpg",
+					"metadata": {
+						"size": 92097,
+						"type": "image/jpeg",
+						"width": 600,
+						"height": 407
+					}
+				},
+				"hdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/promotional/image/68/ello-hdpi-17760cb3.jpg",
+					"metadata": {
+						"size": 92097,
+						"type": "image/jpeg",
+						"width": 600,
+						"height": 407
+					}
+				}
+			},
+			"links": {
+				"user": {
+					"type": "users",
+					"href": "/api/v2/users/27",
+					"id": "27"
+				}
+			}
+		}],
+		"users": [{
+			"id": "4",
+			"href": "/api/v2/users/4",
+			"username": "mk",
+			"name": "Matthew Kitt",
+			"location": null,
+			"posts_adult_content": false,
+			"views_adult_content": true,
+			"has_commenting_enabled": true,
+			"has_sharing_enabled": true,
+			"has_reposting_enabled": true,
+			"has_loves_enabled": true,
+			"has_auto_watch_enabled": true,
+			"experimental_features": true,
+			"relationship_priority": "friend",
+			"bad_for_seo": true,
+			"is_hireable": true,
+			"is_collaborateable": false,
+			"posts_count": 26,
+			"followers_count": 89,
+			"following_count": 18,
+			"loves_count": 0,
+			"formatted_short_bio": "<p>Lorem ipsum <a href='http://ello.co/' rel='nofollow' target='_blank'>http://ello.co/</a> dolor sit amet, consectetur adipiscing elit. Praesent et blandit nunc. Pellentesque non ex in nulla laoreet euismod nec a felis. In at est eget sem consectetur venenatis.</p>\n\n<p>Lorem ipsum <a href='http://ello.co/' rel='nofollow' target='_blank'>http://ello.co/</a> dolor sit amet, consectetur adipiscing elit. Praesent et blandit nunc. Pellentesque no ex in nulla laoreet euismod nec a felis. In at est eget sem consectetur venenatis.</p>\n\n<p>This is the last line</p>",
+			"external_links_list": [{
+				"url": "http://ello.co",
+				"text": "ello.co"
+			}],
+			"background_position": "50% 50%",
+			"avatar": {
+				"original": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/4/ello-72fdc63c-d9d8-4f94-bfb2-9d4b939a5102.jpeg"
+				},
+				"large": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/4/ello-large-30ef5f89.png",
+					"metadata": {
+						"size": 274183,
+						"type": "image/png",
+						"width": 360,
+						"height": 360
+					}
+				},
+				"regular": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/4/ello-regular-30ef5f89.png",
+					"metadata": {
+						"size": 36019,
+						"type": "image/png",
+						"width": 120,
+						"height": 120
+					}
+				},
+				"small": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/4/ello-small-30ef5f89.png",
+					"metadata": {
+						"size": 10188,
+						"type": "image/png",
+						"width": 60,
+						"height": 60
+					}
+				}
+			},
+			"cover_image": {
+				"original": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/4/ello-38988006-1130-449c-a459-b937a5afc463.jpeg"
+				},
+				"optimized": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/4/ello-optimized-e0ba7623.jpg",
+					"metadata": {
+						"size": 175198,
+						"type": "image/jpeg",
+						"width": 500,
+						"height": 749
+					}
+				},
+				"xhdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/4/ello-xhdpi-e0ba7623.jpg",
+					"metadata": {
+						"size": 175491,
+						"type": "image/jpeg",
+						"width": 500,
+						"height": 749
+					}
+				},
+				"hdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/4/ello-hdpi-e0ba7623.jpg",
+					"metadata": {
+						"size": 64491,
+						"type": "image/jpeg",
+						"width": 276,
+						"height": 414
+					}
+				},
+				"mdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/4/ello-mdpi-e0ba7623.jpg",
+					"metadata": {
+						"size": 17479,
+						"type": "image/jpeg",
+						"width": 138,
+						"height": 207
+					}
+				},
+				"ldpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/4/ello-ldpi-e0ba7623.jpg",
+					"metadata": {
+						"size": 4707,
+						"type": "image/jpeg",
+						"width": 66,
+						"height": 99
+					}
+				}
+			}
+		}, {
+			"id": "543",
+			"href": "/api/v2/users/543",
+			"username": "sdough",
+			"name": null,
+			"location": null,
+			"posts_adult_content": false,
+			"views_adult_content": false,
+			"has_commenting_enabled": true,
+			"has_sharing_enabled": true,
+			"has_reposting_enabled": true,
+			"has_loves_enabled": true,
+			"has_auto_watch_enabled": true,
+			"experimental_features": true,
+			"relationship_priority": null,
+			"bad_for_seo": true,
+			"is_hireable": false,
+			"is_collaborateable": false,
+			"posts_count": 1,
+			"followers_count": 9,
+			"following_count": 1,
+			"loves_count": 0,
+			"formatted_short_bio": "",
+			"external_links_list": [],
+			"background_position": null,
+			"avatar": {
+				"original": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/543/sdough.png"
+				},
+				"large": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/543/ello-large-8f0d6e80.png",
+					"metadata": {
+						"size": 47095,
+						"type": "image/png",
+						"width": 360,
+						"height": 360
+					}
+				},
+				"regular": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/543/ello-regular-8f0d6e80.png",
+					"metadata": {
+						"size": 9687,
+						"type": "image/png",
+						"width": 120,
+						"height": 120
+					}
+				},
+				"small": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/543/ello-small-8f0d6e80.png",
+					"metadata": {
+						"size": 3625,
+						"type": "image/png",
+						"width": 60,
+						"height": 60
+					}
+				}
+			},
+			"cover_image": {
+				"original": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/images/fallback/user/cover_image/15/ello-default.jpg"
+				},
+				"optimized": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/images/fallback/user/cover_image/15/ello-default-optimized.jpg",
+					"metadata": null
+				},
+				"xhdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/images/fallback/user/cover_image/15/ello-default-xhdpi.jpg",
+					"metadata": null
+				},
+				"hdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/images/fallback/user/cover_image/15/ello-default-hdpi.jpg",
+					"metadata": null
+				},
+				"mdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/images/fallback/user/cover_image/15/ello-default-mdpi.jpg",
+					"metadata": null
+				},
+				"ldpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/images/fallback/user/cover_image/15/ello-default-ldpi.jpg",
+					"metadata": null
+				}
+			}
+		}, {
+			"id": "663",
+			"href": "/api/v2/users/663",
+			"username": "justin",
+			"name": "",
+			"location": null,
+			"posts_adult_content": false,
+			"views_adult_content": true,
+			"has_commenting_enabled": true,
+			"has_sharing_enabled": true,
+			"has_reposting_enabled": true,
+			"has_loves_enabled": true,
+			"has_auto_watch_enabled": true,
+			"experimental_features": true,
+			"relationship_priority": "friend",
+			"bad_for_seo": false,
+			"is_hireable": false,
+			"is_collaborateable": false,
+			"posts_count": 8,
+			"followers_count": 5,
+			"following_count": 1,
+			"loves_count": 0,
+			"formatted_short_bio": "",
+			"external_links_list": [{
+				"url": "https://play.google.com/store/apps/details?id=asdf",
+				"text": "play.google.com/store/apps/details?id=asdf",
+				"type": "play",
+				"icon": "https://social-icons.ello.co/play.png"
+			}],
+			"background_position": null,
+			"avatar": {
+				"original": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/663/ello-b7ebf461-54be-4e36-9765-eba47debbdc6.jpeg"
+				},
+				"large": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/663/ello-large-38ddee22.png",
+					"metadata": {
+						"size": 222681,
+						"type": "image/png",
+						"width": 360,
+						"height": 360
+					}
+				},
+				"regular": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/663/ello-regular-38ddee22.png",
+					"metadata": {
+						"size": 28230,
+						"type": "image/png",
+						"width": 120,
+						"height": 120
+					}
+				},
+				"small": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/663/ello-small-38ddee22.png",
+					"metadata": {
+						"size": 7608,
+						"type": "image/png",
+						"width": 60,
+						"height": 60
+					}
+				}
+			},
+			"cover_image": {
+				"original": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/663/ello-ec69965c-58d4-4662-a31f-161bd45b8234.jpeg"
+				},
+				"optimized": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/663/ello-optimized-6355d92b.jpg",
+					"metadata": {
+						"size": 1546525,
+						"type": "image/jpeg",
+						"width": 1435,
+						"height": 1440
+					}
+				},
+				"xhdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/663/ello-xhdpi-6355d92b.jpg",
+					"metadata": {
+						"size": 572953,
+						"type": "image/jpeg",
+						"width": 834,
+						"height": 837
+					}
+				},
+				"hdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/663/ello-hdpi-6355d92b.jpg",
+					"metadata": {
+						"size": 161242,
+						"type": "image/jpeg",
+						"width": 413,
+						"height": 414
+					}
+				},
+				"mdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/663/ello-mdpi-6355d92b.jpg",
+					"metadata": {
+						"size": 44129,
+						"type": "image/jpeg",
+						"width": 206,
+						"height": 207
+					}
+				},
+				"ldpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/663/ello-ldpi-6355d92b.jpg",
+					"metadata": {
+						"size": 11606,
+						"type": "image/jpeg",
+						"width": 99,
+						"height": 99
+					}
+				}
+			}
+		}, {
+			"id": "9",
+			"href": "/api/v2/users/9",
+			"username": "666",
+			"name": "staging",
+			"location": "Denver, CO, United States",
+			"posts_adult_content": false,
+			"views_adult_content": true,
+			"has_commenting_enabled": true,
+			"has_sharing_enabled": false,
+			"has_reposting_enabled": false,
+			"has_loves_enabled": true,
+			"has_auto_watch_enabled": true,
+			"experimental_features": true,
+			"relationship_priority": "friend",
+			"bad_for_seo": false,
+			"is_hireable": true,
+			"is_collaborateable": true,
+			"posts_count": 102,
+			"followers_count": 98,
+			"following_count": 55,
+			"loves_count": 2,
+			"formatted_short_bio": "<p>what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? what&apos;s happening suckaz? <img class='emoji' title=':metal:' alt=':metal:' src='https://ello-stage2.herokuapp.com/images/emoji/metal.png' height='20' width='20' align='absmiddle'/> <img class='emoji' title=':skull:' alt=':skull:' src='https://ello-stage2.herokuapp.com/images/emoji/unicode/1f480.png' height='20' width='20' align='absmiddle'/> <img class='emoji' title=':metal:' alt=':metal:' src='https://ello-stage2.herokuapp.com/images/emoji/metal.png' height='20' width='20' align='absmiddle'/> <img class='emoji' title=':skull:' alt=':skull:' src='https://ello-stage2.herokuapp.com/images/emoji/unicode/1f480.png' height='20' width='20' align='absmiddle'/> <img class='emoji' title=':metal:' alt=':metal:' src='https://ello-stage2.herokuapp.com/images/emoji/metal.png' height='20' width='20' align='absmiddle'/> :</p>",
+			"external_links_list": [{
+				"url": "http://github.com/rynbyjn",
+				"text": "github.com/rynbyjn",
+				"type": "github",
+				"icon": "https://social-icons.ello.co/github.png"
+			}, {
+				"url": "http://soundcloud.com/18-squeeler",
+				"text": "soundcloud.com/18-squeeler",
+				"type": "soundcloud",
+				"icon": "https://social-icons.ello.co/soundcloud.png"
+			}],
+			"background_position": "50% 50%",
+			"avatar": {
+				"original": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/9/ello-dfc11f00-0eea-4660-b089-8d554a0f4d0a.jpeg"
+				},
+				"large": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/9/ello-large-da2278c1.png",
+					"metadata": {
+						"size": 238273,
+						"type": "image/png",
+						"width": 360,
+						"height": 360
+					}
+				},
+				"regular": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/9/ello-regular-da2278c1.png",
+					"metadata": {
+						"size": 29608,
+						"type": "image/png",
+						"width": 120,
+						"height": 120
+					}
+				},
+				"small": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/9/ello-small-da2278c1.png",
+					"metadata": {
+						"size": 8467,
+						"type": "image/png",
+						"width": 60,
+						"height": 60
+					}
+				}
+			},
+			"cover_image": {
+				"original": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/9/ello-c831a0ee-d39a-40af-b643-ebab71c98158.jpeg"
+				},
+				"optimized": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/9/ello-optimized-e74d1b6d.jpg",
+					"metadata": {
+						"size": 114467,
+						"type": "image/jpeg",
+						"width": 680,
+						"height": 453
+					}
+				},
+				"xhdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/9/ello-xhdpi-e74d1b6d.jpg",
+					"metadata": {
+						"size": 111009,
+						"type": "image/jpeg",
+						"width": 680,
+						"height": 453
+					}
+				},
+				"hdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/9/ello-hdpi-e74d1b6d.jpg",
+					"metadata": {
+						"size": 105798,
+						"type": "image/jpeg",
+						"width": 621,
+						"height": 414
+					}
+				},
+				"mdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/9/ello-mdpi-e74d1b6d.jpg",
+					"metadata": {
+						"size": 32152,
+						"type": "image/jpeg",
+						"width": 311,
+						"height": 207
+					}
+				},
+				"ldpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/9/ello-ldpi-e74d1b6d.jpg",
+					"metadata": {
+						"size": 9776,
+						"type": "image/jpeg",
+						"width": 149,
+						"height": 99
+					}
+				}
+			}
+		}, {
+			"id": "27",
+			"href": "/api/v2/users/27",
+			"username": "dcdoran",
+			"name": "Casey Doran",
+			"location": null,
+			"posts_adult_content": false,
+			"views_adult_content": true,
+			"has_commenting_enabled": true,
+			"has_sharing_enabled": true,
+			"has_reposting_enabled": true,
+			"has_loves_enabled": true,
+			"has_auto_watch_enabled": true,
+			"experimental_features": true,
+			"relationship_priority": null,
+			"bad_for_seo": false,
+			"is_hireable": false,
+			"is_collaborateable": false,
+			"posts_count": 219,
+			"followers_count": 126,
+			"following_count": 43,
+			"loves_count": 20,
+			"formatted_short_bio": "<p>bio bio bio bio</p>",
+			"external_links_list": [{
+				"url": "http://twitter.com/dcdoran",
+				"text": "twitter.com/dcdoran",
+				"type": "twitter",
+				"icon": "https://social-icons.ello.co/twitter.png"
+			}],
+			"background_position": "50% 50%",
+			"avatar": {
+				"original": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/27/ello-28543c9f-06bc-444e-98db-909aa8890017.jpeg"
+				},
+				"large": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/27/ello-large-e2cfacc2.png",
+					"metadata": {
+						"size": 127069,
+						"type": "image/png",
+						"width": 360,
+						"height": 360
+					}
+				},
+				"regular": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/27/ello-regular-e2cfacc2.png",
+					"metadata": {
+						"size": 18516,
+						"type": "image/png",
+						"width": 120,
+						"height": 120
+					}
+				},
+				"small": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/avatar/27/ello-small-e2cfacc2.png",
+					"metadata": {
+						"size": 5996,
+						"type": "image/png",
+						"width": 60,
+						"height": 60
+					}
+				}
+			},
+			"cover_image": {
+				"original": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/27/ello-2e54b943-4d2d-4329-ae65-b3c3ca53fb31.jpeg"
+				},
+				"optimized": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/27/ello-optimized-809906f0.jpg",
+					"metadata": {
+						"size": 1584915,
+						"type": "image/jpeg",
+						"width": 1920,
+						"height": 1440
+					}
+				},
+				"xhdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/27/ello-xhdpi-809906f0.jpg",
+					"metadata": {
+						"size": 577955,
+						"type": "image/jpeg",
+						"width": 1116,
+						"height": 837
+					}
+				},
+				"hdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/27/ello-hdpi-809906f0.jpg",
+					"metadata": {
+						"size": 144840,
+						"type": "image/jpeg",
+						"width": 552,
+						"height": 414
+					}
+				},
+				"mdpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/27/ello-mdpi-809906f0.jpg",
+					"metadata": {
+						"size": 41863,
+						"type": "image/jpeg",
+						"width": 276,
+						"height": 207
+					}
+				},
+				"ldpi": {
+					"url": "https://d1qqdyhbrvi5gr.cloudfront.net/uploads/user/cover_image/27/ello-ldpi-809906f0.jpg",
+					"metadata": {
+						"size": 12005,
+						"type": "image/jpeg",
+						"width": 132,
+						"height": 99
+					}
+				}
+			}
+		}]
+	}
+}

--- a/Sources/Controllers/App/AppViewController.swift
+++ b/Sources/Controllers/App/AppViewController.swift
@@ -460,12 +460,6 @@ extension AppViewController {
              .DiscoverTrending,
              .Category:
             showCategoryScreen(data)
-//            if let nav = vc.selectedViewController as? UINavigationController,
-//                discoverViewController = nav.childViewControllers[0] as? DiscoverViewController
-//            {
-//                nav.popToRootViewControllerAnimated(false)
-//                discoverViewController.showCategory(data)
-//            }
         case .Invitations:
             showInvitationScreen(vc)
         case .Enter, .Exit, .Root, .Explore:

--- a/Sources/Controllers/App/AppViewController.swift
+++ b/Sources/Controllers/App/AppViewController.swift
@@ -451,9 +451,9 @@ extension AppViewController {
         case .ExploreRecommended,
              .ExploreRecent,
              .ExploreTrending:
-            showDiscoverScreen(vc)
+            showDiscoverScreen()
         case .Discover:
-            showDiscoverScreen(vc)
+            showDiscoverScreen()
         case .DiscoverRandom,
              .DiscoverRecent,
              .DiscoverRelated,
@@ -535,14 +535,16 @@ extension AppViewController {
     }
 
     private func showInvitationScreen(vc: ElloTabBarController) {
-        showDiscoverScreen(vc)
+        vc.selectedTab = .Discover
 
         let responder = targetForAction(#selector(InviteResponder.onInviteFriends), withSender: self) as? InviteResponder
         responder?.onInviteFriends()
     }
 
-    private func showDiscoverScreen(vc: ElloTabBarController) {
-        vc.selectedTab = .Discover
+    private func showDiscoverScreen() {
+        let vc = DiscoverAllCategoriesViewController()
+        vc.currentUser = currentUser
+        pushDeepLinkViewController(vc)
     }
 
     private func showCategoryScreen(slug: String) {

--- a/Sources/Controllers/BaseElloViewController.swift
+++ b/Sources/Controllers/BaseElloViewController.swift
@@ -56,6 +56,13 @@ public class BaseElloViewController: UIViewController, ControllerThatMightHaveTh
         return false
     }
 
+    func alreadyOnCategory(slug: String) -> Bool {
+        if let categoryVC = navigationController?.topViewController as? CategoryViewController {
+            return slug == categoryVC.slug
+        }
+        return false
+    }
+
     func alreadyOnUserProfile(userParam: String) -> Bool {
         if let profileVC = self.navigationController?.topViewController as? ProfileViewController {
             return userParam == profileVC.userParam

--- a/Sources/Controllers/BaseElloViewController.swift
+++ b/Sources/Controllers/BaseElloViewController.swift
@@ -56,7 +56,7 @@ public class BaseElloViewController: UIViewController, ControllerThatMightHaveTh
         return false
     }
 
-    func alreadyOnCategory(slug: String) -> Bool {
+    func alreadyOnCurrentCategory(slug: String) -> Bool {
         if let categoryVC = navigationController?.topViewController as? CategoryViewController {
             return slug == categoryVC.slug
         }

--- a/Sources/Controllers/Categories/CategoryViewController.swift
+++ b/Sources/Controllers/Categories/CategoryViewController.swift
@@ -18,9 +18,10 @@ public final class CategoryViewController: StreamableViewController {
     var generator: CategoryGenerator?
     var userDidScroll: Bool = false
 
-    public init(slug: String) {
+    public init(slug: String, name: String? = nil) {
         self.slug = slug
         super.init(nibName: nil, bundle: nil)
+        self.title = name
     }
 
     required public init?(coder aDecoder: NSCoder) {
@@ -28,7 +29,7 @@ public final class CategoryViewController: StreamableViewController {
     }
 
     override public func loadView() {
-        self.title = category?.name ?? slug.uppercaseFirst
+        self.title = category?.name ?? DiscoverType.fromURL(slug)?.name
         elloNavigationItem.title = title
         let item = UIBarButtonItem.backChevronWithTarget(self, action: #selector(backTapped(_:)))
         elloNavigationItem.leftBarButtonItems = [item]

--- a/Sources/Controllers/Categories/CategoryViewController.swift
+++ b/Sources/Controllers/Categories/CategoryViewController.swift
@@ -28,7 +28,7 @@ public final class CategoryViewController: StreamableViewController {
     }
 
     override public func loadView() {
-        self.title = category?.name
+        self.title = category?.name ?? slug.uppercaseFirst
         elloNavigationItem.title = title
         let item = UIBarButtonItem.backChevronWithTarget(self, action: #selector(backTapped(_:)))
         elloNavigationItem.leftBarButtonItems = [item]
@@ -205,14 +205,26 @@ extension CategoryViewController: CategoryStreamDestination, StreamDestination {
 
 extension CategoryViewController: CategoryScreenDelegate {
 
+    public func selectCategoryForSlug(slug: String) {
+        guard let category = categoryForSlug(slug) else { return }
+        selectCatgory(category)
+    }
+
+    private func categoryForSlug(slug: String) -> Category? {
+        return allCategories.filter { $0.slug == slug }.first
+    }
+
     public func categorySelected(index: Int) {
         guard
             let category = allCategories.safeValue(index)
         where category.id != self.category?.id
         else { return }
 
-        Tracker.sharedTracker.categoryOpened(category.slug)
+        selectCatgory(category)
+    }
 
+    public func selectCatgory(category: Category) {
+		Tracker.sharedTracker.categoryOpened(category.slug)
         let streamKind: StreamKind
         switch category.level {
         case .Meta:
@@ -224,6 +236,8 @@ extension CategoryViewController: CategoryScreenDelegate {
         streamViewController.streamKind = streamKind
         generator?.reset(streamKind: streamKind, category: category, pagePromotional: nil)
         self.category = category
+        self.slug = category.slug
+        self.title = category.name
         reloadEntireCategory()
     }
 }

--- a/Sources/Controllers/Categories/CategoryViewController.swift
+++ b/Sources/Controllers/Categories/CategoryViewController.swift
@@ -211,7 +211,7 @@ extension CategoryViewController: CategoryScreenDelegate {
     }
 
     private func categoryForSlug(slug: String) -> Category? {
-        return allCategories.filter { $0.slug == slug }.first
+        return allCategories.find { $0.slug == slug }
     }
 
     public func categorySelected(index: Int) {

--- a/Sources/Controllers/Discover/DiscoverAllCategoriesViewController.swift
+++ b/Sources/Controllers/Discover/DiscoverAllCategoriesViewController.swift
@@ -23,6 +23,13 @@ public class DiscoverAllCategoriesViewController: StreamableViewController {
     }
 
     override public func loadView() {
+
+        if !isRootViewController() {
+            let item = UIBarButtonItem.backChevronWithTarget(self, action: #selector(backTapped(_:)))
+            self.elloNavigationItem.leftBarButtonItems = [item]
+            self.elloNavigationItem.fixNavBarItemPadding()
+        }
+
         title = InterfaceString.Discover.Title
         elloNavigationItem.title = title
 

--- a/Sources/Controllers/Profile/Categories/ProfileCategoriesViewController.swift
+++ b/Sources/Controllers/Profile/Categories/ProfileCategoriesViewController.swift
@@ -41,8 +41,8 @@ extension ProfileCategoriesViewController: UIViewControllerTransitioningDelegate
 extension ProfileCategoriesViewController: ProfileCategoriesDelegate {
 
     public func categoryTapped(category: Category) {
-        Tracker.sharedTracker.categoryOpened(category.slug)
-        let vc = CategoryViewController(slug: category.slug)
+		Tracker.sharedTracker.categoryOpened(category.slug)
+        let vc = CategoryViewController(slug: category.slug, name: category.name)
         vc.currentUser = currentUser
 
         navigationController?.pushViewController(vc, animated: true)

--- a/Sources/Controllers/Stream/Cells/CategoryListCell.swift
+++ b/Sources/Controllers/Stream/Cells/CategoryListCell.swift
@@ -25,11 +25,11 @@ public class CategoryListCell: UICollectionViewCell {
         }
     }
 
-    private var buttonCategoryLookup: [UIButton: String] = [:]
+    private var buttonCategoryLookup: [UIButton: CategoryInfo] = [:]
     private var categoryButtons: [UIButton] = []
 
     private class func buttonTitle(category: String) -> NSAttributedString {
-        var attrs: [String: AnyObject] = [
+        let attrs: [String: AnyObject] = [
             NSFontAttributeName: UIFont.defaultFont(),
             NSForegroundColorAttributeName: UIColor.blackColor()
         ]
@@ -65,8 +65,8 @@ public class CategoryListCell: UICollectionViewCell {
 
     @objc
     func categoryButtonTapped(button: UIButton) {
-        guard let slug = buttonCategoryLookup[button] else { return }
-        delegate?.categoryListCellTapped(slug: slug)
+        guard let categoryInfo = buttonCategoryLookup[button] else { return }
+        delegate?.categoryListCellTapped(slug: categoryInfo.slug, name: categoryInfo.title)
     }
 
     private func updateCategoryViews() {
@@ -75,12 +75,12 @@ public class CategoryListCell: UICollectionViewCell {
         }
         buttonCategoryLookup = [:]
 
-        categoryButtons = categoriesInfo.map { (category, slug) in
+        categoryButtons = categoriesInfo.map { categoryInfo in
             let button = UIButton()
-            buttonCategoryLookup[button] = slug
+            buttonCategoryLookup[button] = categoryInfo
             button.backgroundColor = .greyF2()
             button.addTarget(self, action: #selector(categoryButtonTapped(_:)), forControlEvents: .TouchUpInside)
-            let attributedString = CategoryListCell.buttonTitle(category)
+            let attributedString = CategoryListCell.buttonTitle(categoryInfo.title)
             button.setAttributedTitle(attributedString, forState: UIControlState.Normal)
 
             return button

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -1015,10 +1015,15 @@ extension StreamViewController: WebLinkDelegate {
     }
 
     private func showCategory(slug: String) {
-        if alreadyOnCategory(slug) { return }
-        let vc = CategoryViewController(slug: slug)
-        vc.currentUser = ElloWebBrowserViewController.currentUser
-        navigationController?.pushViewController(vc, animated: true)
+        if alreadyOnCurrentCategory(slug) { return }
+        if let categoryVC = navigationController?.topViewController as? CategoryViewController {
+            categoryVC.selectCategoryForSlug(slug)
+        }
+        else {
+            let vc = CategoryViewController(slug: slug)
+            vc.currentUser = ElloWebBrowserViewController.currentUser
+            navigationController?.pushViewController(vc, animated: true)
+        }
     }
 
     private func showProfile(username: String) {

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -983,8 +983,9 @@ extension StreamViewController: WebLinkDelegate {
              .WhoMadeThis,
              .WTF:
             postNotification(ExternalWebNotification, value: data)
+        case .Discover:
+            self.selectTab(.Discover)
         case .Category,
-             .Discover,
              .DiscoverRandom,
              .DiscoverRecent,
              .DiscoverRelated,

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -61,7 +61,7 @@ public protocol ColumnToggleDelegate: class {
 }
 
 public protocol CategoryListCellDelegate: class {
-    func categoryListCellTapped(slug slug: String)
+    func categoryListCellTapped(slug slug: String, name: String)
 }
 
 public protocol SearchStreamDelegate: class {
@@ -729,8 +729,8 @@ extension StreamViewController: ColumnToggleDelegate {
 // MARK: StreamViewController: CategoryListCellDelegate
 extension StreamViewController: CategoryListCellDelegate {
 
-    public func categoryListCellTapped(slug slug: String) {
-        showCategoryController(slug: slug)
+    public func categoryListCellTapped(slug slug: String, name: String) {
+        showCategoryViewController(slug: slug, name: name)
     }
 
 }
@@ -877,8 +877,12 @@ extension StreamViewController {
 extension StreamViewController {
 
     public func categoryTapped(category: Category) {
-		Tracker.sharedTracker.categoryOpened(slug)
-        let vc = CategoryViewController(slug: category.slug, name: category.name)
+        showCategoryViewController(slug: category.slug, name: category.name)
+    }
+
+    public func showCategoryViewController(slug slug: String, name: String) {
+        Tracker.sharedTracker.categoryOpened(slug)
+        let vc = CategoryViewController(slug: slug, name: name)
         vc.currentUser = currentUser
         navigationController?.pushViewController(vc, animated: true)
     }
@@ -894,7 +898,7 @@ extension StreamViewController: CategoryDelegate {
             category = post.category
         else { return }
 
-        showCategoryController(slug: category.slug)
+        categoryTapped(category)
     }
 }
 
@@ -983,7 +987,7 @@ extension StreamViewController: WebLinkDelegate {
              .WTF:
             postNotification(ExternalWebNotification, value: data)
         case .Discover:
-            self.selectTab(.Discover)
+            self.showDiscover()
         case .Category,
              .DiscoverRandom,
              .DiscoverRecent,
@@ -1012,6 +1016,14 @@ extension StreamViewController: WebLinkDelegate {
         case .Search: showSearch(data)
         case .Settings: showSettings()
         }
+    }
+
+    private func showDiscover() {
+        if navigationController?.topViewController is DiscoverAllCategoriesViewController { return }
+
+        let vc = DiscoverAllCategoriesViewController()
+        vc.currentUser = ElloWebBrowserViewController.currentUser
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     private func showCategory(slug: String) {
@@ -1141,7 +1153,7 @@ extension StreamViewController: UICollectionViewDelegate {
                 selectedCategoryDelegate?.categoriesSelectionChanged(selection ?? [Category]())
             }
             else {
-                showCategoryController(slug: category.slug)
+                showCategoryViewController(slug: category.slug, name: category.name)
             }
         }
 

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -876,9 +876,9 @@ extension StreamViewController {
 // MARK: StreamViewController: Open category
 extension StreamViewController {
 
-    public func showCategoryController(slug slug: String) {
-        Tracker.sharedTracker.categoryOpened(slug)
-        let vc = CategoryViewController(slug: slug)
+    public func categoryTapped(category: Category) {
+		Tracker.sharedTracker.categoryOpened(slug)
+        let vc = CategoryViewController(slug: category.slug, name: category.name)
         vc.currentUser = currentUser
         navigationController?.pushViewController(vc, animated: true)
     }

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -951,6 +951,7 @@ extension StreamViewController: UserDelegate {
 extension StreamViewController: WebLinkDelegate {
 
     public func webLinkTapped(type: ElloURI, data: String) {
+        print(type)
         switch type {
         case .Confirm,
              .FaceMaker,
@@ -982,7 +983,8 @@ extension StreamViewController: WebLinkDelegate {
              .WhoMadeThis,
              .WTF:
             postNotification(ExternalWebNotification, value: data)
-        case .Discover,
+        case .Category,
+             .Discover,
              .DiscoverRandom,
              .DiscoverRecent,
              .DiscoverRelated,
@@ -990,16 +992,7 @@ extension StreamViewController: WebLinkDelegate {
              .ExploreRecommended,
              .ExploreRecent,
              .ExploreTrending:
-            selectTab(.Discover)
-        case .Category:
-            selectTab(.Discover)
-            // TODO: wire category and discover up to the new category view controller
-//            if let nav = elloTabBarController?.selectedViewController as? UINavigationController,
-//                discoverViewController = nav.childViewControllers[0] as? DiscoverViewController
-//            {
-//                nav.popToRootViewControllerAnimated(false)
-//                discoverViewController.showCategory(data)
-//            }
+            showCategory(data)
         case .Email: break // this is handled in ElloWebViewHelper
         case .BetaPublicProfiles,
              .Enter,
@@ -1019,6 +1012,13 @@ extension StreamViewController: WebLinkDelegate {
         case .Search: showSearch(data)
         case .Settings: showSettings()
         }
+    }
+
+    private func showCategory(slug: String) {
+        if alreadyOnCategory(slug) { return }
+        let vc = CategoryViewController(slug: slug)
+        vc.currentUser = ElloWebBrowserViewController.currentUser
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     private func showProfile(username: String) {

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -951,7 +951,6 @@ extension StreamViewController: UserDelegate {
 extension StreamViewController: WebLinkDelegate {
 
     public func webLinkTapped(type: ElloURI, data: String) {
-        print(type)
         switch type {
         case .Confirm,
              .FaceMaker,

--- a/Sources/Controllers/WebBrowser/ElloWebBrowserViewController.swift
+++ b/Sources/Controllers/WebBrowser/ElloWebBrowserViewController.swift
@@ -129,7 +129,8 @@ extension ElloWebBrowserViewController : WebLinkDelegate {
              .WhoMadeThis,
              .WTF:
             break // this is handled in ElloWebViewHelper/KINWebBrowserViewController
-        case .Discover,
+        case .Category,
+             .Discover,
              .DiscoverRandom,
              .DiscoverRecent,
              .DiscoverRelated,
@@ -137,9 +138,7 @@ extension ElloWebBrowserViewController : WebLinkDelegate {
              .ExploreRecommended,
              .ExploreRecent,
              .ExploreTrending:
-            self.selectTab(.Discover)
-        case .Category:
-            self.selectTab(.Discover)
+            self.showCategory(data)
         case .BetaPublicProfiles,
              .Enter,
              .Exit,
@@ -162,6 +161,13 @@ extension ElloWebBrowserViewController : WebLinkDelegate {
         case .Search: showSearch(data)
         case .Settings: self.showSettings()
         }
+    }
+
+    private func showCategory(slug: String) {
+        if alreadyOnCategory(slug) { return }
+        let vc = CategoryViewController(slug: slug)
+        vc.currentUser = ElloWebBrowserViewController.currentUser
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     private func showProfile(username: String) {
@@ -198,6 +204,13 @@ extension ElloWebBrowserViewController : WebLinkDelegate {
         navigationController?.dismissViewControllerAnimated(true) {
             ElloWebBrowserViewController.elloTabBarController?.selectedTab = tab
         }
+    }
+
+    func alreadyOnCategory(slug: String) -> Bool {
+        if let categoryVC = navigationController?.topViewController as? CategoryViewController {
+            return slug == categoryVC.slug
+        }
+        return false
     }
 
     func alreadyOnUserProfile(userParam: String) -> Bool {

--- a/Sources/Controllers/WebBrowser/ElloWebBrowserViewController.swift
+++ b/Sources/Controllers/WebBrowser/ElloWebBrowserViewController.swift
@@ -130,7 +130,7 @@ extension ElloWebBrowserViewController : WebLinkDelegate {
              .WTF:
             break // this is handled in ElloWebViewHelper/KINWebBrowserViewController
         case .Discover:
-            self.selectTab(.Discover)
+            self.showDiscover()
         case .Category,
              .DiscoverRandom,
              .DiscoverRecent,
@@ -162,6 +162,14 @@ extension ElloWebBrowserViewController : WebLinkDelegate {
         case .Search: showSearch(data)
         case .Settings: self.showSettings()
         }
+    }
+
+    private func showDiscover() {
+        if navigationController?.topViewController is DiscoverAllCategoriesViewController { return }
+
+        let vc = DiscoverAllCategoriesViewController()
+        vc.currentUser = ElloWebBrowserViewController.currentUser
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     private func showCategory(slug: String) {

--- a/Sources/Controllers/WebBrowser/ElloWebBrowserViewController.swift
+++ b/Sources/Controllers/WebBrowser/ElloWebBrowserViewController.swift
@@ -129,8 +129,9 @@ extension ElloWebBrowserViewController : WebLinkDelegate {
              .WhoMadeThis,
              .WTF:
             break // this is handled in ElloWebViewHelper/KINWebBrowserViewController
+        case .Discover:
+            self.selectTab(.Discover)
         case .Category,
-             .Discover,
              .DiscoverRandom,
              .DiscoverRecent,
              .DiscoverRelated,

--- a/Sources/Controllers/WebBrowser/ElloWebBrowserViewController.swift
+++ b/Sources/Controllers/WebBrowser/ElloWebBrowserViewController.swift
@@ -164,10 +164,15 @@ extension ElloWebBrowserViewController : WebLinkDelegate {
     }
 
     private func showCategory(slug: String) {
-        if alreadyOnCategory(slug) { return }
-        let vc = CategoryViewController(slug: slug)
-        vc.currentUser = ElloWebBrowserViewController.currentUser
-        navigationController?.pushViewController(vc, animated: true)
+        if alreadyOnCurrentCategory(slug) { return }
+        if let categoryVC = navigationController?.topViewController as? CategoryViewController {
+            categoryVC.selectCategoryForSlug(slug)
+        }
+        else {
+            let vc = CategoryViewController(slug: slug)
+            vc.currentUser = ElloWebBrowserViewController.currentUser
+            navigationController?.pushViewController(vc, animated: true)
+        }
     }
 
     private func showProfile(username: String) {
@@ -206,7 +211,7 @@ extension ElloWebBrowserViewController : WebLinkDelegate {
         }
     }
 
-    func alreadyOnCategory(slug: String) -> Bool {
+    func alreadyOnCurrentCategory(slug: String) -> Bool {
         if let categoryVC = navigationController?.topViewController as? CategoryViewController {
             return slug == categoryVC.slug
         }

--- a/Sources/Extensions/StringExtensions.swift
+++ b/Sources/Extensions/StringExtensions.swift
@@ -395,4 +395,16 @@ public extension String {
         capSplits.replaceRange(0..<1, with: [splits.first ?? ""])
         return capSplits.joinWithSeparator("")
     }
+
+    var first: String {
+        return String(characters.prefix(1))
+    }
+
+    var last: String {
+        return String(characters.suffix(1))
+    }
+
+    var uppercaseFirst: String {
+        return first.uppercaseString + String(characters.dropFirst())
+    }
 }

--- a/Sources/Networking/ElloAPI.swift
+++ b/Sources/Networking/ElloAPI.swift
@@ -421,7 +421,7 @@ extension ElloAPI: Moya.TargetType {
         case .Categories:
             return stubbedData("categories")
         case .Category:
-            return stubbedData("categories")
+            return stubbedData("category")
         case .DeleteComment,
              .DeleteLove,
              .DeletePost,

--- a/Specs/Controllers/Categories/CategoryGeneratorSpec.swift
+++ b/Specs/Controllers/Categories/CategoryGeneratorSpec.swift
@@ -75,7 +75,7 @@ class CategoryGeneratorSpec: QuickSpec {
                         expect(destination.placeholderItems.count) == 2
                     }
 
-                    it("replaces only CatgoryHeader and CategoryPosts") {
+                    it("replaces only CategoryHeader and CategoryPosts") {
                         subject.load()
                         expect(destination.headerItems.count) > 0
                         expect(destination.postItems.count) > 0

--- a/Specs/Controllers/Categories/CategoryGeneratorSpec.swift
+++ b/Specs/Controllers/Categories/CategoryGeneratorSpec.swift
@@ -60,7 +60,7 @@ class CategoryGeneratorSpec: QuickSpec {
             }
 
             context("category") {
-                let category = Ello.Category.stub(["level" : "primary"])
+                let category = Ello.Category.stub(["level" : "primary", "slug" : "art"])
                 let subject = CategoryGenerator(
                     slug: category.slug,
                     currentUser: currentUser,

--- a/Specs/Controllers/Stream/Cells/CategoryListCellSpec.swift
+++ b/Specs/Controllers/Stream/Cells/CategoryListCellSpec.swift
@@ -12,10 +12,12 @@ class CategoryListCellSpec: QuickSpec {
     class Delegate: CategoryListCellDelegate {
         var categoryTapped = false
         var slug: String?
+        var name: String?
 
-        func categoryListCellTapped(slug slug: String) {
+        func categoryListCellTapped(slug slug: String, name: String) {
             categoryTapped = true
             self.slug = slug
+            self.name = name
         }
     }
 


### PR DESCRIPTION
Deep linking to the new Category screens is setup. We may need to change this behavior pending feedback from Product but it at least functional.

The large number of lines is deceiving. Most of them come from `category.json`. Specs should pass this go around. 