### PR TITLE
Locks down dependencies

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -22,10 +22,10 @@ def ello_app_pods
   pod 'KINWebBrowser', git: 'https://github.com/ello/KINWebBrowser'
   pod 'PINRemoteImage', git: 'https://github.com/pinterest/PINRemoteImage.git', commit: 'af312667f0ce830264198366f481f1b222675a31'
   pod 'SSPullToRefresh', '~> 1.2'
-  pod 'ImagePickerSheetController', git: 'https://github.com/lbrndnr/ImagePickerSheetController', branch: 'swift2.3-improvements'
+  pod 'ImagePickerSheetController', git: 'https://github.com/lbrndnr/ImagePickerSheetController', commit: '92bcc3fde8def54c1947771247d5d677377a2f39'
   pod 'iRate', '~> 1.11'
   # swift pods
-  pod 'TimeAgoInWords', git: 'https://github.com/ello/TimeAgoInWords'
+  pod 'TimeAgoInWords', git: 'https://github.com/ello/TimeAgoInWords', commit: '3cf3e8b3b8d76168a2324294db70790fade54925'
   pod 'WebLinking', '~> 1.0'
   pod 'SnapKit', git: 'https://github.com/SnapKit/SnapKit', commit: '307d03ec433d61fbb25c9c4a6bb32689537db4d6'
   pod 'FutureKit', '~> 2.0'
@@ -44,7 +44,7 @@ def common_pods
     pod 'ElloOSSCerts', '~> 1.1'
   end
   pod 'MBProgressHUD', '~> 0.9.0'
-  pod 'SVGKit', git: 'https://github.com/SVGKit/SVGKit'
+  pod 'SVGKit', git: 'https://github.com/ello/SVGKit', commit: '6160bbdfd0a8924b5e57b13c462db6a0944c8966'
   pod 'FLAnimatedImage', '~> 1.0'
   pod 'YapDatabase', '2.8.1'
   pod 'Alamofire', '~> 3.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,47 +1,49 @@
 PODS:
   - 1PasswordExtension (1.6.1)
-  - Alamofire (3.5.0)
+  - Alamofire (3.5.1)
   - Analytics/Core-iOS (2.0.17):
     - TRVSDictionaryWithCaseInsensitivity (= 0.0.2)
   - Analytics/Segmentio (2.0.17):
     - Analytics/Core-iOS
-  - CocoaLumberjack (2.3.0):
-    - CocoaLumberjack/Default (= 2.3.0)
-    - CocoaLumberjack/Extensions (= 2.3.0)
-  - CocoaLumberjack/Core (2.3.0)
-  - CocoaLumberjack/Default (2.3.0):
+  - CocoaLumberjack (2.4.0):
+    - CocoaLumberjack/Default (= 2.4.0)
+    - CocoaLumberjack/Extensions (= 2.4.0)
+  - CocoaLumberjack/Core (2.4.0)
+  - CocoaLumberjack/Default (2.4.0):
     - CocoaLumberjack/Core
-  - CocoaLumberjack/Extensions (2.3.0):
+  - CocoaLumberjack/Extensions (2.4.0):
     - CocoaLumberjack/Default
-  - Crashlytics (3.8.1):
+  - Crashlytics (3.8.3):
     - Fabric (~> 1.6.3)
   - CRToast (0.0.7)
   - DeltaCalculator (1.0.4)
   - ElloCerts (1.2.0):
     - Alamofire (~> 3.0)
   - ElloUIFonts (1.2.0)
-  - Fabric (1.6.8)
+  - Fabric (1.6.11)
   - FBSnapshotTestCase (2.1.2):
     - FBSnapshotTestCase/SwiftSupport (= 2.1.2)
   - FBSnapshotTestCase/Core (2.1.2)
   - FBSnapshotTestCase/SwiftSupport (2.1.2):
     - FBSnapshotTestCase/Core
   - FLAnimatedImage (1.0.12)
-  - FutureKit (2.0.0)
+  - FutureKit (2.3.0)
   - ImagePickerSheetController (0.9.1)
-  - iRate (1.11.6)
+  - iRate (1.11.7)
   - JTSImageViewController (1.5)
   - KeychainAccess (2.4.0)
   - Keys (1.0.0)
   - KINWebBrowser (1.1.0)
   - MBProgressHUD (0.9.2)
-  - Moya (7.0.2):
-    - Moya/Core (= 7.0.2)
-  - Moya/Core (7.0.2):
+  - Moya (7.0.4):
+    - Moya/Core (= 7.0.4)
+  - Moya/Core (7.0.4):
     - Alamofire (~> 3.5)
     - Result (~> 2.0)
   - Nimble (4.1.0)
