### PR TITLE
Just like in notifications: only set placeholders on initial load

### DIFF
--- a/Sources/Controllers/Profile/ProfileGenerator.swift
+++ b/Sources/Controllers/Profile/ProfileGenerator.swift
@@ -51,7 +51,13 @@ public final class ProfileGenerator: StreamGenerator {
         queue.addOperation(doneOperation)
 
         localToken = loadingToken.resetInitialPageLoadingToken()
-        setPlaceHolders()
+        if reload {
+            user = nil
+            posts = nil
+        }
+        else {
+            setPlaceHolders()
+        }
         setInitialUser(doneOperation)
         loadUser(doneOperation, reload: reload)
         loadUserPosts(doneOperation)

--- a/Sources/Controllers/Stream/Detail/PostDetailGenerator.swift
+++ b/Sources/Controllers/Stream/Detail/PostDetailGenerator.swift
@@ -35,7 +35,13 @@ public final class PostDetailGenerator: StreamGenerator {
 
         hasPaddedSocial = false
         localToken = loadingToken.resetInitialPageLoadingToken()
-        setPlaceHolders()
+
+        if reload {
+            post = nil
+        }
+        else {
+            setPlaceHolders()
+        }
         setInitialPost(doneOperation)
         loadPost(doneOperation, reload: reload)
         displayCommentBar(doneOperation)
@@ -73,7 +79,9 @@ private extension PostDetailGenerator {
     func loadPost(doneOperation: AsyncOperation, reload: Bool = false) {
         guard !doneOperation.finished || reload else { return }
 
-        self.destination?.replacePlaceholder(.PostHeader, items: [StreamCellItem(type: .StreamLoading)]) {}
+        if post == nil && !reload {
+            self.destination?.replacePlaceholder(.PostHeader, items: [StreamCellItem(type: .StreamLoading)]) {}
+        }
 
         // load the post with no comments
         PostService().loadPost(postParam, needsComments: false)


### PR DESCRIPTION
This allows content to "stick around" during a reload.  Tested in post detail and profile, reloading and infinite scroll.