### PR TITLE
Adds Tracking events to category/category headers

### DIFF
--- a/Sources/Controllers/App/AppViewController.swift
+++ b/Sources/Controllers/App/AppViewController.swift
@@ -552,6 +552,7 @@ extension AppViewController {
     }
 
     private func showCategoryScreen(slug: String) {
+        Tracker.sharedTracker.categoryOpened(slug)
         let vc = CategoryViewController(slug: slug)
         vc.currentUser = currentUser
         pushDeepLinkViewController(vc)

--- a/Sources/Controllers/Categories/CategoryViewController.swift
+++ b/Sources/Controllers/Categories/CategoryViewController.swift
@@ -211,6 +211,8 @@ extension CategoryViewController: CategoryScreenDelegate {
         where category.id != self.category?.id
         else { return }
 
+        Tracker.sharedTracker.categoryOpened(category.slug)
+
         let streamKind: StreamKind
         switch category.level {
         case .Meta:

--- a/Sources/Controllers/Onboarding/CategoriesSelectionViewController.swift
+++ b/Sources/Controllers/Onboarding/CategoriesSelectionViewController.swift
@@ -66,7 +66,7 @@ extension CategoriesSelectionViewController: OnboardingStepController {
         if selectedCategories.count > 0 {
             let categories = self.selectedCategories
             for category in categories {
-                Tracker.sharedTracker.categorySelected(category)
+                Tracker.sharedTracker.onboardingCategorySelected(category)
             }
 
             UserService().setUserCategories(categories)

--- a/Sources/Controllers/Profile/Categories/ProfileCategoriesViewController.swift
+++ b/Sources/Controllers/Profile/Categories/ProfileCategoriesViewController.swift
@@ -41,7 +41,7 @@ extension ProfileCategoriesViewController: UIViewControllerTransitioningDelegate
 extension ProfileCategoriesViewController: ProfileCategoriesDelegate {
 
     public func categoryTapped(category: Category) {
-        Tracker.sharedTracker.categoryOpened(categoryOpened.slug)
+        Tracker.sharedTracker.categoryOpened(category.slug)
         let vc = CategoryViewController(slug: category.slug)
         vc.currentUser = currentUser
 

--- a/Sources/Controllers/Profile/Categories/ProfileCategoriesViewController.swift
+++ b/Sources/Controllers/Profile/Categories/ProfileCategoriesViewController.swift
@@ -41,6 +41,7 @@ extension ProfileCategoriesViewController: UIViewControllerTransitioningDelegate
 extension ProfileCategoriesViewController: ProfileCategoriesDelegate {
 
     public func categoryTapped(category: Category) {
+        Tracker.sharedTracker.categoryOpened(categoryOpened.slug)
         let vc = CategoryViewController(slug: category.slug)
         vc.currentUser = currentUser
 

--- a/Sources/Controllers/Stream/Cells/CategoryHeaderCell.swift
+++ b/Sources/Controllers/Stream/Cells/CategoryHeaderCell.swift
@@ -29,6 +29,7 @@ public class CategoryHeaderCell: UICollectionViewCell {
         public init(style: Style) {
             self.style = style
             self.title = ""
+            self.tracking = ""
         }
     }
 

--- a/Sources/Controllers/Stream/Cells/CategoryHeaderCell.swift
+++ b/Sources/Controllers/Stream/Cells/CategoryHeaderCell.swift
@@ -18,6 +18,7 @@ public class CategoryHeaderCell: UICollectionViewCell {
     public struct Config {
         var style: Style
         var title: String
+        var tracking: String
         var body: String?
         var imageURL: NSURL?
         var user: User?
@@ -171,11 +172,13 @@ public class CategoryHeaderCell: UICollectionViewCell {
     }
 
     public func postedByTapped() {
+        Tracker.sharedTracker.categoryHeaderPostedBy(config.tracking)
         userDelegate?.userTappedAuthor(self)
     }
 
     public func callToActionTapped() {
         guard let url = callToActionURL else { return }
+        Tracker.sharedTracker.categoryHeaderCallToAction(config.tracking)
         let request = NSURLRequest(URL: url)
         ElloWebViewHelper.handleRequest(request, webLinkDelegate: webLinkDelegate)
     }
@@ -367,6 +370,7 @@ extension CategoryHeaderCell.Config {
         self.init(style: .Category)
         title = category.name
         body = category.body
+        tracking = category.slug
         isSponsored = category.isSponsored
         callToAction = category.ctaCaption
         callToActionURL = category.ctaURL
@@ -382,6 +386,7 @@ extension CategoryHeaderCell.Config {
 
         title = pagePromotional.header
         body = pagePromotional.subheader
+        tracking = "general"
         imageURL = pagePromotional.tileURL
         user = pagePromotional.user
         callToAction = pagePromotional.ctaCaption

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -877,8 +877,8 @@ extension StreamViewController {
 extension StreamViewController {
 
     public func showCategoryController(slug slug: String) {
-        let vc = CategoryViewController(slug: slug)
         Tracker.sharedTracker.categoryOpened(slug)
+        let vc = CategoryViewController(slug: slug)
         vc.currentUser = currentUser
         navigationController?.pushViewController(vc, animated: true)
     }

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -730,9 +730,7 @@ extension StreamViewController: ColumnToggleDelegate {
 extension StreamViewController: CategoryListCellDelegate {
 
     public func categoryListCellTapped(slug slug: String) {
-        let vc = CategoryViewController(slug: slug)
-        vc.currentUser = currentUser
-        navigationController?.pushViewController(vc, animated: true)
+        showCategoryController(slug: slug)
     }
 
 }
@@ -878,8 +876,9 @@ extension StreamViewController {
 // MARK: StreamViewController: Open category
 extension StreamViewController {
 
-    public func categoryTapped(category: Category) {
-        let vc = CategoryViewController(slug: category.slug)
+    public func showCategoryController(slug slug: String) {
+        let vc = CategoryViewController(slug: slug)
+        Tracker.sharedTracker.categoryOpened(slug)
         vc.currentUser = currentUser
         navigationController?.pushViewController(vc, animated: true)
     }
@@ -895,7 +894,7 @@ extension StreamViewController: CategoryDelegate {
             category = post.category
         else { return }
 
-        categoryTapped(category)
+        showCategoryController(slug: category.slug)
     }
 }
 
@@ -1137,7 +1136,7 @@ extension StreamViewController: UICollectionViewDelegate {
                 selectedCategoryDelegate?.categoriesSelectionChanged(selection ?? [Category]())
             }
             else {
-                categoryTapped(category)
+                showCategoryController(slug: category.slug)
             }
         }
 

--- a/Sources/Model/Tracker.swift
+++ b/Sources/Model/Tracker.swift
@@ -239,7 +239,7 @@ public extension Tracker {
         agent.track("completed categories in onboarding")
     }
 
-    func categorySelected(category: Category) {
+    func onboardingCategorySelected(category: Category) {
         agent.track("onboarding category chosen", properties: ["category": category.name])
     }
 

--- a/Sources/Model/Tracker.swift
+++ b/Sources/Model/Tracker.swift
@@ -300,18 +300,6 @@ public extension Tracker {
         screenAppeared(name, properties: props)
     }
 
-    func categoryOpened(categorySlug: String) {
-        agent.track("category opened", properties: ["category": categorySlug])
-    }
-
-    func categoryHeaderPostedBy(categoryTitle: String) {
-        agent.track("promoByline clicked", properties: ["category": categoryTitle])
-    }
-
-    func categoryHeaderCallToAction(categoryTitle: String) {
-        agent.track("promoCTA clicked", properties: ["category": categoryTitle])
-    }
-
     func screenAppeared(name: String, properties: [String: AnyObject]? = nil) {
         agent.screen(name, properties: properties)
     }
@@ -330,6 +318,18 @@ public extension Tracker {
 
     func postLoaded(id: String) {
         agent.track("Post Loaded", properties: ["id": id])
+    }
+
+    func categoryOpened(categorySlug: String) {
+        agent.track("category opened", properties: ["category": categorySlug])
+    }
+
+    func categoryHeaderPostedBy(categoryTitle: String) {
+        agent.track("promoByline clicked", properties: ["category": categoryTitle])
+    }
+
+    func categoryHeaderCallToAction(categoryTitle: String) {
+        agent.track("promoCTA clicked", properties: ["category": categoryTitle])
     }
 
     func viewedImage(asset: Asset, post: Post) {

--- a/Sources/Model/Tracker.swift
+++ b/Sources/Model/Tracker.swift
@@ -305,6 +305,14 @@ public extension Tracker {
         agent.track("DiscoverViewController category filter", properties: ["category": category])
     }
 
+    func categoryHeaderPostedBy(categoryTitle: String) {
+        agent.track("promoByline clicked", properties: ["category": categoryTitle])
+    }
+
+    func categoryHeaderCallToAction(categoryTitle: String) {
+        agent.track("promoCTA clicked", properties: ["category": categoryTitle])
+    }
+
     func screenAppeared(name: String, properties: [String: AnyObject]? = nil) {
         agent.screen(name, properties: properties)
     }

--- a/Sources/Model/Tracker.swift
+++ b/Sources/Model/Tracker.swift
@@ -300,9 +300,8 @@ public extension Tracker {
         screenAppeared(name, properties: props)
     }
 
-    // TODO: decide if this should be change to to the new CategorViewController
-    func discoverCategory(category: String) {
-        agent.track("DiscoverViewController category filter", properties: ["category": category])
+    func categoryOpened(categorySlug: String) {
+        agent.track("category opened", properties: ["category": categorySlug])
     }
 
     func categoryHeaderPostedBy(categoryTitle: String) {


### PR DESCRIPTION
Since "category opened" can also occur when tapping a `CategoryCardListView` button, there's a custom tracking event for that (`"category opened", {category: category.slug}`).