### PR TITLE
Fixes onboarding invite and scroll-to-last-comment

### DIFF
--- a/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
+++ b/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
@@ -138,7 +138,7 @@ public final class PostDetailViewController: StreamableViewController {
 
         let commentItem = streamViewController.dataSource.visibleCellItems.find { item in
             return (item.jsonable as? ElloComment)?.id == comment.id
-        } ?? streamViewController.dataSource.visibleCellItems.last
+        }
 
         if let commentItem = commentItem, indexPath = self.streamViewController.dataSource.indexPathForItem(commentItem) {
             self.scrollToComment = nil

--- a/Sources/Controllers/Stream/StreamDataSource.swift
+++ b/Sources/Controllers/Stream/StreamDataSource.swift
@@ -342,7 +342,7 @@ public class StreamDataSource: NSObject, UICollectionViewDataSource {
         case .Image:
             (cell as! StreamImageCell).streamImageCellDelegate = imageDelegate
             (cell as! StreamImageCell).streamEditingDelegate = editingDelegate
-        case .InviteFriends:
+        case .InviteFriends, .OnboardingInviteFriends:
             (cell as! StreamInviteFriendsCell).inviteDelegate = inviteDelegate
             (cell as! StreamInviteFriendsCell).inviteCache = inviteCache
         case .Notification:


### PR DESCRIPTION
A bug we found in swift3 is also in 1.20; tapping on "Invite" has no effect (because of the `.onboardingInviteFriend` cell type).

Also figured out "scroll to last comment", so I backported that one, too.