### PR TITLE
Adds AutoCompleteViewController to Settings when Location changes

### DIFF
--- a/Resources/Settings.storyboard
+++ b/Resources/Settings.storyboard
@@ -1,23 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Eqr-kF-k9D">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11761" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Eqr-kF-k9D">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
-        <mutableArray key="AtlasGroteskBold.otf">
+        <array key="AtlasGroteskBold.otf">
             <string>AtlasGrotesk-Bold</string>
-            <string>AtlasGrotesk-Bold</string>
-        </mutableArray>
-        <mutableArray key="AtlasGroteskRegular.otf">
+        </array>
+        <array key="AtlasGroteskRegular.otf">
             <string>AtlasGrotesk-Regular</string>
-            <string>AtlasGrotesk-Regular</string>
-            <string>AtlasGrotesk-Regular</string>
-            <string>AtlasGrotesk-Regular</string>
-            <string>AtlasGrotesk-Regular</string>
-            <string>AtlasGrotesk-Regular</string>
-        </mutableArray>
+        </array>
     </customFonts>
     <scenes>
         <!--Settings Container-->
@@ -40,13 +37,13 @@
                             </containerView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RTz-hl-55m" customClass="ElloNavigationBar" customModule="Ello" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="600" height="64"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="64" id="oW2-Fb-DDN"/>
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="centerX" secondItem="aiC-5l-KQt" secondAttribute="centerX" id="04f-eX-Pq7"/>
                             <constraint firstAttribute="centerX" secondItem="RTz-hl-55m" secondAttribute="centerX" id="TNQ-UU-lfX"/>
@@ -76,7 +73,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="bSl-xt-2XL">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="1500"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <sections>
                             <tableViewSection id="Syc-4t-DLC">
                                 <cells>
@@ -94,9 +91,9 @@
                                                     <rect key="frame" x="0.0" y="0.0" width="600" height="200"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="(tap to edit)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R8R-j4-bAe">
-                                                            <rect key="frame" x="261" y="93" width="78" height="14"/>
+                                                            <rect key="frame" x="261.5" y="93.5" width="78" height="14"/>
                                                             <fontDescription key="fontDescription" name="AtlasGrotesk-Regular" family="Atlas Grotesk" pointSize="14"/>
-                                                            <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
+                                                            <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                     </subviews>
@@ -143,13 +140,13 @@
                                                             <rect key="frame" x="0.0" y="0.0" width="200" height="195"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="(tap to edit)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="spU-yZ-sOq">
-                                                                    <rect key="frame" x="61" y="91" width="78" height="14"/>
+                                                                    <rect key="frame" x="61.5" y="91.5" width="78" height="14"/>
                                                                     <fontDescription key="fontDescription" name="AtlasGrotesk-Regular" family="Atlas Grotesk" pointSize="14"/>
-                                                                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
+                                                                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                             </subviews>
-                                                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.35000000000000003" colorSpace="calibratedRGB"/>
+                                                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.35000000000000003" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <gestureRecognizers/>
                                                             <constraints>
                                                                 <constraint firstAttribute="centerX" secondItem="spU-yZ-sOq" secondAttribute="centerX" id="gwQ-Nb-EQ7"/>
@@ -160,7 +157,7 @@
                                                             </connections>
                                                         </view>
                                                     </subviews>
-                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstItem="JlU-8X-cmD" firstAttribute="top" secondItem="yfC-cy-c0C" secondAttribute="top" id="1EY-bR-NM8"/>
                                                         <constraint firstAttribute="bottom" secondItem="bEB-3t-p7d" secondAttribute="bottom" id="2r0-ql-hpn"/>
@@ -177,7 +174,7 @@
                                                     <rect key="frame" x="534" y="18" width="51" height="32"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <state key="normal" title="Logout">
-                                                        <color key="titleColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                                        <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
                                                     <connections>
                                                         <action selector="logOutTapped" destination="co9-Rd-OXG" eventType="touchUpInside" id="3ba-Pw-sE1"/>
