### PR TITLE
Fixes the double spinner, and another stab at the contentInsets bug

### DIFF
--- a/Sources/Controllers/Categories/CategoryGenerator.swift
+++ b/Sources/Controllers/Categories/CategoryGenerator.swift
@@ -46,10 +46,10 @@ public final class CategoryGenerator: StreamGenerator {
     }
 
     public init(slug: String,
-                currentUser: User?,
-                streamKind: StreamKind,
-                destination: StreamDestination?
-        ) {
+        currentUser: User?,
+        streamKind: StreamKind,
+        destination: StreamDestination?
+    ) {
         self.slug = slug
         self.currentUser = currentUser
         self.streamKind = streamKind

--- a/Sources/Controllers/Categories/CategoryGenerator.swift
+++ b/Sources/Controllers/Categories/CategoryGenerator.swift
@@ -195,6 +195,10 @@ private extension CategoryGenerator {
         displayPostsOperation.addDependency(doneOperation)
         queue.addOperation(displayPostsOperation)
 
+        if !reload && posts != nil {
+            self.destination?.replacePlaceholder(.CategoryPosts, items: [StreamCellItem(type: .StreamLoading)]) {}
+        }
+
         var apiEndpoint: ElloAPI?
         if usesPagePromo() {
             guard let discoverType = DiscoverType.fromURL(slug) else { return }

--- a/Sources/Controllers/Categories/CategoryGenerator.swift
+++ b/Sources/Controllers/Categories/CategoryGenerator.swift
@@ -73,14 +73,22 @@ public final class CategoryGenerator: StreamGenerator {
         queue.addOperation(doneOperation)
 
         localToken = loadingToken.resetInitialPageLoadingToken()
-        setPlaceHolders()
+        if reload {
+            category = nil
+            categories = nil
+            pagePromotional = nil
+            posts = nil
+        }
+        else {
+            setPlaceHolders()
+        }
         setInitialJSONAble(doneOperation)
         loadCategories()
         loadCategory(doneOperation, reload: reload)
         if usesPagePromo() {
             loadPagePromotional(doneOperation)
         }
-        loadCategoryPosts(doneOperation)
+        loadCategoryPosts(doneOperation, reload: reload)
     }
 
     public func toggleGrid() {
@@ -182,12 +190,10 @@ private extension CategoryGenerator {
             }.ignoreFailures()
     }
 
-    func loadCategoryPosts(doneOperation: AsyncOperation) {
+    func loadCategoryPosts(doneOperation: AsyncOperation, reload: Bool) {
         let displayPostsOperation = AsyncOperation()
         displayPostsOperation.addDependency(doneOperation)
         queue.addOperation(displayPostsOperation)
-
-        self.destination?.replacePlaceholder(.CategoryPosts, items: [StreamCellItem(type: .StreamLoading)]) {}
 
         var apiEndpoint: ElloAPI?
         if usesPagePromo() {

--- a/Sources/Controllers/Categories/CategoryViewController.swift
+++ b/Sources/Controllers/Categories/CategoryViewController.swift
@@ -62,7 +62,7 @@ public final class CategoryViewController: StreamableViewController {
         scrollLogic.prevOffset = streamViewController.collectionView.contentOffset
         ElloHUD.showLoadingHudInView(streamViewController.view)
         streamViewController.initialLoadClosure = { [unowned self] in self.loadCategory() }
-        streamViewController.reloadClosure = { [unowned self] in self.reloadEntireCategory() }
+        streamViewController.reloadClosure = { [unowned self] in self.reloadCurrentCategory() }
         streamViewController.toggleClosure = { [unowned self] isGridView in self.toggleGrid(isGridView) }
 
         streamViewController.loadInitialPage()
@@ -125,10 +125,13 @@ private extension CategoryViewController {
     }
 
     func loadCategory() {
+        pagePromotional = nil
+        categoryPromotional = nil
+        category?.randomPromotional = nil
         generator?.load()
     }
 
-    func reloadEntireCategory() {
+    func reloadCurrentCategory() {
         pagePromotional = nil
         categoryPromotional = nil
         category?.randomPromotional = nil
@@ -240,6 +243,7 @@ extension CategoryViewController: CategoryScreenDelegate {
 
         guard let streamKind = kind else { return }
 
+
         category.randomPromotional = nil
         streamViewController.streamKind = streamKind
         gridListItem?.setImage(isGridView: streamKind.isGridView)
@@ -247,6 +251,6 @@ extension CategoryViewController: CategoryScreenDelegate {
         self.category = category
         self.slug = category.slug
         self.title = category.name
-        reloadEntireCategory()
+        loadCategory()
     }
 }

--- a/Sources/Controllers/Notifications/NotificationsViewController.swift
+++ b/Sources/Controllers/Notifications/NotificationsViewController.swift
@@ -90,7 +90,6 @@ public class NotificationsViewController: StreamableViewController, Notification
     }
 
     func reload() {
-        ElloHUD.showLoadingHudInView(streamViewController.view)
         hasNewContent = false
 
         generator?.load(reload: true)

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -208,9 +208,12 @@ public final class StreamViewController: BaseElloViewController {
     public var contentInset: UIEdgeInsets {
         get { return collectionView.contentInset }
         set {
+            // the order here is important, because SSPullToRefresh will try to
+            // set the contentInset, and that can have weird side effects, so
+            // we need to set the contentInset *after* pullToRefreshView.
+            pullToRefreshView?.defaultContentInset = newValue
             collectionView.contentInset = newValue
             collectionView.scrollIndicatorInsets = newValue
-            pullToRefreshView?.defaultContentInset = newValue
         }
     }
     public var columnCount: Int {


### PR DESCRIPTION
Double spinner was showing up on Post Detail, and also on the Category view.

If you tapped a post from notifications and refreshed it, the contentInsets were incorrect, I put in a simple fix for that (work around `SSPullToRefresh` overriding contentInset).