### PR TITLE
Fixes to Notifications and other Stream loading/reloading

### DIFF
--- a/Sources/Controllers/Categories/CategoryViewController.swift
+++ b/Sources/Controllers/Categories/CategoryViewController.swift
@@ -151,7 +151,7 @@ extension CategoryViewController: CategoryStreamDestination, StreamDestination {
 
     public func setPlaceholders(items: [StreamCellItem]) {
         streamViewController.clearForInitialLoad()
-        streamViewController.appendUnsizedCellItems(items, withWidth: view.frame.width) { _ in }
+        streamViewController.appendStreamCellItems(items)
     }
 
     public func setPrimaryJSONAble(jsonable: JSONAble) {
@@ -171,6 +171,7 @@ extension CategoryViewController: CategoryStreamDestination, StreamDestination {
             self.pagePromotional = pagePromotional
         }
         updateInsets()
+        streamViewController.doneLoading()
     }
 
     public func setCategories(categories: [Category]) {

--- a/Sources/Controllers/Notifications/NotificationsGenerator.swift
+++ b/Sources/Controllers/Notifications/NotificationsGenerator.swift
@@ -33,8 +33,10 @@ public final class NotificationsGenerator: StreamGenerator {
             announcements = []
             notifications = []
         }
+        else {
+            setPlaceHolders()
+        }
 
-        setPlaceHolders()
         loadAnnouncements()
         loadNotifications()
     }

--- a/Sources/Controllers/Notifications/NotificationsViewController.swift
+++ b/Sources/Controllers/Notifications/NotificationsViewController.swift
@@ -63,7 +63,7 @@ public class NotificationsViewController: StreamableViewController, Notification
         scrollLogic.prevOffset = streamViewController.collectionView.contentOffset
         scrollLogic.navBarHeight = 44
 
-        reload()
+        initialLoad()
     }
 
     override public func viewWillAppear(animated: Bool) {
@@ -93,7 +93,6 @@ public class NotificationsViewController: StreamableViewController, Notification
         ElloHUD.showLoadingHudInView(streamViewController.view)
         hasNewContent = false
 
-        generator?.streamKind = categoryStreamKind
         generator?.load(reload: true)
     }
 
@@ -127,7 +126,6 @@ public class NotificationsViewController: StreamableViewController, Notification
         updateInsets()
     }
 