@@ -203,7 +200,7 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Profile" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fsS-Ce-3ei">
                                                     <rect key="frame" x="15" y="8" width="65" height="32"/>
                                                     <fontDescription key="fontDescription" name="AtlasGrotesk-Bold" family="Atlas Grotesk" pointSize="20"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your name, username, bio and links appear on your public profile. Your email address remains private." lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2YC-45-ipS" customClass="ElloLabel" customModule="Ello" customModuleProvider="target">
@@ -256,7 +253,7 @@
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qeu-Yg-Zbl" customClass="ElloTextFieldView" customModule="Ello" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="600" height="97"/>
-                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </view>
                                             </subviews>
                                             <constraints>
@@ -275,21 +272,21 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bio" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ByA-mg-wdp" customClass="ElloLabel" customModule="Ello" customModuleProvider="target">
-                                                    <rect key="frame" x="15" y="8" width="23" height="14"/>
+                                                    <rect key="frame" x="15" y="8" width="22.5" height="14"/>
                                                     <fontDescription key="fontDescription" name="AtlasGrotesk-Regular" family="Atlas Grotesk" pointSize="14"/>
-                                                    <color key="textColor" red="0.66666666669999997" green="0.66666666669999997" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="textColor" red="0.60271793603897095" green="0.602699875831604" blue="0.60271012783050537" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8GS-hA-vSR" customClass="ElloEditableTextView" customModule="Ello" customModuleProvider="target">
                                                     <rect key="frame" x="15" y="30" width="570" height="162"/>
-                                                    <color key="backgroundColor" red="0.89803921568627454" green="0.89803921568627454" blue="0.89803921568627454" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="backgroundColor" red="0.87326538562774658" green="0.87323927879333496" blue="0.87325406074523926" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <fontDescription key="fontDescription" name="AtlasGrotesk-Regular" family="Atlas Grotesk" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                 </textView>
                                                 <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3ws-k3-vsf" customClass="ElloErrorLabel" customModule="Ello" customModuleProvider="target">
-                                                    <rect key="frame" x="46" y="8" width="539" height="14"/>
+                                                    <rect key="frame" x="45.5" y="8" width="539.5" height="14"/>
                                                     <fontDescription key="fontDescription" name="AtlasGrotesk-Regular" family="Atlas Grotesk" pointSize="14"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="BRk-56-eVr">
@@ -324,7 +321,7 @@
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YkZ-N1-zPh" customClass="ElloTextFieldView" customModule="Ello" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="600" height="97"/>
-                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </view>
                                             </subviews>
                                             <constraints>
@@ -335,8 +332,28 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="97" id="ivQ-0G-t1M">
+                                        <rect key="frame" x="0.0" y="1241" width="600" height="97"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ivQ-0G-t1M" id="j6W-SJ-AVC">
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="97"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s8h-hd-0k4" customClass="ElloTextFieldView" customModule="Ello" customModuleProvider="target">
+                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="97"/>
+                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </view>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="s8h-hd-0k4" secondAttribute="bottom" id="59n-jZ-Z4Y"/>
+                                                <constraint firstItem="s8h-hd-0k4" firstAttribute="leading" secondItem="j6W-SJ-AVC" secondAttribute="leading" id="JnO-uA-2yL"/>
+                                                <constraint firstAttribute="trailing" secondItem="s8h-hd-0k4" secondAttribute="trailing" id="T16-Z8-vuy"/>
+                                                <constraint firstItem="s8h-hd-0k4" firstAttribute="top" secondItem="j6W-SJ-AVC" secondAttribute="top" id="kjU-gy-a8H"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="193" id="4rA-BX-V13">
-                                        <rect key="frame" x="0.0" y="1241" width="600" height="193"/>
+                                        <rect key="frame" x="0.0" y="1338" width="600" height="193"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="4rA-BX-V13" id="PzM-Ub-ryx">
                                             <rect key="frame" x="0.0" y="0.0" width="600" height="193"/>
@@ -377,6 +394,7 @@
                         <outlet property="bioTextView" destination="8GS-hA-vSR" id="mlp-aP-hra"/>
                         <outlet property="coverImage" destination="4f3-Di-kfH" id="2op-Ie-4IJ"/>
                         <outlet property="linksTextFieldView" destination="YkZ-N1-zPh" id="4lP-7w-Y1j"/>
