### PR TITLE
Changes behavior of red-dot reloading in Notifications and Streams

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -59,7 +59,7 @@ end
 def spec_pods
   pod 'FBSnapshotTestCase'
   pod 'Quick', '~> 1.0'
-  pod 'Nimble', '5.1'
+  pod 'Nimble', '5.1.1'
   pod 'Nimble-Snapshots', '~> 4.4'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -41,7 +41,7 @@ PODS:
   - Moya/Core (8.0.0):
     - Alamofire (~> 4.2.0)
     - Result (~> 3.1.0)
-  - Nimble (5.1.0)
+  - Nimble (5.1.1)
   - Nimble-Snapshots (4.4.0):
     - Nimble-Snapshots/Core (= 4.4.0)
   - Nimble-Snapshots/Core (4.4.0):
@@ -133,7 +133,7 @@ DEPENDENCIES:
   - KINWebBrowser (from `https://github.com/ello/KINWebBrowser`)
   - MBProgressHUD (~> 0.9.0)
   - Moya (~> 8.0.0-beta.6)
-  - Nimble (= 5.1)
+  - Nimble (= 5.1.1)
   - Nimble-Snapshots (~> 4.4)
   - PINRemoteImage (from `https://github.com/pinterest/PINRemoteImage.git`, commit `af312667f0ce830264198366f481f1b222675a31`)
   - Quick (~> 1.0)
@@ -248,7 +248,7 @@ SPEC CHECKSUMS:
   KINWebBrowser: dad85d7d93e6f4620a8589b96992394affffa66e
   MBProgressHUD: 1569cf7ace17a8bac47aabfbb8580a49690386d1
   Moya: 850a166ab8241bd1c1cea6dbe012e3a2ad62944a
-  Nimble: 5ea121a2eda60440287054cde077fc0ad22227b3
+  Nimble: 415e3aa3267e7bc2c96b05fa814ddea7bb686a29
   Nimble-Snapshots: e743439f26c2fa99d8f7e0d7c01c99bcb40aa6f2
   PINCache: ce36ed282031b92fc7733ffe831f474ff80fddc2
   PINRemoteImage: 77a7f7bfacd2b4040786a0e31192a81003fdd41f
@@ -264,6 +264,6 @@ SPEC CHECKSUMS:
   WebLinking: 3f71787c14a225148e8be29fe6e7c98597cbc459
   YapDatabase: 861c720d5850a59f9e5c0bad0fd95334012b9dc9
 
-PODFILE CHECKSUM: 61588905f19f7d5b819c68efad6958429a636594
+PODFILE CHECKSUM: cb5cc74e76f9a8b541df4e98a5c03b0740984e24
 
 COCOAPODS: 1.1.1

--- a/Sources/Controllers/Notifications/NotificationsViewController.swift
+++ b/Sources/Controllers/Notifications/NotificationsViewController.swift
@@ -78,7 +78,7 @@ class NotificationsViewController: StreamableViewController, NotificationDelegat
         super.viewWillAppear(animated)
 
         if hasNewContent && fromTabBar {
-            reload()
+            reload(showSpinner: true)
         }
         fromTabBar = false
 
@@ -97,8 +97,11 @@ class NotificationsViewController: StreamableViewController, NotificationDelegat
         generator?.load(reload: false)
     }
 
-    func reload() {
+    func reload(showSpinner: Bool) {
         hasNewContent = false
+        if showSpinner {
+            ElloHUD.showLoadingHudInView(streamViewController.view)
+        }
 
         generator?.load(reload: true)
         Tracker.shared.screenAppeared(self)
@@ -115,7 +118,7 @@ class NotificationsViewController: StreamableViewController, NotificationDelegat
         streamViewController.announcementDelegate = self
         streamViewController.notificationDelegate = self
         streamViewController.initialLoadClosure = { [weak self] in self?.initialLoad() }
-        streamViewController.reloadClosure = { [weak self] in self?.reload() }
+        streamViewController.reloadClosure = { [weak self] in self?.reload(showSpinner: false) }
     }
 
     override func showNavBars() {
@@ -186,7 +189,7 @@ class NotificationsViewController: StreamableViewController, NotificationDelegat
             _ = navigationController?.popToRootViewController(animated: true)
         }
 
-        reload()
+        reload(showSpinner: true)
     }
 
 }
