### PR TITLE
Fixes onboarding links validation

### DIFF
--- a/Sources/Controllers/Onboarding/CreateProfileProtocols.swift
+++ b/Sources/Controllers/Onboarding/CreateProfileProtocols.swift
@@ -6,9 +6,9 @@ protocol CreateProfileDelegate: class {
     func presentController(controller: UIViewController)
     func dismissController()
 
-    func assignName(name: String?)
-    func assignBio(bio: String?)
-    func assignLinks(links: String?)
+    func assignName(name: String?) -> ValidationState
+    func assignBio(bio: String?) -> ValidationState
+    func assignLinks(links: String?) -> ValidationState
     func assignCoverImage(image: ImageRegionData)
     func assignAvatar(image: ImageRegionData)
 }

--- a/Sources/Controllers/Onboarding/CreateProfileScreen.swift
+++ b/Sources/Controllers/Onboarding/CreateProfileScreen.swift
@@ -380,8 +380,7 @@ extension CreateProfileScreen: UITextViewDelegate {
             if replacementText == "\n" {
                 text = originalText
             }
-            delegate?.assignName(text)
-            nameTextView.validationState = text.isEmpty ? .None : .OKSmall
+            nameTextView.validationState = delegate?.assignName(text) ?? .None
 
             if replacementText == "\n" {
                 nameTextView.resignFirstResponder()
@@ -389,11 +388,9 @@ extension CreateProfileScreen: UITextViewDelegate {
                 return false
             }
         case bioTextView:
-            delegate?.assignBio(text)
-            bioTextView.validationState = text.isEmpty ? .None : .OKSmall
+            bioTextView.validationState = delegate?.assignBio(text) ?? .None
         case linksTextView:
-            delegate?.assignLinks(text)
-            linksTextView.validationState = text.isEmpty ? .None : .OKSmall
+            linksTextView.validationState = delegate?.assignLinks(text) ?? .None
         default: break
         }
 

--- a/Sources/Controllers/Onboarding/CreateProfileViewController.swift
+++ b/Sources/Controllers/Onboarding/CreateProfileViewController.swift
@@ -96,7 +96,14 @@ extension CreateProfileViewController: OnboardingStepController {
     public func onboardingStepBegin() {
         didSetName = (onboardingData.name?.isEmpty == false)
         didSetBio = (onboardingData.bio?.isEmpty == false)
-        didSetLinks = (onboardingData.links?.isEmpty == false)
+        if let links = onboardingData.links {
+            didSetLinks = !links.isEmpty
+            linksAreValid = Validator.hasValidLinks(links)
+        }
+        else {
+            didSetLinks = false
+            linksAreValid = false
+        }
         didUploadAvatarImage = (onboardingData.avatarImage != nil)
         didUploadCoverImage = (onboardingData.coverImage != nil)
         onboardingViewController?.hasAbortButton = true

--- a/Sources/Controllers/Onboarding/CreateProfileViewController.swift
+++ b/Sources/Controllers/Onboarding/CreateProfileViewController.swift
@@ -75,7 +75,7 @@ extension CreateProfileViewController: CreateProfileDelegate {
 
         debouncedLinksValidator { [weak self] in
             guard let sself = self else { return }
-            sself.screen.linksValid = sself.didSetLinks ? (sself.linksAreValid ? true : false) : nil
+            sself.screen.linksValid = sself.didSetLinks ? sself.linksAreValid : nil
         }
         return linksAreValid ? .OKSmall : .None
     }

--- a/Sources/Extensions/StringExtensions.swift
+++ b/Sources/Extensions/StringExtensions.swift
@@ -386,6 +386,14 @@ public extension String {
         return false
     }
 
+    func split(char char: Character) -> [String] {
+        return characters.split { $0 == char }.map { String($0) }
+    }
+
+    func trimmed() -> String {
+        return stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+    }
+
     var camelCase: String {
         let splits = self.characters.split { $0 == "_" }.map { String($0) }
         var capSplits: [String] = splits.map { s in

--- a/Sources/Model/User.swift
+++ b/Sources/Model/User.swift
@@ -221,8 +221,10 @@ public final class User: JSONAble {
 
     public override func merge(other: JSONAble) -> JSONAble {
         if let otherUser = other as? User {
-            if (otherUser.formattedShortBio ?? "").characters.count == 0 {
+            if otherUser.formattedShortBio == nil {
                 otherUser.formattedShortBio = formattedShortBio
+            }
+            if otherUser.externalLinksList == nil {
                 otherUser.externalLinksList = externalLinksList
             }
             return otherUser
@@ -258,7 +260,7 @@ public final class User: JSONAble {
         user.lovesCount = json["loves_count"].int
         user.followersCount = json["followers_count"].stringValue
         user.followingCount = json["following_count"].int
-        user.formattedShortBio = json["formatted_short_bio"].stringValue
+        user.formattedShortBio = json["formatted_short_bio"].string
         // grab links
         if let links = json["external_links_list"].array {
             let externalLinks = links.flatMap({ $0.dictionaryObject as? [String: String] })

--- a/Sources/Networking/ReAuthService.swift
+++ b/Sources/Networking/ReAuthService.swift
@@ -9,7 +9,6 @@ public class ReAuthService {
     public func reAuthenticateToken(success success: AuthSuccessCompletion, failure: ElloFailureCompletion, noNetwork: ElloEmptyCompletion) {
         let endpoint: ElloAPI
         let token = AuthToken()
-        let prevToken = token.token
         let refreshToken = token.refreshToken
         if let refreshToken = refreshToken where token.isPasswordBased {
             endpoint = .ReAuth(token: refreshToken)

--- a/Sources/Utilities/Validator.swift
+++ b/Sources/Utilities/Validator.swift
@@ -4,6 +4,31 @@
 
 public struct Validator {
 
+    public static func hasValidLinks(links: String) -> Bool {
+        let splitLinks = links.split(char: ",").map { $0.trimmed() }
+        return splitLinks.count > 0 && splitLinks.all {
+            return Validator.isValidLink($0)
+        }
+    }
+
+    public static func isValidLink(link: String) -> Bool {
+        guard let url = NSURL(string: link) else {
+            return false
+        }
+
+        if url.scheme?.lowercaseString == "http" || url.scheme?.lowercaseString == "https" {
+            return isValidHost(url.host)
+        }
+        else {
+            return isValidLink("http://\(link)")
+        }
+    }
+
+    private static func isValidHost(host: String?) -> Bool {
+        guard let host = host else { return false }
+        return host.contains(".") && !host.beginsWith(".") && !host.endsWith(".")
+    }
+
     public static func hasValidSignUpCredentials(email email: String, username: String, password: String) -> Bool {
         return isValidEmail(email) && isValidUsername(username) && isValidPassword(password)
     }

--- a/Specs/Controllers/Onboarding/CreateProfileScreenSpec.swift
+++ b/Specs/Controllers/Onboarding/CreateProfileScreenSpec.swift
@@ -18,14 +18,17 @@ class CreateProfileScreenSpec: QuickSpec {
         func presentController(controller: UIViewController) {}
         func dismissController() {}
 
-        func assignName(name: String?) {
+        func assignName(name: String?) -> ValidationState {
             didAssignName = true
+            return (name?.isEmpty == false) ? .OK : .None
         }
-        func assignBio(bio: String?) {
+        func assignBio(bio: String?) -> ValidationState {
             didAssignBio = true
+            return (name?.isEmpty == false) ? .OK : .None
         }
-        func assignLinks(links: String?) {
+        func assignLinks(links: String?) -> ValidationState {
             didAssignLinks = true
+            return (name?.isEmpty == false) ? .OK : .None
         }
         func assignCoverImage(image: ImageRegionData) {
             didAssignCoverImage = true

--- a/Specs/Controllers/Onboarding/CreateProfileScreenSpec.swift
+++ b/Specs/Controllers/Onboarding/CreateProfileScreenSpec.swift
@@ -24,11 +24,11 @@ class CreateProfileScreenSpec: QuickSpec {
         }
         func assignBio(bio: String?) -> ValidationState {
             didAssignBio = true
-            return (name?.isEmpty == false) ? .OK : .None
+            return (bio?.isEmpty == false) ? .OK : .None
         }
         func assignLinks(links: String?) -> ValidationState {
             didAssignLinks = true
-            return (name?.isEmpty == false) ? .OK : .None
+            return (links?.isEmpty == false) ? .OK : .None
         }
         func assignCoverImage(image: ImageRegionData) {
             didAssignCoverImage = true

--- a/Specs/Controllers/Onboarding/CreateProfileViewControllerSpec.swift
+++ b/Specs/Controllers/Onboarding/CreateProfileViewControllerSpec.swift
@@ -58,7 +58,7 @@ class CreateProfileViewControllerSpec: QuickSpec {
                     }
                     it("sets 'didSet' vars if everything is set") {
                         onboardingData.name = "my name"
-                        onboardingData.links = "my links"
+                        onboardingData.links = "http://my.links"
                         onboardingData.bio = "my bio"
                         let image = ImageRegionData(image: UIImage.imageWithColor(.blueColor())!)
                         onboardingData.coverImage = image
@@ -76,7 +76,7 @@ class CreateProfileViewControllerSpec: QuickSpec {
                     beforeEach {
                         image = ImageRegionData(image: UIImage.imageWithColor(.blueColor())!)
                         onboardingData.name = "my name"
-                        onboardingData.links = "my links"
+                        onboardingData.links = "http://my.links"
                         onboardingData.bio = "my bio"
                         onboardingData.coverImage = image
                         onboardingData.avatarImage = image
@@ -87,7 +87,7 @@ class CreateProfileViewControllerSpec: QuickSpec {
                         expect(mockScreen.name) == "my name"
                     }
                     it("sets links") {
-                        expect(mockScreen.links) == "my links"
+                        expect(mockScreen.links) == "http://my.links"
                     }
                     it("sets bio") {
                         expect(mockScreen.bio) == "my bio"
@@ -117,7 +117,7 @@ class CreateProfileViewControllerSpec: QuickSpec {
                     }
                     it("if everything is set, 'canGoNext' is true") {
                         onboardingData.name = "my name"
-                        onboardingData.links = "my links"
+                        onboardingData.links = "http://my.links"
                         onboardingData.bio = "my bio"
                         let image = ImageRegionData(image: UIImage.imageWithColor(.blueColor())!)
                         onboardingData.coverImage = image
@@ -139,8 +139,8 @@ class CreateProfileViewControllerSpec: QuickSpec {
                     expect(onboardingViewController.canGoNext) == true
                 }
                 it("forwards links") {
-                    subject.assignLinks("my links")
-                    expect(onboardingData.links) == "my links"
+                    subject.assignLinks("http://my.links")
+                    expect(onboardingData.links) == "http://my.links"
                     expect(subject.didSetLinks) == true
                     expect(subject.didSetBio) == false
                     expect(onboardingViewController.canGoNext) == true
@@ -189,11 +189,11 @@ class CreateProfileViewControllerSpec: QuickSpec {
                 }
                 it("changed name,links,bio") {
                     subject.assignName("my name")
-                    subject.assignLinks("my links")
+                    subject.assignLinks("http://my.links")
                     subject.assignBio("my bio")
                     subject.onboardingWillProceed(false, proceedClosure: { _ in })
                     expect(props["name"] as? String) == "my name"
-                    expect(props["external_links"] as? String) == "my links"
+                    expect(props["external_links"] as? String) == "http://my.links"
                     expect(props["unsanitized_short_bio"] as? String) == "my bio"
                 }
                 // ElloS3 doesn't support/use the shared provider paradigm

--- a/Specs/Extensions/StringExtensionSpec.swift
+++ b/Specs/Extensions/StringExtensionSpec.swift
@@ -135,6 +135,65 @@ class StringExtensionSpec: QuickSpec {
                 }
             }
         }
+        describe("split") {
+            it("splits a string") {
+                let str = "a,b,cc,ddd"
+                expect(str.split(char: ",")) == ["a", "b", "cc", "ddd"]
+            }
+            it("ignores a string with no splits") {
+                let str = "abccddd"
+                expect(str.split(char: ",")) == ["abccddd"]
+            }
+        }
+        describe("trimmed") {
+            it("trims leading whitespace") {
+                let strs = [
+                    "  string",
+                    "\t\tstring",
+                    " \t\nstring",
+                ]
+                for str in strs {
+                    expect(str.trimmed()) == "string"
+                }
+            }
+            it("trims trailing whitespace") {
+                let strs = [
+                    "string  ",
+                    "string\t\t",
+                    "string\n\t ",
+                ]
+                for str in strs {
+                    expect(str.trimmed()) == "string"
+                }
+            }
+            it("trims leading and trailing whitespace") {
+                let strs = [
+                    "  string  ",
+                    "\t\tstring\t\t",
+                    "\n \tstring\t\n ",
+                ]
+                for str in strs {
+                    expect(str.trimmed()) == "string"
+                }
+            }
+            it("ignores embedded whitespace") {
+                let strs = [
+                    "str  ing",
+                    "  str  ing",
+                    "\t\tstr  ing",
+                    "\n\nstr  ing",
+                    "str  ing  ",
+                    "str  ing\t\t",
+                    "str  ing\n\n",
+                    "  str  ing  ",
+                    "\t\tstr  ing\t\t",
+                    "\n\nstr  ing\n\n",
+                ]
+                for str in strs {
+                    expect(str.trimmed()) == "str  ing"
+                }
+            }
+        }
         describe("camelCase") {
             it("converts a string from snake case to camel case") {
                 let snake = "hhhhh_sssss"

--- a/Specs/Utilities/ValidatorSpec.swift
+++ b/Specs/Utilities/ValidatorSpec.swift
@@ -9,65 +9,146 @@ import Nimble
 
 class ValidatorSpec: QuickSpec {
     override func spec() {
+        describe("Validator") {
 
-        context("email validation") {
-            let expectations: [(String, Bool)] = [
-                ("name@test.com", true),
-                ("n@t.co", true),
-                ("n@t.shopping", true),
-                ("some.name@domain.co.uk", true),
-                ("some+name@domain.somethingreallylong", true),
-                ("test.com", false),
-                ("name@test", false),
-                ("name@.com", false),
-                ("name@name.com.", false),
-                ("name@name.t", false),
-                ("", false),
-            ]
+            context("isValidLink") {
+                let expectations: [(String, Bool)] = [
+                    ("http://foo.com", true),
+                    ("http://foo.com/path", true),
+                    ("http://foo.com/+path", true),
+                    ("http://foo.com/#path", true),
+                    ("http://foo.com/and_(wow)", true),
+                    ("https://foo.com", true),
+                    ("http://foo.co", true),
+                    ("http://foo.co:80", true),
+                    ("example.com", true),
+                    ("github.com/example", true),
+                    ("HTTP://FOO.COM", true),
+                    ("HTTPS://FOO.COM", true),
+                    ("http://foo.com/blah_blah", true),
+                    ("http://foo.com/blah_blah/", true),
+                    ("http://foo.com/blah_blah_(wikipedia)", true),
+                    ("http://foo.com/blah_blah_(wikipedia)_(again)", true),
+                    ("http://www.example.com/wpstyle/?p=364", true),
+                    ("https://www.example.com/foo/?bar=baz&inga=42&quux", true),
+                    ("http://userid:password@example.com:8080", true),
+                    ("http://userid:password@example.com:8080/", true),
+                    ("http://userid@example.com", true),
+                    ("http://userid@example.com/", true),
+                    ("http://userid@example.com:8080", true),
+                    ("http://userid@example.com:8080/", true),
+                    ("http://userid:password@example.com", true),
+                    ("http://userid:password@example.com/", true),
+                    ("http://142.42.1.1/", true),
+                    ("http://142.42.1.1:8080/", true),
+                    ("http://foo.com/blah_(wikipedia)#cite-", true),
+                    ("http://foo.com/blah_(wikipedia)_blah#cite-", true),
+                    ("http://foo.com/(something)?after=parens", true),
+                    ("http://code.google.com/events/#&product=browser", true),
+                    ("http://j.mp", true),
+                    ("http://foo.bar/?q=Test%20URL-encoded%20stuff", true),
+                    ("http://1337.net", true),
+                    ("http://a.b-c.de", true),
+                    ("http://223.255.255.254", true),
+                    ("", false),
+                    ("foo", false),
+                    ("ftp://foo.com", false),
+                    ("ftp://foo.com", false),
+                    ("http://..", false),
+                    ("http://../", false),
+                    ("//", false),
+                    ("///", false),
+                    ("http://##/", false),
+                    ("http://.www.foo.bar./", false),
+                    ("rdar://1234", false),
+                    ("http://foo.bar?q=Spaces should be encoded", false),
+                    ("http:// shouldfail.com", false),
+                    (":// should fail", false),
+                ]
 
-            for (test, expected) in expectations {
-                it("returns \(expected) for \(test)") {
-                    expect(Validator.isValidEmail(test)) == expected
+                for (test, expected) in expectations {
+                    it("Validator.isValidLink(\(test)) returns \(expected)") {
+                        expect(Validator.isValidLink(test)) == expected
+                    }
                 }
             }
-        }
 
-        context("username validation") {
-            let expectations: [(String, Bool)] = [
-                ("", false),
-                ("a", false),
-                ("aa", true),
-                ("-a", true),
-                ("a-", true),
-                ("--", true),
-                ("user%", false),
-            ]
+            context("hasValidLinks") {
+                let expectations: [(String, Bool)] = [
+                    ("http://foo.com", true),
+                    ("http://foo.com,example.com", true),
+                    ("http://foo.com, example.com", true),
+                    ("", false),
+                    ("foo", false),
+                    ("foo,http://foo.com", false),
+                ]
 
-            for (test, expected) in expectations {
-                it("returns \(expected) for \(test)") {
-                    expect(Validator.isValidUsername(test)) == expected
+                for (test, expected) in expectations {
+                    it("Validator.hasValidLinks(\(test)) returns \(expected)") {
+                        expect(Validator.hasValidLinks(test)) == expected
+                    }
                 }
             }
-        }
 
-        context("password validation") {
-            let expectations: [(String, Bool)] = [
-                ("asdfasdf", true),
-                ("12345678", true),
-                ("123456789", true),
-                ("", false),
-                ("1", false),
-                ("12", false),
-                ("123", false),
-                ("1234", false),
-                ("12345", false),
-                ("123456", false),
-                ("1234567", false),
-            ]
+            context("isValidEmail") {
+                let expectations: [(String, Bool)] = [
+                    ("name@test.com", true),
+                    ("n@t.co", true),
+                    ("n@t.shopping", true),
+                    ("some.name@domain.co.uk", true),
+                    ("some+name@domain.somethingreallylong", true),
+                    ("test.com", false),
+                    ("name@test", false),
+                    ("name@.com", false),
+                    ("name@name.com.", false),
+                    ("name@name.t", false),
+                    ("", false),
+                ]
 
-            for (test, expected) in expectations {
-                it("returns \(expected) for \(test)") {
-                    expect(Validator.isValidPassword(test)) == expected
+                for (test, expected) in expectations {
+                    it("Validator.isValidEmail(\(test)) returns \(expected)") {
+                        expect(Validator.isValidEmail(test)) == expected
+                    }
+                }
+            }
+
+            context("isValidUsername") {
+                let expectations: [(String, Bool)] = [
+                    ("", false),
+                    ("a", false),
+                    ("aa", true),
+                    ("-a", true),
+                    ("a-", true),
+                    ("--", true),
+                    ("user%", false),
+                ]
+
+                for (test, expected) in expectations {
+                    it("isValidUsername(\(test)) returns \(expected)") {
+                        expect(Validator.isValidUsername(test)) == expected
+                    }
+                }
+            }
+
+            context("isValidPassword") {
+                let expectations: [(String, Bool)] = [
+                    ("asdfasdf", true),
+                    ("12345678", true),
+                    ("123456789", true),
+                    ("", false),
+                    ("1", false),
+                    ("12", false),
+                    ("123", false),
+                    ("1234", false),
+                    ("12345", false),
+                    ("123456", false),
+                    ("1234567", false),
+                ]
+
+                for (test, expected) in expectations {
+                    it("Validator.isValidPassword(\(test)) returns \(expected)") {
+                        expect(Validator.isValidPassword(test)) == expected
+                    }
                 }
             }
         }


### PR DESCRIPTION
Links are now validated on the client, and the user cannot continue if the link field is invalid, even if they entered other info.

Also discovered a bug where an existing user's links would not be displayed by the app if they deleted their bio.  The changes *are* saved, though, and it's only when updatind an existing user (would not affect onboarding).