### PR TITLE
Hide pull-to-refresh while the category cards animate in

### DIFF
--- a/Sources/Controllers/Categories/CategoryProtocols.swift
+++ b/Sources/Controllers/Categories/CategoryProtocols.swift
@@ -5,7 +5,7 @@
 public protocol CategoryScreenProtocol: StreamableScreenProtocol {
     var topInsetView: UIView { get }
     var categoryCardsVisible: Bool { get }
-    func setCategoriesInfo(categoriesInfo: [CategoryCardListView.CategoryInfo], animated: Bool)
+    func setCategoriesInfo(categoriesInfo: [CategoryCardListView.CategoryInfo], animated: Bool, completion: ElloEmptyCompletion)
     func animateCategoriesList(navBarVisible navBarVisible: Bool)
     func scrollToCategoryIndex(index: Int)
     func selectCategoryIndex(index: Int)

--- a/Sources/Controllers/Categories/CategoryScreen.swift
+++ b/Sources/Controllers/Categories/CategoryScreen.swift
@@ -41,16 +41,19 @@ public class CategoryScreen: StreamableScreen, CategoryScreenProtocol {
         }
     }
 
-    public func setCategoriesInfo(newValue: [CategoryCardListView.CategoryInfo], animated: Bool) {
+    public func setCategoriesInfo(newValue: [CategoryCardListView.CategoryInfo], animated: Bool, completion: ElloEmptyCompletion) {
         categoryCardList.hidden = newValue.isEmpty
         categoryCardList.categoriesInfo = newValue
 
         if !categoryCardList.hidden && animated {
             let originalY = categoryCardList.frame.origin.y
             categoryCardList.frame.origin.y = -categoryCardList.frame.size.height
-            animate {
+            animate(completion: { _ in completion() }) {
                 self.categoryCardList.frame.origin.y = originalY
             }
+        }
+        else {
+            completion()
         }
     }
 

--- a/Sources/Controllers/Categories/CategoryViewController.swift
+++ b/Sources/Controllers/Categories/CategoryViewController.swift
@@ -71,7 +71,7 @@ public final class CategoryViewController: StreamableViewController {
     private func updateInsets() {
         updateInsets(navBar: screen.topInsetView, streamController: streamViewController)
 
-        if !userDidScroll && streamViewController.dataSource.visibleCellItems.count > 0 {
+        if !userDidScroll && screen.categoryCardsVisible {
             var offset: CGFloat = CategoryCardListView.Size.height
             if tabBarVisible() {
                 offset += ElloNavigationBar.Size.height
@@ -180,7 +180,12 @@ extension CategoryViewController: CategoryStreamDestination, StreamDestination {
         let info = allCategories.map { (category: Category) -> CategoryCardListView.CategoryInfo in
             return CategoryCardListView.CategoryInfo(title: category.name, imageURL: category.tileURL)
         }
-        screen.setCategoriesInfo(info, animated: shouldAnimate)
+
+        let pullToRefreshView = streamViewController.pullToRefreshView
+        pullToRefreshView?.hidden = true
+        screen.setCategoriesInfo(info, animated: shouldAnimate) {
+            pullToRefreshView?.hidden = false
+        }
 
         let selectedCategoryIndex = allCategories.indexOf { $0.slug == slug }
         if let selectedCategoryIndex = selectedCategoryIndex where shouldAnimate {

--- a/Specs/Controllers/Categories/CategoryScreenSpec.swift
+++ b/Specs/Controllers/Categories/CategoryScreenSpec.swift
@@ -29,7 +29,7 @@ class CategoryScreenSpec: QuickSpec {
                     imageURL: nil
                     )
                 subject = CategoryScreen()
-                subject.setCategoriesInfo([infoA, infoB, infoA, infoB], animated: false)
+                subject.setCategoriesInfo([infoA, infoB, infoA, infoB], animated: false, completion: {})
                 delegate = MockCategoryScreenDelegate()
                 subject.delegate = delegate
             }

--- a/Specs/Controllers/Categories/CategoryViewControllerSpec.swift
+++ b/Specs/Controllers/Categories/CategoryViewControllerSpec.swift
@@ -19,7 +19,7 @@ class CategoryViewControllerSpec: QuickSpec {
         var scrollTo: Int?
         var select: Int?
 
-        func setCategoriesInfo(categoriesInfo: [CategoryCardListView.CategoryInfo], animated: Bool) {
+        func setCategoriesInfo(categoriesInfo: [CategoryCardListView.CategoryInfo], animated: Bool, completion: ElloEmptyCompletion) {
             categoryTitles = categoriesInfo.map { $0.title }
         }
         func animateCategoriesList(navBarVisible navBarVisible: Bool) {}


### PR DESCRIPTION
Fixes the "double spinner" issue.