@@ -203,7 +206,7 @@ private extension NotificationsViewController {
             [weak self] _ in
             guard let `self` = self else { return }
             if self.navigationController?.childViewControllers.count == 1 {
-                self.reload()
+                self.reload(showSpinner: true)
             }
             else {
                 self.hasNewContent = true

--- a/Sources/Controllers/Stream/StreamContainerViewController.swift
+++ b/Sources/Controllers/Stream/StreamContainerViewController.swift
@@ -103,20 +103,15 @@ class StreamContainerViewController: StreamableViewController {
     }
 
     func reload(streamKind: StreamKind) {
-        let controller: StreamViewController?
         switch streamKind {
         case .following:
-            controller = childStreamControllers[0]
+            showSegmentIndex(0, forceReload: true)
+            streamsSegmentedControl.selectedSegmentIndex = 0
         case .starred:
-            controller = childStreamControllers[1]
+            showSegmentIndex(1, forceReload: true)
+            streamsSegmentedControl.selectedSegmentIndex = 1
         default:
-            controller = nil
-        }
-
-        if let controller = controller, controller == childStreamControllers[currentStreamIndex] {
-            ElloHUD.showLoadingHudInView(controller.view)
-            controller.loadInitialPage()
-            Tracker.shared.screenAppeared(self)
+            break
         }
     }
 
@@ -215,7 +210,7 @@ class StreamContainerViewController: StreamableViewController {
         streamsSegmentedControl = control
     }
 
-    fileprivate func showSegmentIndex(_ index: Int) {
+    fileprivate func showSegmentIndex(_ index: Int, forceReload: Bool) {
         for controller in childStreamControllers {
             controller.collectionView.scrollsToTop = false
         }
@@ -234,7 +229,10 @@ class StreamContainerViewController: StreamableViewController {
 
         setupNavigationBar(controller: currentController)
 
-        if !streamLoaded[index] {
+        if forceReload || !streamLoaded[index] {
+            if forceReload && streamLoaded[index] {
+                ElloHUD.showLoadingHudInView(currentController.view)
+            }
             streamLoaded[index] = true
             currentController.loadInitialPage()
         }
@@ -254,19 +252,19 @@ class StreamContainerViewController: StreamableViewController {
     }
 
     @IBAction func streamSegmentTapped(_ sender: UISegmentedControl) {
-        showSegmentIndex(sender.selectedSegmentIndex)
+        showSegmentIndex(sender.selectedSegmentIndex, forceReload: false)
     }
 }
 
 extension StreamContainerViewController {
 
     func showFriends() {
-        showSegmentIndex(0)
+        showSegmentIndex(0, forceReload: false)
         streamsSegmentedControl.selectedSegmentIndex = 0
     }
 
     func showNoise() {
-        showSegmentIndex(1)
+        showSegmentIndex(1, forceReload: false)
         streamsSegmentedControl.selectedSegmentIndex = 1
     }
 }

--- a/Specs/Controllers/Omnibar/OmnibarViewControllerSpec.swift
+++ b/Specs/Controllers/Omnibar/OmnibarViewControllerSpec.swift
@@ -80,7 +80,7 @@ class OmnibarViewControllerSpec: QuickSpec {
                     let post = Post.stub([
                         "author": User.stub(["username": "colinta"])
                         ])
-                    subject = OmnibarViewController(parentPost: post)
+                    subject = OmnibarViewController(parentPostId: post.id)
                     expect(subject).notTo(beNil())
                 }
 
@@ -105,7 +105,7 @@ class OmnibarViewControllerSpec: QuickSpec {
                     expect(subject.screen.isComment) == false
                 }
                 it("should be true for a new comment") {
-                    subject = OmnibarViewController(parentPost: stub([:]))
+                    subject = OmnibarViewController(parentPostId: "123")
                     showController(subject)
                     expect(subject.screen.isComment) == true
                 }
@@ -234,7 +234,7 @@ class OmnibarViewControllerSpec: QuickSpec {
                         ),
                     ])
 
-                    subject = OmnibarViewController(parentPost: post)
+                    subject = OmnibarViewController(parentPostId: post.id)
                     subject.currentUser = User.stub([:])
                     showController(subject)
                     let text = NSAttributedString(string: "test")
@@ -261,7 +261,7 @@ class OmnibarViewControllerSpec: QuickSpec {
                     omnibarData.regions = [attributedString, image]
                     let data = NSKeyedArchiver.archivedData(withRootObject: omnibarData)
 
-                    subject = OmnibarViewController(parentPost: post)
+                    subject = OmnibarViewController(parentPostId: post.id)
                     if let fileName = subject.omnibarDataName() {
                         _ = Tmp.write(data, to: fileName)
                     }
@@ -293,7 +293,7 @@ class OmnibarViewControllerSpec: QuickSpec {
                         "author": User.stub(["username": "colinta"])
                     ])
 
-                    subject = OmnibarViewController(parentPost: post)
+                    subject = OmnibarViewController(parentPostId: post.id)
                     screen = OmnibarMockScreen()
                     subject.screen = screen
                     subject.beginAppearanceTransition(true, animated: false)
@@ -322,7 +322,7 @@ class OmnibarViewControllerSpec: QuickSpec {
                 let post = Post.stub([:])
 
                 beforeEach {
-                    subject = OmnibarViewController(parentPost: post, defaultText: "@666 ")
+                    subject = OmnibarViewController(parentPostId: post.id, defaultText: "@666 ")
                     showController(subject)
                 }
 
@@ -349,7 +349,7 @@ class OmnibarViewControllerSpec: QuickSpec {
                         _ = Tmp.write(data, to: fileName)
                     }
 
-                    subject = OmnibarViewController(parentPost: post, defaultText: "@666 ")
+                    subject = OmnibarViewController(parentPostId: post.id, defaultText: "@666 ")
                     checkRegions(subject.screen.regions, contain: "@666 ")
                     checkRegions(subject.screen.regions, notToContain: "testing!")
                 }
@@ -367,7 +367,7 @@ class OmnibarViewControllerSpec: QuickSpec {
                         _ = Tmp.write(data, to: fileName)
                     }
 
-                    subject = OmnibarViewController(parentPost: Post.stub([:]), defaultText: "@666 ")
+                    subject = OmnibarViewController(parentPostId: "123", defaultText: "@666 ")
                     checkRegions(subject.screen.regions, contain: "@666 ")
                     checkRegions(subject.screen.regions, notToContain: "testing!")
                 }

--- a/Specs/Controllers/Stream/PostbarControllerSpec.swift
+++ b/Specs/Controllers/Stream/PostbarControllerSpec.swift
@@ -10,6 +10,7 @@ import Moya
 
 class PostbarControllerSpec: QuickSpec {
     class ReplyAllCreatePostDelegate: CreatePostDelegate {
+        var postId: String?
         var post: Post?
         var comment: ElloComment?
         var text: String?
@@ -17,8 +18,8 @@ class PostbarControllerSpec: QuickSpec {
         func createPost(text: String?, fromController: UIViewController) {
             self.text = text
         }
-        func createComment(_ post: Post, text: String?, fromController: UIViewController) {
-            self.post = post
+        func createComment(_ postId: String, text: String?, fromController: UIViewController) {
+            self.postId = postId
             self.text = text
         }
         func editComment(_ comment: ElloComment, fromController: UIViewController) {


### PR DESCRIPTION
Tapping red dot in Notifications shows the loader (regression fix), and in Streams tapping the red dot while viewing "Starred" will switch to "Following" and reload the page.