### PR TITLE
Truncates text regions even more

### DIFF
--- a/Ello.xcodeproj/project.pbxproj
+++ b/Ello.xcodeproj/project.pbxproj
@@ -483,6 +483,7 @@
 		1D061B521AAA1C6D00493435 /* StringExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D061B511AAA1C6D00493435 /* StringExtensionSpec.swift */; };
 		1D066FF31B8BA19E002B303D /* ArraySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D066FF21B8BA19E002B303D /* ArraySpec.swift */; };
 		1D066FF61B8BAF43002B303D /* OmnibarImageDownloadCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D066FF41B8BAEC5002B303D /* OmnibarImageDownloadCell.swift */; };
+		1D06D6CE1E43BC50004FA878 /* RegionKindStreamCellTypeAdditionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D06D6CD1E43BC50004FA878 /* RegionKindStreamCellTypeAdditionSpec.swift */; };
 		1D08320F1AAA54880076C67D /* TypedNotificationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D08320E1AAA54880076C67D /* TypedNotificationSpec.swift */; };
 		1D0832111AAA56EF0076C67D /* AmazonCredentialsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0832101AAA56EF0076C67D /* AmazonCredentialsSpec.swift */; };
 		1D15C2781C7D12890013B192 /* InterfaceImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D15C2761C7D12890013B192 /* InterfaceImage.swift */; };
