### PR TITLE
Combines inviteResponder and inviteDelegate

### DIFF
--- a/Sources/Controllers/Stream/Cells/StreamInviteFriendsCell.swift
+++ b/Sources/Controllers/Stream/Cells/StreamInviteFriendsCell.swift
@@ -10,7 +10,6 @@ class StreamInviteFriendsCell: UICollectionViewCell {
     @IBOutlet weak var nameLabel: UILabel!
     @IBOutlet weak var inviteButton: StyledButton!
 
-    weak var inviteDelegate: InviteDelegate?
     var inviteCache: InviteCache?
     var bottomBorder = CALayer()
     var isOnboarding = false
@@ -44,7 +43,9 @@ class StreamInviteFriendsCell: UICollectionViewCell {
 
     @IBAction func invite() {
         guard let person = person else { return }
-        inviteDelegate?.sendInvite(person: person, isOnboarding: isOnboarding) {
+        let responder = target(forAction: #selector(InviteResponder.sendInvite(person:isOnboarding:didUpdate:)), withSender: self) as? InviteResponder
+        responder?.sendInvite(person: person, isOnboarding: isOnboarding) { [weak self] in
+            guard let `self` = self else { return }
             self.inviteCache?.saveInvite(person.identifier)
             self.styleInviteButton(self.inviteCache?.has(person.identifier))
         }

--- a/Sources/Controllers/Stream/Cells/StreamInviteFriendsCell.swift
+++ b/Sources/Controllers/Stream/Cells/StreamInviteFriendsCell.swift
@@ -43,7 +43,7 @@ class StreamInviteFriendsCell: UICollectionViewCell {
 
     @IBAction func invite() {
         guard let person = person else { return }
-        let responder = target(forAction: #selector(InviteResponder.sendInvite(person:isOnboarding:didUpdate:)), withSender: self) as? InviteResponder
+        let responder = target(forAction: #selector(InviteResponder.sendInvite(person:isOnboarding:completion:)), withSender: self) as? InviteResponder
         responder?.sendInvite(person: person, isOnboarding: isOnboarding) { [weak self] in
             guard let `self` = self else { return }
             self.inviteCache?.saveInvite(person.identifier)

--- a/Sources/Controllers/Stream/StreamDataSource.swift
+++ b/Sources/Controllers/Stream/StreamDataSource.swift
@@ -46,7 +46,6 @@ class StreamDataSource: NSObject, UICollectionViewDataSource {
     weak var relationshipDelegate: RelationshipDelegate?
     weak var simpleStreamDelegate: SimpleStreamDelegate?
     weak var searchStreamDelegate: SearchStreamDelegate?
-    weak var inviteDelegate: InviteDelegate?
     weak var categoryListCellDelegate: CategoryListCellDelegate?
     weak var announcementCellDelegate: AnnouncementCellDelegate?
     var inviteCache = InviteCache()
@@ -349,7 +348,6 @@ class StreamDataSource: NSObject, UICollectionViewDataSource {
         case .image:
             (cell as! StreamImageCell).streamImageCellDelegate = imageDelegate
         case .inviteFriends, .onboardingInviteFriends:
-            (cell as! StreamInviteFriendsCell).inviteDelegate = inviteDelegate
             (cell as! StreamInviteFriendsCell).inviteCache = inviteCache
         case .notification:
             (cell as! NotificationCell).relationshipControl.relationshipDelegate = relationshipDelegate

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -9,10 +9,7 @@ import SwiftyUserDefaults
 import DeltaCalculator
 
 
-// MARK: Delegate Implementations
-protocol InviteDelegate: class {
-    func sendInvite(person: LocalPerson, isOnboarding: Bool, didUpdate: @escaping ElloEmptyCompletion)
-}
+// MARK: Responder Implementations
 
 protocol SimpleStreamDelegate: class {
     func showSimpleStream(endpoint: ElloAPI, title: String, noResultsMessages: (title: String, body: String)?)
@@ -617,7 +614,6 @@ final class StreamViewController: BaseElloViewController {
 
         // set delegates
         dataSource.imageDelegate = self
-        dataSource.inviteDelegate = self
         dataSource.simpleStreamDelegate = self
         dataSource.categoryDelegate = self
         dataSource.userDelegate = self
@@ -682,30 +678,6 @@ final class StreamViewController: BaseElloViewController {
 
 // MARK: DELEGATE EXTENSIONS
 
-// MARK: StreamViewController: InviteDelegate
-extension StreamViewController: InviteDelegate {
-
-    func sendInvite(person: LocalPerson, isOnboarding: Bool, didUpdate: @escaping ElloEmptyCompletion) {
-        guard let email = person.emails.first else { return }
-
-        if isOnboarding {
-            Tracker.shared.onboardingFriendInvited()
-        }
-        else {
-            Tracker.shared.friendInvited()
-        }
-        ElloHUD.showLoadingHudInView(view)
-        InviteService().invite(email,
-            success: {
-                ElloHUD.hideLoadingHudInView(self.view)
-                didUpdate()
-            },
-            failure: { _ in
-                ElloHUD.hideLoadingHudInView(self.view)
-                didUpdate()
-            })
-    }
-}
 
 // MARK: StreamViewController: GridListToggleDelegate
 extension StreamViewController: GridListToggleDelegate {

--- a/Sources/Controllers/Stream/StreamableViewController.swift
+++ b/Sources/Controllers/Stream/StreamableViewController.swift
@@ -23,7 +23,7 @@ protocol CreatePostDelegate: class {
 @objc
 protocol InviteResponder: class {
     func onInviteFriends()
-    func sendInvite(person: LocalPerson, isOnboarding: Bool, didUpdate: @escaping ElloEmptyCompletion)
+    func sendInvite(person: LocalPerson, isOnboarding: Bool, completion: @escaping ElloEmptyCompletion)
 }
 
 class StreamableViewController: BaseElloViewController, PostTappedDelegate {
@@ -310,7 +310,7 @@ extension StreamableViewController: InviteResponder {
         })
     }
 
-    func sendInvite(person: LocalPerson, isOnboarding: Bool, didUpdate: @escaping ElloEmptyCompletion) {
+    func sendInvite(person: LocalPerson, isOnboarding: Bool, completion: @escaping ElloEmptyCompletion) {
         guard let email = person.emails.first else { return }
 
         if isOnboarding {
@@ -324,12 +324,12 @@ extension StreamableViewController: InviteResponder {
             success: { [weak self] in
                 guard let `self` = self else { return }
                 ElloHUD.hideLoadingHudInView(self.view)
-                didUpdate()
+                completion()
             },
             failure: { [weak self] _ in
                 guard let `self` = self else { return }
                 ElloHUD.hideLoadingHudInView(self.view)
-                didUpdate()
+                completion()
             })
     }
 }


### PR DESCRIPTION
Previously, we had `inviteDelegate` and `inviteResponder` protocols. One was implemented by `StreamableViewController`, the other by `StreamViewController`. Now that we're using the responder chain they can both be moved into `StreamableViewController`. A nice side effect that slims down `StreamViewController` a bit.