### PR TITLE
Disable pull-to-refresh during Category selection in onboarding

### DIFF
--- a/Sources/Controllers/Onboarding/CategoriesSelectionViewController.swift
+++ b/Sources/Controllers/Onboarding/CategoriesSelectionViewController.swift
@@ -28,6 +28,7 @@ class CategoriesSelectionViewController: StreamableViewController, HasAppControl
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        streamViewController.pullToRefreshEnabled = false
         streamViewController.selectedCategoryDelegate = self
         ElloHUD.showLoadingHudInView(streamViewController.view)
         streamViewController.loadInitialPage()


### PR DESCRIPTION
Pending approval from @caseydoran on this "quick fix" (https://www.pivotaltracker.com/story/show/137182279)