-  - Nimble-Snapshots (4.1.0):
+  - Nimble-Snapshots (4.4.2):
+    - Nimble-Snapshots/Core (= 4.4.2)
+  - Nimble-Snapshots/Core (4.4.2):
     - FBSnapshotTestCase (~> 2.0)
     - Nimble
     - Quick
@@ -134,7 +136,7 @@ DEPENDENCIES:
   - FBSnapshotTestCase (from `https://github.com/ello/ios-snapshot-test-case`)
   - FLAnimatedImage (~> 1.0)
   - FutureKit (~> 2.0)
-  - ImagePickerSheetController (from `https://github.com/lbrndnr/ImagePickerSheetController`, branch `swift2.3-improvements`)
+  - ImagePickerSheetController (from `https://github.com/lbrndnr/ImagePickerSheetController`, commit `92bcc3fde8def54c1947771247d5d677377a2f39`)
   - iRate (~> 1.11)
   - JTSImageViewController (from `https://github.com/ello/JTSImageViewController`)
   - KeychainAccess (~> 2.4.0)
@@ -149,10 +151,10 @@ DEPENDENCIES:
   - Quick (~> 0.9.3)
   - SnapKit (from `https://github.com/SnapKit/SnapKit`, commit `307d03ec433d61fbb25c9c4a6bb32689537db4d6`)
   - SSPullToRefresh (~> 1.2)
-  - SVGKit (from `https://github.com/SVGKit/SVGKit`)
+  - SVGKit (from `https://github.com/ello/SVGKit`, commit `6160bbdfd0a8924b5e57b13c462db6a0944c8966`)
   - SwiftyJSON (from `https://github.com/ello/SwiftyJSON`, branch `Swift-2.0`)
   - SwiftyUserDefaults (~> 1.3.0)
-  - TimeAgoInWords (from `https://github.com/ello/TimeAgoInWords`)
+  - TimeAgoInWords (from `https://github.com/ello/TimeAgoInWords`, commit `3cf3e8b3b8d76168a2324294db70790fade54925`)
   - WebLinking (~> 1.0)
   - YapDatabase (= 2.8.1)
 
@@ -164,7 +166,7 @@ EXTERNAL SOURCES:
   FBSnapshotTestCase:
     :git: https://github.com/ello/ios-snapshot-test-case
   ImagePickerSheetController:
-    :branch: swift2.3-improvements
+    :commit: 92bcc3fde8def54c1947771247d5d677377a2f39
     :git: https://github.com/lbrndnr/ImagePickerSheetController
   JTSImageViewController:
     :git: https://github.com/ello/JTSImageViewController
@@ -181,11 +183,13 @@ EXTERNAL SOURCES:
     :commit: 307d03ec433d61fbb25c9c4a6bb32689537db4d6
     :git: https://github.com/SnapKit/SnapKit
   SVGKit:
-    :git: https://github.com/SVGKit/SVGKit
+    :commit: 6160bbdfd0a8924b5e57b13c462db6a0944c8966
+    :git: https://github.com/ello/SVGKit
   SwiftyJSON:
     :branch: Swift-2.0
     :git: https://github.com/ello/SwiftyJSON
   TimeAgoInWords:
+    :commit: 3cf3e8b3b8d76168a2324294db70790fade54925
     :git: https://github.com/ello/TimeAgoInWords
 
 CHECKOUT OPTIONS:
@@ -199,7 +203,7 @@ CHECKOUT OPTIONS:
     :commit: 9dd0dd1ddb177adc3555df0c2dfd3b6848eaba9b
     :git: https://github.com/ello/ios-snapshot-test-case
   ImagePickerSheetController:
-    :commit: 252a1228f2e9bb7302e296389f8e7232c86c2330
+    :commit: 92bcc3fde8def54c1947771247d5d677377a2f39
     :git: https://github.com/lbrndnr/ImagePickerSheetController
   JTSImageViewController:
     :commit: 4f0a918c38c7606fc5f876774cd3b96701b3f548
@@ -208,7 +212,7 @@ CHECKOUT OPTIONS:
     :commit: bcf29fd0beb6afb1c28a236306ad0fa1b8677bf3
     :git: https://github.com/ello/KINWebBrowser
   Nimble-Snapshots:
-    :commit: 98eb1755a60e03c89a05ab7121f6a9454dca37b2
+    :commit: 26c5ba0a953faccb358f139c60461f3010da7e56
     :git: https://github.com/ashfurrow/Nimble-Snapshots
   PINRemoteImage:
     :commit: af312667f0ce830264198366f481f1b222675a31
@@ -217,8 +221,8 @@ CHECKOUT OPTIONS:
     :commit: 307d03ec433d61fbb25c9c4a6bb32689537db4d6
     :git: https://github.com/SnapKit/SnapKit
   SVGKit:
