### PR TITLE
Fixes status bar visibility on Notifications Screen

### DIFF
--- a/Sources/Controllers/Notifications/NotificationsScreen.swift
+++ b/Sources/Controllers/Notifications/NotificationsScreen.swift
@@ -38,7 +38,6 @@ class NotificationsScreen: UIView {
         return button
     }
 
-
     weak var delegate: NotificationsScreenDelegate?
     let filterBar = NotificationsFilterBar()
     let streamContainer = UIView()
@@ -124,15 +123,6 @@ extension NotificationsScreen {
         case .repost: filterBar.selectButton(filterRepostButton)
         case .relationship: filterBar.selectButton(filterInviteButton)
         }
-    }
-
-    func animateNavigationBar(visible: Bool) {
-        navBarVisible = visible
-        animate {
-            self.positionFilterBar()
-        }
-//        UIApplication.shared.
-//        UIApplication.shared.setStatusBarHidden(!visible, with: .none)
     }
 
     fileprivate func positionFilterBar() {

--- a/Sources/Controllers/Notifications/NotificationsViewController.swift
+++ b/Sources/Controllers/Notifications/NotificationsViewController.swift
@@ -123,13 +123,15 @@ class NotificationsViewController: StreamableViewController, NotificationDelegat
 
     override func showNavBars() {
         super.showNavBars()
-        screen.animateNavigationBar(visible: true)
+        screen.navBarVisible = true
+        positionNavBar(screen.filterBar, visible: true)
         updateInsets()
     }
 
     override func hideNavBars() {
         super.hideNavBars()
-        screen.animateNavigationBar(visible: false)
+        screen.navBarVisible = false
+        positionNavBar(screen.filterBar, visible: false)
         updateInsets()
     }
 


### PR DESCRIPTION
I started out fixing the `NotificationsScreen`, but switched to reusing the `positionNavBar` method instead.