+                        <outlet property="locationTextFieldView" destination="s8h-hd-0k4" id="TkY-jb-ZQw"/>
                         <outlet property="nameTextFieldView" destination="qeu-Yg-Zbl" id="7oL-x3-YG3"/>
                         <outlet property="profileDescription" destination="2YC-45-ipS" id="tR5-q4-5A4"/>
                     </connections>
@@ -402,7 +420,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="static" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="80" sectionHeaderHeight="22" sectionFooterHeight="22" id="QLt-tZ-ekt">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="447"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <sections>
                             <tableViewSection id="EhG-FP-wz8">
                                 <cells>
@@ -415,7 +433,7 @@
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WI9-c1-A8C" customClass="ElloTextFieldView" customModule="Ello" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="600" height="89"/>
-                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </view>
                                             </subviews>
                                             <constraints>
@@ -435,7 +453,7 @@
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1Vt-x7-9bm" customClass="ElloTextFieldView" customModule="Ello" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="600" height="89"/>
-                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </view>
                                             </subviews>
                                             <constraints>
@@ -455,7 +473,7 @@
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fbg-6E-NBp" customClass="ElloTextFieldView" customModule="Ello" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="600" height="89"/>
-                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </view>
                                             </subviews>
                                             <constraints>
@@ -476,7 +494,7 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Re-enter your Ello password to save changes to your account." lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EeE-Bu-dku">
                                                     <rect key="frame" x="15" y="8" width="217" height="28"/>
                                                     <fontDescription key="fontDescription" name="AtlasGrotesk-Regular" family="Atlas Grotesk" pointSize="14"/>
-                                                    <color key="textColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="textColor" red="0.60271793603897095" green="0.602699875831604" blue="0.60271012783050537" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Current Password *" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Znt-wY-XbZ" customClass="ElloTextField" customModule="Ello" customModuleProvider="target">
@@ -501,7 +519,7 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hCs-KV-8Pu" customClass="ElloErrorLabel" customModule="Ello" customModuleProvider="target">
                                                     <rect key="frame" x="15" y="104" width="0.0" height="0.0"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -540,7 +558,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iWJ-Cv-JGS" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1342" y="515.5"/>
+            <point key="canvasLocation" x="1960" y="480"/>
         </scene>
         <!--Dynamic Settings View Controller-->
         <scene sceneID="63N-GQ-Lh9">
@@ -549,7 +567,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="qyN-ih-Oly">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="193"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="PreferenceCell" textLabel="Y1b-rf-IbJ" rowHeight="50" style="IBUITableViewCellStyleDefault" id="jld-9f-tZa">
                                 <rect key="frame" x="0.0" y="22" width="600" height="50"/>
@@ -579,7 +597,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="oQY-Xx-tMH" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="628" y="1485"/>
+            <point key="canvasLocation" x="2136" y="1056"/>
         </scene>
         <!--Dynamic Setting Category View Controller-->
         <scene sceneID="hKB-Hi-WYj">
@@ -601,7 +619,7 @@
                             </navigationBar>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="50" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="TqN-8X-tkG">
                                 <rect key="frame" x="0.0" y="44" width="600" height="200"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 <connections>
                                     <outlet property="dataSource" destination="ohM-iJ-4Uy" id="wSf-dl-Sj1"/>
@@ -609,7 +627,7 @@
                                 </connections>
                             </tableView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="centerX" secondItem="TqN-8X-tkG" secondAttribute="centerX" id="DOU-Rp-8Cp"/>
                             <constraint firstAttribute="centerX" secondItem="avo-sD-Kn2" secondAttribute="centerX" id="Ebw-Jg-GZp"/>
@@ -631,7 +649,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0lb-rY-rQ8" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1369" y="1476"/>
+            <point key="canvasLocation" x="2187" y="1443"/>
         </scene>
     </scenes>
 </document>