-
     // used to provide StreamableViewController access to the container it then
     // loads the StreamViewController's content into
     override func viewForStream() -> UIView {
@@ -143,11 +141,11 @@ public class NotificationsViewController: StreamableViewController, Notification
         screen.selectFilterButton(filterType)
         categoryFilterType = filterType
 
+        generator?.streamKind = categoryStreamKind
         streamViewController.streamKind = categoryStreamKind
         streamViewController.hideNoResults()
         streamViewController.removeAllCellItems()
-
-        reload()
+        streamViewController.loadInitialPage()
     }
 
     public func commentTapped(comment: ElloComment) {
@@ -237,7 +235,7 @@ extension NotificationsViewController: StreamDestination {
 
     public func setPlaceholders(items: [StreamCellItem]) {
         streamViewController.clearForInitialLoad()
-        streamViewController.appendUnsizedCellItems(items, withWidth: view.frame.width) { _ in }
+        streamViewController.appendStreamCellItems(items)
     }
 
     public func setPrimaryJSONAble(jsonable: JSONAble) {

--- a/Sources/Controllers/Profile/ProfileViewController.swift
+++ b/Sources/Controllers/Profile/ProfileViewController.swift
@@ -456,7 +456,7 @@ extension ProfileViewController:  StreamDestination {
 
     public func setPlaceholders(items: [StreamCellItem]) {
         streamViewController.clearForInitialLoad()
-        streamViewController.appendUnsizedCellItems(items, withWidth: view.frame.width) { _ in }
+        streamViewController.appendStreamCellItems(items)
         setupNavigationItems()
     }
 
@@ -465,6 +465,7 @@ extension ProfileViewController:  StreamDestination {
 
         self.user = user
         updateUser(user)
+        streamViewController.doneLoading()
 
         userParam = user.id
         title = user.atName

--- a/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
+++ b/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
@@ -222,12 +222,7 @@ extension PostDetailViewController: StreamDestination {
     }
 
     public func replacePlaceholder(type: StreamCellType.PlaceholderType, items: [StreamCellItem], completion: ElloEmptyCompletion) {
-        streamViewController.replacePlaceholder(type, with: items, completion: completion)
-    }
-
-    public func setPlaceholders(items: [StreamCellItem]) {
-        streamViewController.clearForInitialLoad()
-        streamViewController.appendUnsizedCellItems(items, withWidth: view.frame.width) { _ in
+        streamViewController.replacePlaceholder(type, with: items) {
             if let scrollToComment = self.scrollToComment {
                 // nextTick didn't work, the collection view hadn't shown its
                 // cells or updated contentView.  so this.
@@ -235,13 +230,20 @@ extension PostDetailViewController: StreamDestination {
                     self.scrollToComment(scrollToComment)
                 }
             }
+            completion()
         }
+    }
+
+    public func setPlaceholders(items: [StreamCellItem]) {
+        streamViewController.clearForInitialLoad()
+        streamViewController.appendStreamCellItems(items)
     }
 
     public func setPrimaryJSONAble(jsonable: JSONAble) {
         guard let post = jsonable as? Post else { return }
 
         self.post = post
+        streamViewController.doneLoading()
 
         // need to reassign the userParam to the id for paging
         self.postParam = post.id

--- a/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
+++ b/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
@@ -133,17 +133,24 @@ public final class PostDetailViewController: StreamableViewController {
         }
     }
 
-    private func scrollToComment(comment: ElloComment) {
+    private func checkScrollToComment() {
+        guard let comment = self.scrollToComment else { return }
+
         let commentItem = streamViewController.dataSource.visibleCellItems.find { item in
             return (item.jsonable as? ElloComment)?.id == comment.id
         } ?? streamViewController.dataSource.visibleCellItems.last
 
         if let commentItem = commentItem, indexPath = self.streamViewController.dataSource.indexPathForItem(commentItem) {
-            self.streamViewController.collectionView.scrollToItemAtIndexPath(
-                indexPath,
-                atScrollPosition: .Top,
-                animated: true
-            )
+            self.scrollToComment = nil
+            // nextTick didn't work, the collection view hadn't shown its
+            // cells or updated contentView.  so this.
+            delay(0.1) {
+                self.streamViewController.collectionView.scrollToItemAtIndexPath(
+                    indexPath,
+                    atScrollPosition: .Top,
+                    animated: true
+                )
+            }
         }
     }
 
@@ -223,13 +230,7 @@ extension PostDetailViewController: StreamDestination {
 
     public func replacePlaceholder(type: StreamCellType.PlaceholderType, items: [StreamCellItem], completion: ElloEmptyCompletion) {
         streamViewController.replacePlaceholder(type, with: items) {
-            if let scrollToComment = self.scrollToComment {
-                // nextTick didn't work, the collection view hadn't shown its
-                // cells or updated contentView.  so this.
-                delay(0.1) {
-                    self.scrollToComment(scrollToComment)
-                }
-            }
+            self.checkScrollToComment()
             completion()
         }
     }

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -723,9 +723,9 @@ extension StreamViewController: GridListToggleDelegate {
         else {
             UIView.animateWithDuration(0.2, animations: {
                 self.collectionView.alpha = 0
-                }, completion: { _ in
-                    self.toggleGrid(isGridView)
-                })
+            }, completion: { _ in
+                self.toggleGrid(isGridView)
+            })
         }
     }
 

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -208,7 +208,7 @@ public final class StreamViewController: BaseElloViewController {
     public var contentInset: UIEdgeInsets {
         get { return collectionView.contentInset }
         set {
-            collectionView.elloContentInset = newValue
+            collectionView.contentInset = newValue
             collectionView.scrollIndicatorInsets = newValue
             pullToRefreshView?.defaultContentInset = newValue
         }

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -313,8 +313,8 @@ public final class StreamViewController: BaseElloViewController {
         reloadCells(now: true)
     }
 
-    public func appendUnsizedCellItems(items: [StreamCellItem], withWidth: CGFloat?, completion: StreamDataSource.StreamContentReady? = nil) {
-        let width = withWidth ?? self.view.frame.width
+    public func appendUnsizedCellItems(items: [StreamCellItem], completion: StreamDataSource.StreamContentReady? = nil) {
+        let width = view.frame.width
         dataSource.appendUnsizedCellItems(items, withWidth: width) { indexPaths in
             self.reloadCells()
             self.doneLoading()
@@ -323,7 +323,8 @@ public final class StreamViewController: BaseElloViewController {
     }
 
     public func insertUnsizedCellItems(cellItems: [StreamCellItem], startingIndexPath: NSIndexPath, completion: ElloEmptyCompletion? = nil) {
-        dataSource.insertUnsizedCellItems(cellItems, withWidth: self.view.frame.width, startingIndexPath: startingIndexPath) { _ in
+        let width = view.frame.width
+        dataSource.insertUnsizedCellItems(cellItems, withWidth: width, startingIndexPath: startingIndexPath) { _ in
             self.reloadCells()
             completion?()
         }
@@ -344,7 +345,8 @@ public final class StreamViewController: BaseElloViewController {
             item.placeholderType = placeholderType
         }
 
-        dataSource.calculateCellItems(streamCellItems, withWidth: view.frame.width) {
+        let width = view.frame.width
+        dataSource.calculateCellItems(streamCellItems, withWidth: width) {
             let indexPathsToReplace = self.dataSource.indexPathsForPlaceholderType(placeholderType)
             guard indexPathsToReplace.count > 0 else { return }
 
@@ -381,7 +383,7 @@ public final class StreamViewController: BaseElloViewController {
                     self.currentJSONables = []
                     var items = self.generateStreamCellItems([])
                     items.append(StreamCellItem(type: .EmptyStream(height: 282)))
-                    self.appendUnsizedCellItems(items, withWidth: nil, completion: { _ in })
+                    self.appendUnsizedCellItems(items, completion: { _ in })
                 })
         }
     }
@@ -393,9 +395,9 @@ public final class StreamViewController: BaseElloViewController {
         self.currentJSONables = jsonables
 
         let items = self.generateStreamCellItems(jsonables)
-        self.appendUnsizedCellItems(items, withWidth: nil, completion: { indexPaths in
+        self.appendUnsizedCellItems(items) { indexPaths in
             self.pagingEnabled = true
-        })
+        }
     }
 
     private func generateStreamCellItems(jsonables: [JSONAble]) -> [StreamCellItem] {
@@ -743,7 +745,7 @@ extension StreamViewController: GridListToggleDelegate {
             items = [item]
         }
 
-        self.appendUnsizedCellItems(items, withWidth: nil) { indexPaths in
+        self.appendUnsizedCellItems(items) { indexPaths in
             animate {
                 self.collectionView.alpha = 1
             }

--- a/Sources/Views/ElloCollectionView.swift
+++ b/Sources/Views/ElloCollectionView.swift
@@ -5,32 +5,5 @@
 import UIKit
 
 
-//
-// This `contentInset` nonsense is to prevent UIKit from setting the content
-// inset when we don't want it to.  Setting `automaticallyAdjustsContentInsets`
-// to `false` *should* prevent this from happening, but it doesn't.  So instead,
-// the `StreamViewController` sets `elloContentInset`.  If `contentInset` is
-// set outside the scope of `uikitOverride` being set, it will be *restored* to
-// whatever `elloContentInset` was set to.
-//
-// UG
-//
 public class ElloCollectionView: UICollectionView {
-    private var uikitOverride = false
-    public var elloContentInset: UIEdgeInsets = UIEdgeInsetsZero {
-        didSet {
-            uikitOverride = true
-            contentInset = elloContentInset
-            uikitOverride = false
-        }
-    }
-    override public var contentInset: UIEdgeInsets {
-        didSet {
-            if !uikitOverride {
-                uikitOverride = true
-                contentInset = elloContentInset
-                uikitOverride = false
-            }
-        }
-    }
 }

--- a/Specs/Controllers/Stream/StreamViewControllerSpec.swift
+++ b/Specs/Controllers/Stream/StreamViewControllerSpec.swift
@@ -116,7 +116,7 @@ class StreamViewControllerSpec: QuickSpec {
                 showController(controller)
                 controller.streamService.loadStream(endpoint: controller.streamKind.endpoint, streamKind: nil,
                     success: { (jsonables, responseConfig) in
-                        controller.appendUnsizedCellItems(StreamCellItemParser().parse(jsonables, streamKind: controller.streamKind), withWidth: nil)
+                        controller.appendUnsizedCellItems(StreamCellItemParser().parse(jsonables, streamKind: controller.streamKind))
                         controller.responseConfig = responseConfig
                         controller.doneLoading()
                     }, failure: { (error, statusCode) in
@@ -209,7 +209,7 @@ class StreamViewControllerSpec: QuickSpec {
                     service.loadUser(ElloAPI.FriendStream,
                         streamKind: nil,
                         success: { (user, responseConfig) in
-                        controller.appendUnsizedCellItems(StreamCellItemParser().parse(user.posts!, streamKind: .Following), withWidth: nil)
+                        controller.appendUnsizedCellItems(StreamCellItemParser().parse(user.posts!, streamKind: .Following))
                     }, failure: { _ in })
                 }
 


### PR DESCRIPTION
Most of the logic changes are in `NotificationsViewController`, but all the Generator-based controllers were clearing the HUD in `setPlaceholders`, which meant the HUD was going away immediately since that callback is called immediately.

The `ElloCollectionView` code is being reverted, we already reverted it in swift3.0, it was meant to fix a minor bug, but causes an issue with pull-to-refresh.