@@ -1480,6 +1481,7 @@
 		1D061B511AAA1C6D00493435 /* StringExtensionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensionSpec.swift; sourceTree = "<group>"; };
 		1D066FF21B8BA19E002B303D /* ArraySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArraySpec.swift; sourceTree = "<group>"; };
 		1D066FF41B8BAEC5002B303D /* OmnibarImageDownloadCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OmnibarImageDownloadCell.swift; sourceTree = "<group>"; };
+		1D06D6CD1E43BC50004FA878 /* RegionKindStreamCellTypeAdditionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegionKindStreamCellTypeAdditionSpec.swift; sourceTree = "<group>"; };
 		1D08320E1AAA54880076C67D /* TypedNotificationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypedNotificationSpec.swift; sourceTree = "<group>"; };
 		1D0832101AAA56EF0076C67D /* AmazonCredentialsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmazonCredentialsSpec.swift; sourceTree = "<group>"; };
 		1D15C2761C7D12890013B192 /* InterfaceImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceImage.swift; sourceTree = "<group>"; };
@@ -2378,10 +2380,11 @@
 		124727611AB14A6E000079D7 /* Regions */ = {
 			isa = PBXGroup;
 			children = (
-				12CEC2BB1AB2108F000DC184 /* TextRegionSpec.swift */,
-				12CEC2B91AB21087000DC184 /* ImageRegionSpec.swift */,
 				124727621AB14AA0000079D7 /* AssetSpec.swift */,
 				124727641AB14AC8000079D7 /* ImageAttachmentSpec.swift */,
+				12CEC2B91AB21087000DC184 /* ImageRegionSpec.swift */,
+				1D06D6CD1E43BC50004FA878 /* RegionKindStreamCellTypeAdditionSpec.swift */,
+				12CEC2BB1AB2108F000DC184 /* TextRegionSpec.swift */,
 				1247276A1AB14B04000079D7 /* UnknownRegionSpec.swift */,
 			);
 			name = Regions;
@@ -4760,6 +4763,7 @@
 				762ABBA51A8ACB7700B19E34 /* JSONAbleSpec.swift in Sources */,
 				12A1D8391DAD78F100A327D6 /* ProfileTotalCountPresenterSpec.swift in Sources */,
 				1DF50C8D1C61452D00C62D89 /* UIImagePickerControllerSpec.swift in Sources */,
+				1D06D6CE1E43BC50004FA878 /* RegionKindStreamCellTypeAdditionSpec.swift in Sources */,
 				12DB1CA71D9C6B9E007E3E4C /* UINavigationItemSpec.swift in Sources */,
 				12B093661A6D87C000BF104E /* StreamContainerViewControllerSpec.swift in Sources */,
 				1DA18DFE1DAC3B64000231CC /* ProfileStatsViewSpec.swift in Sources */,

--- a/Sources/Controllers/Stream/CellDequeing/StreamTextCellPresenter.swift
+++ b/Sources/Controllers/Stream/CellDequeing/StreamTextCellPresenter.swift
@@ -14,34 +14,34 @@ struct StreamTextCellPresenter {
         indexPath: IndexPath,
         currentUser: User?)
     {
-        if let cell = cell as? StreamTextCell {
-            cell.onWebContentReady { webView in
-                if let actualHeight = webView.windowContentSize()?.height, actualHeight != streamCellItem.calculatedCellHeights.webContent {
-                    streamCellItem.calculatedCellHeights.webContent = actualHeight
-                    streamCellItem.calculatedCellHeights.oneColumn = actualHeight
-                    streamCellItem.calculatedCellHeights.multiColumn = actualHeight
-                    postNotification(StreamNotification.UpdateCellHeightNotification, value: cell)
-                }
-            }
+        guard let cell = cell as? StreamTextCell else { return }
 
-            var isRepost = false
-            if let textRegion = streamCellItem.type.data as? TextRegion {
-                isRepost = textRegion.isRepost
-                let content = textRegion.content
-                let html = StreamTextCellHTML.postHTML(content)
-                cell.webView.loadHTMLString(html, baseURL: URL(string: "/"))
+        cell.onWebContentReady { webView in
+            if let actualHeight = webView.windowContentSize()?.height, actualHeight != streamCellItem.calculatedCellHeights.webContent {
+                streamCellItem.calculatedCellHeights.webContent = actualHeight
+                streamCellItem.calculatedCellHeights.oneColumn = actualHeight
+                streamCellItem.calculatedCellHeights.multiColumn = actualHeight
+                postNotification(StreamNotification.UpdateCellHeightNotification, value: cell)
             }
-            // Repost specifics
-            if isRepost == true {
-                cell.leadingConstraint.constant = 30.0
-                cell.showBorder()
-            }
-            else if streamCellItem.jsonable is ElloComment {
-                cell.leadingConstraint.constant = commentMargin
-            }
-            else {
-                cell.leadingConstraint.constant = postMargin
-            }
+        }
+
+        var isRepost = false
+        if let textRegion = streamCellItem.type.data as? TextRegion {
+            isRepost = textRegion.isRepost
+            let content = textRegion.content
+            let html = StreamTextCellHTML.postHTML(content)
+            cell.webView.loadHTMLString(html, baseURL: URL(string: "/"))
+        }
+        // Repost specifics
+        if isRepost == true {
+            cell.leadingConstraint.constant = 30.0
+            cell.showBorder()
+        }
+        else if streamCellItem.jsonable is ElloComment {
+            cell.leadingConstraint.constant = commentMargin
+        }
+        else {
+            cell.leadingConstraint.constant = postMargin
         }
     }
 

--- a/Sources/model/Regions/RegionKindStreamCellTypeAddition.swift
+++ b/Sources/model/Regions/RegionKindStreamCellTypeAddition.swift
@@ -13,14 +13,15 @@ extension RegionKind {
             if let textRegion = regionable as? TextRegion {
                 let content = textRegion.content
                 let paragraphs: [String] = content.components(separatedBy: "</p>").flatMap { (para: String) -> [String] in
+                    guard para.trimmed() != "" else { return [] }
+
                     var subparas = para.components(separatedBy: "<br>")
                     guard
                         subparas.count > 1
-                    else { return [para] }
+                    else { return [para + "</p>"] }
 
                     let first = subparas.removeFirst()
-                    let last = subparas.removeLast()
-                    return ["\(first)</p>"] + subparas.map({ "<p>\($0)</p>"}) + ["<p>\(last)"]
+                    return ["\(first)</p>"] + subparas.map({ "<p>\($0)</p>"})
                 }.map { line in
                     let max = 7500
                     guard line.characters.count < max + 10 else {
@@ -34,7 +35,7 @@ extension RegionKind {
                         return nil
                     }
 
-                    let newRegion = TextRegion(content: para + "</p>")
+                    let newRegion = TextRegion(content: para)
                     newRegion.isRepost = textRegion.isRepost
                     return .text(data: newRegion)
                 }

--- a/Specs/Model/Regions/RegionKindStreamCellTypeAdditionSpec.swift
+++ b/Specs/Model/Regions/RegionKindStreamCellTypeAdditionSpec.swift
@@ -1,0 +1,126 @@
+////
+///  RegionKindStreamCellTypeAdditionSpec.swift
+//
+
+@testable import Ello
+import Quick
+import Nimble
+
+
+class RegionKindStreamCellTypeAdditionSpec: QuickSpec {
+    override func spec() {
+        fdescribe("RegionKind.streamCellTypes") {
+            it("should return images") {
+                let kind = RegionKind.image
+                let region = ImageRegion.stub([:])
+                let streamCellTypes = kind.streamCellTypes(region)
+                expect(streamCellTypes.count) == 1
+                if let streamCellType = streamCellTypes.first {
+                    if case .image(_) = streamCellType {
+                        expect(true) == true
+                    }
+                    else {
+                        fail("wrong cell type \(streamCellType)")
+                    }
+                }
+            }
+
+            it("should return embeds") {
+                let kind = RegionKind.embed
+                let region = EmbedRegion.stub([:])
+                let streamCellTypes = kind.streamCellTypes(region)
+                expect(streamCellTypes.count) == 1
+                if let streamCellType = streamCellTypes.first {
+                    if case .embed(_) = streamCellType {
+                        expect(true) == true
+                    }
+                    else {
+                        fail("wrong cell type \(streamCellType)")
+                    }
+                }
+            }
+
+            it("should return simple text") {
+                let kind = RegionKind.text
+                let content = "<p>text</p>"
+                let region = TextRegion.stub([
+                    "content": content
+                    ])
+                let streamCellTypes = kind.streamCellTypes(region)
+                expect(streamCellTypes.count) == 1
+                if let streamCellType = streamCellTypes.first {
+                    if case let .text(data) = streamCellType, let textRegion = data as? TextRegion {
+                        expect(textRegion.content) == content
+                    }
+                    else {
+                        fail("wrong cell type \(streamCellType)")
+                    }
+                }
+            }
+
+            it("should split paragraphs") {
+                let kind = RegionKind.text
+                let content1 = "<p>text1</p>"
+                let content2 = "<p>text2</p>"
+                let region = TextRegion.stub([
+                    "content": content1 + content2
+                    ])
+                let streamCellTypes = kind.streamCellTypes(region)
+                expect(streamCellTypes.count) == 2
+                if case let .text(data) = streamCellTypes[0], let textRegion = data as? TextRegion {
+                    expect(textRegion.content) == content1
+                }
+                else {
+                    fail("wrong cell type \(streamCellTypes[0])")
+                }
+
+                if case let .text(data) = streamCellTypes[1], let textRegion = data as? TextRegion {
+                    expect(textRegion.content) == content2
+                }
+                else {
+                    fail("wrong cell type \(streamCellTypes[1])")
+                }
+            }
+
+            it("should split break tags") {
+                let kind = RegionKind.text
+                let content1 = "text1"
+                let content2 = "text2"
+                let region = TextRegion.stub([
+                    "content": "<p>\(content1)<br>\(content2)</p>"
+                    ])
+                let streamCellTypes = kind.streamCellTypes(region)
+                expect(streamCellTypes.count) == 2
+                if case let .text(data) = streamCellTypes[0], let textRegion = data as? TextRegion {
+                    expect(textRegion.content) == "<p>\(content1)</p>"
+                }
+                else {
+                    fail("wrong cell type \(streamCellTypes[0])")
+                }
+
+                if case let .text(data) = streamCellTypes[1], let textRegion = data as? TextRegion {
+                    expect(textRegion.content) == "<p>\(content2)</p>"
+                }
+                else {
+                    fail("wrong cell type \(streamCellTypes[1])")
+                }
+            }
+
+            it("should truncate ridiculous text") {
+                let kind = RegionKind.text
+                let region = TextRegion.stub([
+                    "content": "<p>" + String(repeating: "lorem", count: 8000/5) + "</p>"
+                    ])
+                let streamCellTypes = kind.streamCellTypes(region)
+                expect(streamCellTypes.count) == 1
+                if case let .text(data) = streamCellTypes[0], let textRegion = data as? TextRegion {
+                    expect(textRegion.content).to(beginWith("<p>lorem"))
+                    expect(textRegion.content).to(endWith("&hellip;</p>"))
+                }
+                else {
+                    fail("wrong cell type \(streamCellTypes[0])")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
TextRegion `|>` break up `<p>` tags `|>` break up `<br>` tags `|>` truncate to 7500 characters.

Wondering about the `7500 + 10` code?  It's to remove the very last `</p>`, if it's there (and maybe newlines - this is all a bit hand-wavy).