### PR TITLE
Fixes image uploads on new user

### DIFF
--- a/Sources/Controllers/Onboarding/CreateProfileViewController.swift
+++ b/Sources/Controllers/Onboarding/CreateProfileViewController.swift
@@ -207,6 +207,8 @@ extension CreateProfileViewController: OnboardingStepController {
             cancelCompletion: {
                 guard let onboardingView = self.onboardingViewController?.view else { return }
                 ElloHUD.hideLoadingHudInView(onboardingView)
+
+                proceedClosure(.continue)
         })
     }
 }

--- a/Sources/Model/Regions/Asset.swift
+++ b/Sources/Model/Regions/Asset.swift
@@ -10,6 +10,18 @@ let AssetVersion = 1
 
 @objc(Asset)
 final class Asset: JSONAble {
+    enum AttachmentType {
+        case optimized
+        case smallScreen
+        case ldpi
+        case mdpi
+        case hdpi
+        case xhdpi
+        case original
+        case large
+        case regular
+        case small
+    }
 
     // active record
     let id: String
@@ -39,6 +51,14 @@ final class Asset: JSONAble {
     var large: Attachment?
     var regular: Attachment?
     var small: Attachment?
+    var allAttachments: [(AttachmentType, Attachment)] {
+        let possibles: [(AttachmentType, Attachment?)] = [(.optimized, optimized), (.smallScreen, smallScreen), (.ldpi, ldpi), (.mdpi, mdpi), (.hdpi, hdpi), (.xhdpi, xhdpi), (.original, original), (.large, large), (.regular, regular), (.small, small)]
+        return possibles.flatMap() { type, attachment in
+            guard  let attachment = attachment else { return nil }
+            return (type, attachment)
+        }
+    }
+
     // computed
     var isGif: Bool {
         return self.optimized?.type == "image/gif"
@@ -73,6 +93,15 @@ final class Asset: JSONAble {
 
         let attachment = Attachment(url: url)
         self.optimized = attachment
+        self.smallScreen = attachment
+        self.ldpi = attachment
+        self.mdpi = attachment
+        self.hdpi = attachment
+        self.xhdpi = attachment
+        self.original = attachment
+        self.large = attachment
+        self.regular = attachment
+        self.small = attachment
     }
 
     convenience init(url: URL, gifData: Data, posterImage: UIImage) {
@@ -191,6 +220,33 @@ final class Asset: JSONAble {
             asset.small = Attachment.fromJSON(small) as? Attachment
         }
         return asset
+    }
+}
+
+extension Asset {
+    func replace(attachmentType: AttachmentType, with attachment: Attachment?) {
+        switch attachmentType {
+        case .optimized:
+            optimized = attachment
+        case .smallScreen:
+            smallScreen = attachment
+        case .ldpi:
+            ldpi = attachment
+        case .mdpi:
+            mdpi = attachment
+        case .hdpi:
+            hdpi = attachment
+        case .xhdpi:
+            xhdpi = attachment
+        case .original:
+            original = attachment
+        case .large:
+            large = attachment
+        case .regular:
+            regular = attachment
+        case .small:
+            small = attachment
+        }
     }
 }
 

--- a/Sources/Model/User.swift
+++ b/Sources/Model/User.swift
@@ -348,6 +348,38 @@ extension User {
 }
 
 extension User {
+    func updateDefaultImages(avatarURL: URL?, coverImageURL: URL?) {
+        if let avatarURL = avatarURL {
+            if let avatar = avatar {
+                let replacement = Attachment(url: avatarURL)
+                for (type, attachment) in avatar.allAttachments {
+                    if attachment.url.absoluteString.contains("/ello-default-") {
+                        avatar.replace(attachmentType: type, with: replacement)
+                    }
+                }
+            }
+            else {
+                avatar = Asset(url: avatarURL)
+            }
+        }
+
+        if let coverImageURL = coverImageURL {
+            if let coverImage = coverImage {
+                let replacement = Attachment(url: coverImageURL)
+                for (type, attachment) in coverImage.allAttachments {
+                    if attachment.url.absoluteString.contains("/ello-default-") {
+                        coverImage.replace(attachmentType: type, with: replacement)
+                    }
+                }
+            }
+            else {
+                coverImage = Asset(url: coverImageURL)
+            }
+        }
+    }
+}
+
+extension User {
     func coverImageURL(viewsAdultContent: Bool? = false, animated: Bool = false) -> URL? {
         if animated && (!postsAdultContent || viewsAdultContent == true) && coverImage?.original?.url.absoluteString.hasSuffix(".gif") == true {
             return coverImage?.original?.url as URL?

--- a/Sources/Networking/ProfileService.swift
+++ b/Sources/Networking/ProfileService.swift
@@ -46,6 +46,7 @@ struct ProfileService {
         properties: [String: AnyObject] = [:],
         success: @escaping ProfileUploadSuccessCompletion, failure: @escaping ElloFailureCompletion) {
         updateUserImage(image, key: "remote_cover_image_url", properties: properties, success: { (url, user) in
+            user.updateDefaultImages(avatarURL: nil, coverImageURL: url)
             TemporaryCache.save(.coverImage, image: image.image)
             success(url, user)
         }, failure: failure)
@@ -56,6 +57,7 @@ struct ProfileService {
         properties: [String: AnyObject] = [:],
         success: @escaping ProfileUploadSuccessCompletion, failure: @escaping ElloFailureCompletion) {
         updateUserImage(image, key: "remote_avatar_url", properties: properties, success: { (url, user) in
+            user.updateDefaultImages(avatarURL: url, coverImageURL: nil)
             TemporaryCache.save(.avatar, image: image.image)
             success(url, user)
         }, failure: failure)
@@ -90,6 +92,7 @@ struct ProfileService {
                 }
 
                 self.updateUserProfile(mergedProperties, success: { user in
+                    user.updateDefaultImages(avatarURL: avatarURL, coverImageURL: coverImageURL)
                     success(avatarURL, coverImageURL, user)
                 }, failure: failure)
             }

--- a/Sources/Utilities/TemporaryCache.swift
+++ b/Sources/Utilities/TemporaryCache.swift
@@ -38,7 +38,7 @@ struct TemporaryCache {
             entry = TemporaryCache.avatar
         }
 
-        if let entry = entry, (entry.expiration as NSDate).earlierDate(date) == date {
+        if let entry = entry, entry.expiration > date {
             return entry.image
         }
         return nil

--- a/Specs/Model/UserSpec.swift
+++ b/Specs/Model/UserSpec.swift
@@ -325,5 +325,43 @@ class UserSpec: QuickSpec {
                 expect(merged.formattedShortBio) == "userA"
             }
         }
+
+        describe("updateDefaultImages") {
+            let uploadedURL = URL(string: "https://assets0.ello.co/images/uploaded.png")
+            let defaultAsset: Asset = stub(["url": "https://assets0.ello.co/images/ello-default-large.png"])
+            let customAsset: Asset = stub(["url": "https://assets0.ello.co/images/custom.png"])
+
+            it("ignores nil URLs") {
+                let user = User.stub(["avatar": defaultAsset, "coverImage": defaultAsset])
+                user.updateDefaultImages(avatarURL: nil, coverImageURL: nil)
+                expect(user.avatarURL()?.absoluteString).to(contain("ello-default-large"))
+            }
+            it("ignores replaces nil assets") {
+                let user = User.stub([:])
+                user.updateDefaultImages(avatarURL: uploadedURL, coverImageURL: uploadedURL)
+                expect(user.avatarURL()?.absoluteString).to(contain("uploaded"))
+                expect(user.coverImageURL()?.absoluteString).to(contain("uploaded"))
+            }
+            it("replaces default avatar") {
+                let user = User.stub(["avatar": defaultAsset])
+                user.updateDefaultImages(avatarURL: uploadedURL, coverImageURL: nil)
+                expect(user.avatarURL()?.absoluteString).to(contain("uploaded"))
+            }
+            it("replaces default cover image") {
+                let user = User.stub(["coverImage": defaultAsset])
+                user.updateDefaultImages(avatarURL: uploadedURL, coverImageURL: nil)
+                expect(user.coverImageURL()?.absoluteString).to(contain("uploaded"))
+            }
+            it("ignores custom avatar") {
+                let user = User.stub(["avatar": customAsset])
+                user.updateDefaultImages(avatarURL: nil, coverImageURL: uploadedURL)
+                expect(user.avatarURL()?.absoluteString).to(contain("custom"))
+            }
+            it("ignores custom cover image") {
+                let user = User.stub(["coverImage": customAsset])
+                user.updateDefaultImages(avatarURL: nil, coverImageURL: uploadedURL)
+                expect(user.coverImageURL()?.absoluteString).to(contain("custom"))
+            }
+        }
     }
 }


### PR DESCRIPTION
The API returns `ello-default-*` image URLs, even after the user has uploaded images.  This fixes that by detecting those URLs after a successful upload, and replacing the default images with the S3 image URLs.