--- a/Sources/Controllers/AutoComplete/AutoComplete.swift
+++ b/Sources/Controllers/AutoComplete/AutoComplete.swift
@@ -26,6 +26,7 @@ public func == (lhs: AutoCompleteMatch, rhs: AutoCompleteMatch) -> Bool {
 public enum AutoCompleteType: String, CustomStringConvertible {
     case Emoji = "Emoji"
     case Username = "Username"
+    case Location = "Location"
 
     public var description: String {
         return self.rawValue

--- a/Sources/Controllers/AutoComplete/AutoCompleteCellPresenter.swift
+++ b/Sources/Controllers/AutoComplete/AutoCompleteCellPresenter.swift
@@ -10,7 +10,14 @@ public struct AutoCompleteCellPresenter {
         cell.line.hidden = false
         cell.line.backgroundColor = UIColor.grey3()
         if let resultName = item.result.name {
-            cell.name.text = item.type == .Emoji ? ":\(resultName):" : "@\(resultName)"
+            switch item.type {
+            case .Emoji:
+                cell.name.text = ":\(resultName):"
+            case .Username:
+                cell.name.text = "@\(resultName)"
+            case .Location:
+                cell.name.text = resultName
+            }
         }
         else {
             cell.name.text = ""

--- a/Sources/Controllers/AutoComplete/AutoCompleteViewController.swift
+++ b/Sources/Controllers/AutoComplete/AutoCompleteViewController.swift
@@ -4,7 +4,7 @@
 
 
 public protocol AutoCompleteDelegate: NSObjectProtocol {
-    func itemSelected(item: AutoCompleteItem)
+    func autoComplete(controller: AutoCompleteViewController, itemSelected item: AutoCompleteItem)
 }
 
 public class AutoCompleteViewController: UIViewController {
@@ -25,19 +25,11 @@ public class AutoCompleteViewController: UIViewController {
 // MARK: View Lifecycle
 extension AutoCompleteViewController {
     override public func viewDidLoad() {
-        registerCells()
-        style()
         super.viewDidLoad()
-    }
-
-    override public func viewWillAppear(animated: Bool) {
-        super.viewWillAppear(animated)
         tableView.delegate = self
         tableView.dataSource = dataSource
-    }
-
-    override public func viewDidAppear(animated: Bool) {
-        super.viewDidAppear(animated)
+        registerCells()
+        style()
     }
 }
 
@@ -54,11 +46,18 @@ public extension AutoCompleteViewController {
             loaded(count: self.dataSource.items.count)
         case .Username:
             service.loadUsernameResults(match.text,
-                success: { (results, responseConfig) in
+                success: { (results, _) in
                     self.dataSource.items = results.map { AutoCompleteItem(result: $0, type: match.type, match: match) }
                     self.tableView.reloadData()
                     loaded(count: self.dataSource.items.count)
-            }, failure: showAutoCompleteLoadFailure)
+                }, failure: showAutoCompleteLoadFailure)
+        case .Location:
+            service.loadLocationResults(match.text,
+                success: { (results, _) in
+                    self.dataSource.items = results.map { AutoCompleteItem(result: $0, type: match.type, match: match) }
+                    self.tableView.reloadData()
+                    loaded(count: self.dataSource.items.count)
+                }, failure: showAutoCompleteLoadFailure)
         }
     }
 
@@ -78,7 +77,7 @@ public extension AutoCompleteViewController {
 extension AutoCompleteViewController: UITableViewDelegate {
     public func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         if let item = dataSource.itemForIndexPath(indexPath) {
-            delegate?.itemSelected(item)
+            delegate?.autoComplete(self, itemSelected: item)
         }
     }
 }

--- a/Sources/Controllers/AutoComplete/AutoCompleteViewController.xib
+++ b/Sources/Controllers/AutoComplete/AutoCompleteViewController.xib
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14E36b" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11761" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AutoCompleteViewController" customModule="Ello" customModuleProvider="target">
@@ -12,15 +16,15 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="none" rowHeight="49" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="kul-Q7-bI9">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" alwaysBounceVertical="YES" style="plain" separatorStyle="none" rowHeight="49" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="kul-Q7-bI9">
                     <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </tableView>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="kul-Q7-bI9" secondAttribute="bottom" id="COf-3Y-WrL"/>
                 <constraint firstItem="kul-Q7-bI9" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Py7-h0-1mg"/>

--- a/Sources/Controllers/Omnibar/OmnibarScreenAutocomplete.swift
+++ b/Sources/Controllers/Omnibar/OmnibarScreenAutocomplete.swift
@@ -151,7 +151,7 @@ extension OmnibarScreen: UITextViewDelegate {
 
 
 extension OmnibarScreen: AutoCompleteDelegate {
-    public func itemSelected(item: AutoCompleteItem) {
+    public func autoComplete(controller: AutoCompleteViewController, itemSelected item: AutoCompleteItem) {
         if let name = item.result.name {
             let prefix: String
             let suffix: String

--- a/Sources/Controllers/Settings/SettingsViewController.swift
+++ b/Sources/Controllers/Settings/SettingsViewController.swift
@@ -200,6 +200,7 @@ public class SettingsViewController: UITableViewController, ControllerThatMightH
         else {
             autoCompleteVC.view.frame.size.height = 0
         }
+        updateAutoComplete()
     }
 
     private func updateCurrentUser(user: User) {

--- a/Sources/Controllers/Settings/SettingsViewController.swift
+++ b/Sources/Controllers/Settings/SettingsViewController.swift
@@ -262,13 +262,14 @@ public class SettingsViewController: UITableViewController, ControllerThatMightH
         nameTextFieldView.label.setLabelText(InterfaceString.Settings.Name)
         nameTextFieldView.textField.text = currentUser?.name
 
-        let updateNameFunction = debounce(0.5) { [unowned self] in
-            let name = self.nameTextFieldView.textField.text ?? ""
+        let updateNameFunction = debounce(0.5) { [weak self] in
+            guard let sself = self else { return }
+            let name = sself.nameTextFieldView.textField.text ?? ""
             ProfileService().updateUserProfile(["name": name], success: { user in
-                self.updateCurrentUser(user)
-                self.nameTextFieldView.setState(.OK)
+                sself.updateCurrentUser(user)
+                sself.nameTextFieldView.setState(.OK)
             }, failure: { _, _ in
-                self.nameTextFieldView.setState(.Error)
+                sself.nameTextFieldView.setState(.Error)
             })
         }
 
@@ -283,13 +284,14 @@ public class SettingsViewController: UITableViewController, ControllerThatMightH
         bioTextView.attributedText = ElloAttributedString.style(currentUser?.profile?.shortBio ?? "")
         bioTextView.delegate = self
 
-        bioTextViewDidChange = debounce(0.5) { [unowned self] in
-            let bio = self.bioTextView.text
+        bioTextViewDidChange = debounce(0.5) { [weak self] in
+            guard let sself = self else { return }
+            let bio = sself.bioTextView.text
             ProfileService().updateUserProfile(["unsanitized_short_bio": bio], success: { user in
-                self.updateCurrentUser(user)
-                self.bioTextStatusImage.image = ValidationState.OK.imageRepresentation
+                sself.updateCurrentUser(user)
+                sself.bioTextStatusImage.image = ValidationState.OK.imageRepresentation
             }, failure: { _, _ in
-                self.bioTextStatusImage.image = ValidationState.Error.imageRepresentation
+                sself.bioTextStatusImage.image = ValidationState.Error.imageRepresentation
             })
         }
     }
@@ -311,13 +313,14 @@ public class SettingsViewController: UITableViewController, ControllerThatMightH
             linksTextFieldView.textField.text = urls.joinWithSeparator(", ")
         }
 
-        let updateLinksFunction = debounce(0.5) { [unowned self] in
-            let links = self.linksTextFieldView.textField.text ?? ""
+        let updateLinksFunction = debounce(0.5) { [weak self] in
+            guard let sself = self else { return }
+            let links = sself.linksTextFieldView.textField.text ?? ""
             ProfileService().updateUserProfile(["external_links": links], success: { user in
-                self.updateCurrentUser(user)
-                self.linksTextFieldView.setState(.OK)
+                sself.updateCurrentUser(user)
+                sself.linksTextFieldView.setState(.OK)
             }, failure: { _, _ in
-                self.linksTextFieldView.setState(.Error)
+                sself.linksTextFieldView.setState(.Error)
             })
         }
 
@@ -334,17 +337,17 @@ public class SettingsViewController: UITableViewController, ControllerThatMightH
             locationTextFieldView.textField.text = location
         }
 
-        let updateLocationFunction = debounce(0.5) { [unowned self] in
-            let location = self.locationTextFieldView.textField.text ?? ""
+        let updateLocationFunction = debounce(0.5) { [weak self] in
+            guard let sself = self else { return }
+            let location = sself.locationTextFieldView.textField.text ?? ""
             ProfileService().updateUserProfile(["location": location], success: { user in
-                self.updateCurrentUser(user)
-                self.locationTextFieldView.setState(.OK)
+                sself.updateCurrentUser(user)
+                sself.locationTextFieldView.setState(.OK)
             }, failure: { _, _ in
-                self.locationTextFieldView.setState(.Error)
+                sself.locationTextFieldView.setState(.Error)
             })
 
-            self.autoCompleteVC.load(AutoCompleteMatch(type: .Location, range: Range(location.startIndex ..< location.endIndex), text: location)) { [weak self] count in
-                guard let sself = self else { return }
+            sself.autoCompleteVC.load(AutoCompleteMatch(type: .Location, range: Range(location.startIndex ..< location.endIndex), text: location)) { count in
                 guard location == sself.locationTextFieldView.textField.text else { return }
 
                 sself.locationAutoCompleteResultCount = count

--- a/Sources/Controllers/Settings/SettingsViewController.swift
+++ b/Sources/Controllers/Settings/SettingsViewController.swift
@@ -537,7 +537,7 @@ extension SettingsViewController {
 
 extension SettingsViewController: AutoCompleteDelegate {
     public func updateAutoComplete() {
-        self.autoCompleteVC.view.alpha = (locationTextViewSelected && locationAutoCompleteResultCount > 0) ? 1 : 0
+        autoCompleteVC.view.alpha = (locationTextViewSelected && locationAutoCompleteResultCount > 0) ? 1 : 0
         let rowHeight: CGFloat = AutoCompleteCell.cellHeight()
         let maxHeight: CGFloat = 3.5 * rowHeight
         let height: CGFloat = min(maxHeight, CGFloat(locationAutoCompleteResultCount) * rowHeight)

--- a/Sources/Controllers/Settings/SettingsViewController.swift
+++ b/Sources/Controllers/Settings/SettingsViewController.swift
@@ -101,12 +101,12 @@ public class SettingsViewController: UITableViewController, ControllerThatMightH
     var autoCompleteVC = AutoCompleteViewController()
     var locationTextViewSelected = false {
         didSet {
-            updateAutoComplete()
+            updateAutoCompleteFrame()
         }
     }
     var locationAutoCompleteResultCount = 0 {
         didSet {
-            updateAutoComplete()
+            updateAutoCompleteFrame()
         }
     }
 
@@ -200,7 +200,7 @@ public class SettingsViewController: UITableViewController, ControllerThatMightH
         else {
             autoCompleteVC.view.frame.size.height = 0
         }
-        updateAutoComplete()
+        updateAutoCompleteFrame()
     }
 
     private func updateCurrentUser(user: User) {
@@ -548,7 +548,7 @@ extension SettingsViewController {
 }
 
 extension SettingsViewController: AutoCompleteDelegate {
-    public func updateAutoComplete() {
+    public func updateAutoCompleteFrame() {
         autoCompleteVC.view.alpha = (locationTextViewSelected && locationAutoCompleteResultCount > 0) ? 1 : 0
         let rowHeight: CGFloat = AutoCompleteCell.cellHeight()
         let maxHeight: CGFloat = 3.5 * rowHeight

--- a/Sources/Model/AutoCompleteResult.swift
+++ b/Sources/Model/AutoCompleteResult.swift
@@ -45,7 +45,8 @@ public final class AutoCompleteResult: JSONAble {
     override public class func fromJSON(data: [String: AnyObject]) -> JSONAble {
         let json = JSON(data)
         Crashlytics.sharedInstance().setObjectValue(json.rawString(), forKey: CrashlyticsKey.AutoCompleteResultFromJSON.rawValue)
-        let result = AutoCompleteResult(name: json["name"].string)
+        let name = json["name"].string ?? json["location"].string
+        let result = AutoCompleteResult(name: name)
         if let imageUrl = json["image_url"].string,
             url = NSURL(string: imageUrl)
         {

--- a/Sources/Networking/AutoCompleteService.swift
+++ b/Sources/Networking/AutoCompleteService.swift
@@ -91,4 +91,23 @@ public struct AutoCompleteService {
             }
     }
 
+    public func loadLocationResults(
+        search: String,
+        success: AutoCompleteServiceSuccessCompletion,
+        failure: ElloFailureCompletion)
+    {
+        ElloProvider.shared.elloRequest(
+            .LocationAutoComplete(search: search),
+            success: { (data, responseConfig) in
+                if let results = data as? [AutoCompleteResult] {
+                    success(results: results, responseConfig: responseConfig)
+                }
+                else {
+                    ElloProvider.unCastableJSONAble(failure)
+                }
+            },
+            failure: failure
+        )
+    }
+
 }

--- a/Sources/Networking/ElloAPI.swift
+++ b/Sources/Networking/ElloAPI.swift
@@ -39,6 +39,7 @@ public enum ElloAPI {
     case InviteFriends(contact: String)
     case Join(email: String, username: String, password: String, invitationCode: String?)
     case Loves(userId: String)
+    case LocationAutoComplete(search: String)
     case NoiseStream
     case NoiseNewContent(createdAt: NSDate)
     case NotificationsNewContent(createdAt: NSDate)
@@ -155,7 +156,8 @@ public enum ElloAPI {
              .DeleteWatchPost:
             return .WatchesType
         case .EmojiAutoComplete,
-             .UserNameAutoComplete:
+             .UserNameAutoComplete,
+             .LocationAutoComplete:
             return .AutoCompleteResultType
         case .DeleteLove,
              .DeleteSubscriptions,
@@ -341,6 +343,8 @@ extension ElloAPI: Moya.TargetType {
             return "/api/\(ElloAPI.apiVersion)/join"
         case let .Loves(userId):
             return "/api/\(ElloAPI.apiVersion)/users/\(userId)/loves"
+        case .LocationAutoComplete(_):
+            return "/api/\(ElloAPI.apiVersion)/profile/location_autocomplete"
         case .NoiseNewContent,
              .NoiseStream:
             return "/api/\(ElloAPI.apiVersion)/streams/noise"
@@ -455,6 +459,8 @@ extension ElloAPI: Moya.TargetType {
             return stubbedData("users_registering_an_account")
         case .Loves:
             return stubbedData("loves_listing_loves_for_a_user")
+        case .LocationAutoComplete:
+            return stubbedData("users_getting_a_list_for_autocompleted_locations")
         case .NoiseStream:
             return stubbedData("activity_streams_noise_stream")
         case .NotificationsStream:
@@ -651,6 +657,10 @@ extension ElloAPI: Moya.TargetType {
                 params["invitation_code"] = invitationCode
             }
             return params
+        case let .LocationAutoComplete(search):
+            return [
+                "location": search
+            ]
         case .NoiseStream:
             return [
                 "per_page": 10

--- a/Sources/Networking/ElloAPIDescription.swift
+++ b/Sources/Networking/ElloAPIDescription.swift
@@ -43,6 +43,8 @@ extension ElloAPI: CustomStringConvertible, CustomDebugStringConvertible {
             return "InfiniteScroll(elloApi: \(elloApi()))"
         case let .Loves(userId):
             return "Loves(userId: \(userId))"
+        case let .LocationAutoComplete(search):
+            return "LocationAutoComplete(search: \(search))"
         case let .PostComments(postId):
             return "PostComments(postId: \(postId))"
         case let .PostDetail(postParam, commentCount):
@@ -153,6 +155,8 @@ extension ElloAPI: CustomStringConvertible, CustomDebugStringConvertible {
             return "Join"
         case .Loves:
             return "Loves"
+        case .LocationAutoComplete:
+            return "LocationAutoComplete"
         case .NoiseNewContent:
             return "NoiseNewContent"
         case .NoiseStream:

--- a/Sources/Utilities/InterfaceString.swift
+++ b/Sources/Utilities/InterfaceString.swift
@@ -111,6 +111,7 @@ public struct InterfaceString {
         static let EditProfile: String = NSLocalizedString("Edit Profile", comment: "Edit Profile Title")
         static let Name: String = NSLocalizedString("Name", comment: "name setting")
         static let Links: String = NSLocalizedString("Links", comment: "links setting")
+        static let Location: String = NSLocalizedString("Location", comment: "location setting")
         static let AvatarUploaded: String = NSLocalizedString("You’ve updated your Avatar.\n\nIt may take a few minutes for your new avatar/header to appear on Ello, so please be patient. It’ll be live soon!", comment: "Avatar updated copy")
         static let CoverImageUploaded: String = NSLocalizedString("You’ve updated your Header.\n\nIt may take a few minutes for your new avatar/header to appear on Ello, so please be patient. It’ll be live soon!", comment: "Cover Image updated copy")
         static let BlockedTitle: String = NSLocalizedString("Blocked", comment: "blocked settings item")

--- a/Sources/Views/ElloTextField.swift
+++ b/Sources/Views/ElloTextField.swift
@@ -3,6 +3,7 @@
 //
 
 public class ElloTextField: UITextField {
+    public var firstResponderDidChange: (Bool -> Void)?
     var hasOnePassword = false
     var validationState = ValidationState.None {
         didSet {
@@ -54,6 +55,18 @@ public class ElloTextField: UITextField {
 
     private func rectForBounds(bounds: CGRect) -> CGRect {
         return bounds.shrinkLeft(15).inset(topBottom: 10, sides: 15)
+    }
+
+    override public func becomeFirstResponder() -> Bool {
+        let val = super.becomeFirstResponder()
+        firstResponderDidChange?(true)
+        return val
+    }
+
+    override public func resignFirstResponder() -> Bool {
+        let val = super.resignFirstResponder()
+        firstResponderDidChange?(false)
+        return val
     }
 
 }

--- a/Sources/Views/ElloTextFieldView.swift
+++ b/Sources/Views/ElloTextFieldView.swift
@@ -16,10 +16,10 @@ public class ElloTextFieldView: UIView {
     @IBOutlet private var messageLabelHeight: NSLayoutConstraint!
     @IBOutlet private weak var errorLabelSeparationSpacing: NSLayoutConstraint!
 
-    public var textFieldDidChange: (String -> Void)? {
-        didSet {
-            textField.addTarget(self, action: #selector(ElloTextFieldView.valueChanged), forControlEvents: .EditingChanged)
-        }
+    public var textFieldDidChange: (String -> Void)?
+    public var firstResponderDidChange: (Bool -> Void)? {
+        get { return textField.firstResponderDidChange }
+        set { textField.firstResponderDidChange = newValue }
     }
 
     var height: CGFloat {
@@ -64,6 +64,7 @@ public class ElloTextFieldView: UIView {
         view.frame = bounds
         view.autoresizingMask = [.FlexibleHeight, .FlexibleWidth]
         addSubview(view)
+        textField.addTarget(self, action: #selector(valueChanged), forControlEvents: .EditingChanged)
     }
 
     required public init?(coder aDecoder: NSCoder) {
@@ -72,6 +73,7 @@ public class ElloTextFieldView: UIView {
         view.frame = bounds
         view.autoresizingMask = [.FlexibleHeight, .FlexibleWidth]
         addSubview(view)
+        textField.addTarget(self, action: #selector(valueChanged), forControlEvents: .EditingChanged)
     }
 
     override public func updateConstraints() {
@@ -85,8 +87,8 @@ public class ElloTextFieldView: UIView {
 
     func valueChanged() {
         setNeedsUpdateConstraints()
-        if let text = textField.text {
-            textFieldDidChange?(text)
+        if let textFieldDidChange = textFieldDidChange, text = textField.text {
+            textFieldDidChange(text)
         }
     }
 
@@ -126,6 +128,15 @@ public class ElloTextFieldView: UIView {
         setErrorMessage("")
         setMessage("")
     }
+
+    override public func becomeFirstResponder() -> Bool {
+        return textField.becomeFirstResponder()
+    }
+
+    override public func resignFirstResponder() -> Bool {
+        return textField.resignFirstResponder()
+    }
+
 }
 
 


### PR DESCRIPTION
When location results come in, they're "coerced" into `AutoCompleteResult` objects by setting `name` to the `location` value.  Not terribly intuitive (?) but maximizes code reuse.