### PR TITLE
Prevent double tap loves when disabled

### DIFF
--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -807,6 +807,9 @@ extension StreamViewController: StreamEditingDelegate {
             let post = dataSource.postForIndexPath(path),
             let footerPath = dataSource.footerIndexPathForPost(post)
         {
+            guard let lovesEnabled = post.author?.hasLovesEnabled,
+                lovesEnabled == true else { return }
+
             if let window = cell.window {
                 let fullDuration: TimeInterval = 0.4
                 let halfDuration: TimeInterval = fullDuration / 2

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -807,8 +807,7 @@ extension StreamViewController: StreamEditingDelegate {
             let post = dataSource.postForIndexPath(path),
             let footerPath = dataSource.footerIndexPathForPost(post)
         {
-            guard let lovesEnabled = post.author?.hasLovesEnabled,
-                lovesEnabled == true else { return }
+            guard post.author?.hasLovesEnabled == true else { return }
 
             if let window = cell.window {
                 let fullDuration: TimeInterval = 0.4


### PR DESCRIPTION
Double tapping the post of a user with loves disabled is no longer allowed.
[Fixes #257 133266763](https://www.pivotaltracker.com/story/show/133266763)