-    :commit: df5f4a2fad08cfdbc930c007b5c66d65a0295d6e
-    :git: https://github.com/SVGKit/SVGKit
+    :commit: 6160bbdfd0a8924b5e57b13c462db6a0944c8966
+    :git: https://github.com/ello/SVGKit
   SwiftyJSON:
     :commit: c96832365b9ba4e8fa17fad2fa67399e3ed055de
     :git: https://github.com/ello/SwiftyJSON
@@ -228,28 +232,28 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   1PasswordExtension: faed6b7ab3f1e26551b08fef580c88bff0d0f247
-  Alamofire: b70a7352335f8ea5babd0a923eb7e8eacc67b877
+  Alamofire: 0dfba1184a543e2aa160f4e39cac4e8aba48d223
   Analytics: 51d6163cb568c8ede69f2b92ef4779d91e1524e2
-  CocoaLumberjack: 97fab7ee5f507fe54445cca7ea80f926729cfd15
-  Crashlytics: 4391d8df0b125345e9f209c5db6e7f40a6a8435d
+  CocoaLumberjack: aa9dcab71bdf9eaf2a63bbd9ddc87863efe45457
+  Crashlytics: 2b6dbe138a42395577cfa73dfa1aa7248cadf39e
   CRToast: eb22641501990233c53cb8f83f7d2ea87e0ddf73
   DeltaCalculator: 97ea120ac2ebcf55e472d7ba872c8bc79c138454
   ElloCerts: 75bad99e881ee0c8160fbd32bf57fd10fd217d8b
   ElloUIFonts: 9c1dddfae6479ade038a0b18009e45b4f7a93eed
-  Fabric: 5755268d0171435ab167e3d0878a28a777deaf10
+  Fabric: 5911403591946b8228ab1c51d98f1d7137e863c6
   FBSnapshotTestCase: 918c55861356ee83aee7843d759f55a18ff6982b
   FLAnimatedImage: 4a0b56255d9b05f18b6dd7ee06871be5d3b89e31
-  FutureKit: 409baf0c683f4cdd1784b90782f43386ca3749a5
+  FutureKit: 55901ceb084dda25d089bc9f0d7050722a533648
   ImagePickerSheetController: 39ae352f5d93a328e9ed64dca2951de42d0d093b
-  iRate: 61e558919c4a7fde63b3c22ebbd6c114a1eee658
+  iRate: adae3f183d83c925ac42d7a2e86e89e838963f57
   JTSImageViewController: 89ae3c003060c65418fd3224ebbd67acc6046608
   KeychainAccess: c2a71459af5bddf720a51806046a598500976c04
   Keys: 9c35bf00f612ee1d48556f4a4b9b4551e224e90f
   KINWebBrowser: dad85d7d93e6f4620a8589b96992394affffa66e
   MBProgressHUD: 1569cf7ace17a8bac47aabfbb8580a49690386d1
-  Moya: 430be684a6a53d5ad8c0b8222c4232d4f1810848
+  Moya: d309d994aa096916c4d95bc2a162789b4745d7cb
   Nimble: 97a0a4cae5124c117115634b2d055d8c97d0af19
-  Nimble-Snapshots: 2da4d2ec829b458d6886c06812c52493fce284c9
+  Nimble-Snapshots: 9dc8c47ce13d68652caf2510d697c25eb732e487
   OHHTTPStubs: b393565822317305b87a1440d4c7aff131679f66
   PINCache: ce36ed282031b92fc7733ffe831f474ff80fddc2
   PINRemoteImage: 77a7f7bfacd2b4040786a0e31192a81003fdd41f
@@ -265,6 +269,6 @@ SPEC CHECKSUMS:
   WebLinking: 3f71787c14a225148e8be29fe6e7c98597cbc459
   YapDatabase: 861c720d5850a59f9e5c0bad0fd95334012b9dc9
 
-PODFILE CHECKSUM: b974527c0946f4461e2c39453f26ab2f7281cc3c
+PODFILE CHECKSUM: 2efc1d2cd421f509e7c30f91678a6a47f5bf41ff
 
 COCOAPODS: 1.0.1

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -93,7 +93,7 @@ end
 ######################### PRIVATE LANES #########################
 
 private_lane :switch_to_prod do
-  `bundle exec rake generate:staging_keys`
+  `bundle exec rake generate:prod_keys`
 end
 
 private_lane :compile do


### PR DESCRIPTION
A few dependencies were not locked down tightly enough. 

`ImagePickerSheetController` removed their `swift2.3-improvements` branch out from under us and `TimeAgoInWords` and `SVGKit` changed. `Podfile` now locks down to individual commits on those 3 pods.