### PR TITLE
Fixes Announcement tracking

### DIFF
--- a/Sources/Controllers/Notifications/NotificationsGenerator.swift
+++ b/Sources/Controllers/Notifications/NotificationsGenerator.swift
@@ -65,24 +65,15 @@ public final class NotificationsGenerator: StreamGenerator {
             return
         }
 
-        let announcement = Announcement(
-            id: NSUUID().UUIDString,
-            header: "header",
-            body: "body",
-            ctaURL: nil,
-            ctaCaption: "caption",
-            createdAt: NSDate()
-            )
-
         NotificationService().loadAnnouncements()
-            .onSuccess { [weak self] _ in
+            .onSuccess { [weak self] announcement in
                 guard let sself = self else { return }
                 guard sself.loadingToken.isValidInitialPageLoadingToken(sself.localToken) else { return }
 
                 sself.compareAndUpdateAnnouncements([announcement])
             }
             .onFail { [weak self] _ in
-                self?.compareAndUpdateAnnouncements([announcement])
+                self?.compareAndUpdateAnnouncements([])
             }
     }
 

--- a/Sources/Controllers/Notifications/NotificationsGenerator.swift
+++ b/Sources/Controllers/Notifications/NotificationsGenerator.swift
@@ -65,15 +65,24 @@ public final class NotificationsGenerator: StreamGenerator {
             return
         }
 
+        let announcement = Announcement(
+            id: NSUUID().UUIDString,
+            header: "header",
+            body: "body",
+            ctaURL: nil,
+            ctaCaption: "caption",
+            createdAt: NSDate()
+            )
+
         NotificationService().loadAnnouncements()
-            .onSuccess { [weak self] announcement in
+            .onSuccess { [weak self] _ in
                 guard let sself = self else { return }
                 guard sself.loadingToken.isValidInitialPageLoadingToken(sself.localToken) else { return }
 
                 sself.compareAndUpdateAnnouncements([announcement])
             }
             .onFail { [weak self] _ in
-                self?.compareAndUpdateAnnouncements([])
+                self?.compareAndUpdateAnnouncements([announcement])
             }
     }
 

--- a/Sources/Controllers/Notifications/NotificationsViewController.swift
+++ b/Sources/Controllers/Notifications/NotificationsViewController.swift
@@ -266,6 +266,5 @@ extension NotificationsViewController: AnnouncementDelegate {
         for announcement in announcements {
             Tracker.sharedTracker.announcementViewed(announcement)
         }
-        print("=============== \(#file) line \(#line) ===============")
     }
 }

--- a/Sources/Controllers/Notifications/NotificationsViewController.swift
+++ b/Sources/Controllers/Notifications/NotificationsViewController.swift
@@ -77,6 +77,13 @@ public class NotificationsViewController: StreamableViewController, Notification
         PushNotificationController.sharedController.updateBadgeNumber(0)
     }
 
+    override public func viewDidAppear(animated: Bool) {
+        super.viewDidAppear(animated)
+
+        let jsonables = streamViewController.dataSource.streamCellItems.map { $0.jsonable }
+        track(jsonables: jsonables)
+    }
+
     func initialLoad() {
         ElloHUD.showLoadingHudInView(streamViewController.view)
         generator?.load(reload: false)
@@ -220,18 +227,17 @@ extension NotificationsViewController: StreamDestination {
     }
 
     public func replacePlaceholder(type: StreamCellType.PlaceholderType, items: [StreamCellItem], completion: ElloEmptyCompletion) {
+        if type == .Announcements {
+            let jsonables = items.map { $0.jsonable }
+            track(jsonables: jsonables)
+        }
+
         streamViewController.replacePlaceholder(type, with: items, completion: completion)
     }
 
     public func setPlaceholders(items: [StreamCellItem]) {
         streamViewController.clearForInitialLoad()
         streamViewController.appendUnsizedCellItems(items, withWidth: view.frame.width) { _ in }
-
-        for item in items {
-            if let announcement = item.jsonable as? Announcement {
-                Tracker.sharedTracker.announcementViewed(announcement)
-            }
-        }
     }
 
     public func setPrimaryJSONAble(jsonable: JSONAble) {
@@ -247,11 +253,19 @@ extension NotificationsViewController: StreamDestination {
     }
 }
 
-// MARK: NotificationsViewController:
+// MARK: NotificationsViewController: AnnouncementDelegate
 extension NotificationsViewController: AnnouncementDelegate {
     public func markAnnouncementAsRead(_ announcement: Announcement) {
         Tracker.sharedTracker.announcementDismissed(announcement)
         generator?.markAnnouncementAsRead(announcement)
         postNotification(JSONAbleChangedNotification, value: (announcement, .Delete))
+    }
+
+    public func track(jsonables jsonables: [JSONAble]) {
+        let announcements: [Announcement] = jsonables.flatMap { $0 as? Announcement }
+        for announcement in announcements {
+            Tracker.sharedTracker.announcementViewed(announcement)
+        }
+        print("=============== \(#file) line \(#line) ===============")
     }
 }


### PR DESCRIPTION
The tracking code was in the placeholders callback, not replace-items, and needed to be triggered on `viewDidAppear`