### PR TITLE
Fix double reposting crash

### DIFF
--- a/Sources/Controllers/Profile/ProfileViewController.swift
+++ b/Sources/Controllers/Profile/ProfileViewController.swift
@@ -32,7 +32,6 @@ final class ProfileViewController: StreamableViewController {
     var coverImageHeightStart: CGFloat?
     let initialStreamKind: StreamKind
     var currentUserChangedNotification: NotificationObserver?
-    var postChangedNotification: NotificationObserver?
     var relationshipChangedNotification: NotificationObserver?
     var deeplinkPath: String?
     var generator: ProfileGenerator?
@@ -94,8 +93,6 @@ final class ProfileViewController: StreamableViewController {
     deinit {
         currentUserChangedNotification?.removeObserver()
         currentUserChangedNotification = nil
-        postChangedNotification?.removeObserver()
-        postChangedNotification = nil
         relationshipChangedNotification?.removeObserver()
         relationshipChangedNotification = nil
     }

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -531,6 +531,7 @@ final class StreamViewController: BaseElloViewController {
                 .update,
                 .replaced,
                 .loved,
+                .reposted,
                 .watching:
                 self.dataSource.modifyItems(post, change: change, collectionView: self.collectionView)
             case .read: break

--- a/Sources/Model/ExperienceUpdate.swift
+++ b/Sources/Model/ExperienceUpdate.swift
@@ -19,6 +19,7 @@ enum ContentChange {
     case loved
     case watching
     case replaced
+    case reposted
     case delete
 
     static func updateCommentCount(_ comment: ElloComment, delta: Int) {


### PR DESCRIPTION
We were not preventing a user from reposting the same post twice which caused a crash on the second attempt.

For other actions, such as loving a post, the returned post in the api call has it's `loved` property set to true. Reposting is unique in that the API returns the new repost, not the updated original post. The result was reposted posts found in multiple streams were not updated correctly after reposting. 

This PR updates the reposted `Post` in `ElloLinkedStore` and posts a new experience update, `.reposted`.

[Fixes #288137191093](https://www.pivotaltracker.com/story/show/137191093)