### PR TITLE
SimpleStreamDelegate -> SimpleStreamResponder

### DIFF
--- a/Sources/Controllers/App/AppViewController.swift
+++ b/Sources/Controllers/App/AppViewController.swift
@@ -660,7 +660,7 @@ extension AppViewController {
             noResultsBody = InterfaceString.Followers.NoResultsBody
         }
         let followersVC = SimpleStreamViewController(endpoint: endpoint, title: "@" + username + "'s " + InterfaceString.Followers.Title)
-        followersVC.streamViewController.noResultsMessages = (title: noResultsTitle, body: noResultsBody)
+        followersVC.streamViewController.noResultsMessages = NoResultsMessages(title: noResultsTitle, body: noResultsBody)
         followersVC.currentUser = currentUser
         pushDeepLinkViewController(followersVC)
     }
@@ -678,7 +678,7 @@ extension AppViewController {
             noResultsBody = InterfaceString.Following.NoResultsBody
         }
         let vc = SimpleStreamViewController(endpoint: endpoint, title: "@" + username + "'s " + InterfaceString.Following.Title)
-        vc.streamViewController.noResultsMessages = (title: noResultsTitle, body: noResultsBody)
+        vc.streamViewController.noResultsMessages = NoResultsMessages(title: noResultsTitle, body: noResultsBody)
         vc.currentUser = currentUser
         pushDeepLinkViewController(vc)
     }
@@ -696,7 +696,7 @@ extension AppViewController {
             noResultsBody = InterfaceString.Loves.NoResultsBody
         }
         let vc = SimpleStreamViewController(endpoint: endpoint, title: "@" + username + "'s " + InterfaceString.Loves.Title)
-        vc.streamViewController.noResultsMessages = (title: noResultsTitle, body: noResultsBody)
+        vc.streamViewController.noResultsMessages = NoResultsMessages(title: noResultsTitle, body: noResultsBody)
         vc.currentUser = currentUser
         pushDeepLinkViewController(vc)
     }

--- a/Sources/Controllers/Profile/ProfileHeaderCell.swift
+++ b/Sources/Controllers/Profile/ProfileHeaderCell.swift
@@ -47,7 +47,6 @@ class ProfileHeaderCell: UICollectionViewCell {
         get { return bioView.webLinkDelegate }
     }
 
-    weak var simpleStreamDelegate: SimpleStreamDelegate?
     weak var userDelegate: UserDelegate?
 
     var user: User?

--- a/Sources/Controllers/Profile/ProfileViewController.swift
+++ b/Sources/Controllers/Profile/ProfileViewController.swift
@@ -384,7 +384,12 @@ extension ProfileViewController: ProfileHeaderResponder {
             noResultsTitle = InterfaceString.Loves.NoResultsTitle
             noResultsBody = InterfaceString.Loves.NoResultsBody
         }
-        streamViewController.showSimpleStream(endpoint: .loves(userId: user.id), title: InterfaceString.Loves.Title, noResultsMessages: (title: noResultsTitle, body: noResultsBody))
+
+        streamViewController.showSimpleStream(
+            boxedEndpoint: BoxedElloAPI(endpoint: .loves(userId: user.id)),
+            title: InterfaceString.Loves.Title,
+            noResultsMessages: NoResultsMessages(title: noResultsTitle, body: noResultsBody)
+        )
     }
 
     func onFollowersTapped(_ cell: UICollectionViewCell) {
@@ -400,7 +405,12 @@ extension ProfileViewController: ProfileHeaderResponder {
             noResultsTitle = InterfaceString.Followers.NoResultsTitle
             noResultsBody = InterfaceString.Followers.NoResultsBody
         }
-        streamViewController.showSimpleStream(endpoint: .userStreamFollowers(userId: user.id), title: InterfaceString.Followers.Title, noResultsMessages: (title: noResultsTitle, body: noResultsBody))
+
+        streamViewController.showSimpleStream(
+            boxedEndpoint: BoxedElloAPI(endpoint: .userStreamFollowers(userId: user.id)),
+            title: InterfaceString.Followers.Title,
+            noResultsMessages: NoResultsMessages(title: noResultsTitle, body: noResultsBody)
+        )
     }
 
     func onFollowingTapped(_ cell: UICollectionViewCell) {
@@ -416,7 +426,12 @@ extension ProfileViewController: ProfileHeaderResponder {
             noResultsTitle = InterfaceString.Following.NoResultsTitle
             noResultsBody = InterfaceString.Following.NoResultsBody
         }
-        streamViewController.showSimpleStream(endpoint: .userStreamFollowing(userId: user.id), title: InterfaceString.Following.Title, noResultsMessages: (title: noResultsTitle, body: noResultsBody))
+
+        streamViewController.showSimpleStream(
+            boxedEndpoint: BoxedElloAPI(endpoint: .userStreamFollowing(userId: user.id)),
+            title: InterfaceString.Following.Title,
+            noResultsMessages: NoResultsMessages(title: noResultsTitle, body: noResultsBody)
+        )
     }}
 
 

--- a/Sources/Controllers/Search/SearchViewController.swift
+++ b/Sources/Controllers/Search/SearchViewController.swift
@@ -77,7 +77,7 @@ extension SearchViewController: SearchScreenDelegate {
         searchText = ""
         streamViewController.removeAllCellItems()
         streamViewController.loadingToken.cancelInitialPage()
-        streamViewController.noResultsMessages = (title: "", body: "")
+        streamViewController.noResultsMessages = NoResultsMessages(title: "", body: "")
         screen.hasGridViewToggle = false
     }
 
@@ -109,7 +109,7 @@ extension SearchViewController: SearchScreenDelegate {
         streamViewController.hideNoResults()
         searchText = text
         let endpoint = isPostSearch ? ElloAPI.searchForPosts(terms: text) : ElloAPI.searchForUsers(terms: text)
-        streamViewController.noResultsMessages = (title: InterfaceString.Search.NoMatches, body: InterfaceString.Search.TryAgain)
+        streamViewController.noResultsMessages = NoResultsMessages(title: InterfaceString.Search.NoMatches, body: InterfaceString.Search.TryAgain)
         let streamKind = StreamKind.simpleStream(endpoint: endpoint, title: "")
         screen.hasGridViewToggle = streamKind.hasGridViewToggle
         streamViewController.streamKind = streamKind

--- a/Sources/Controllers/Settings/DynamicSettingsViewController.swift
+++ b/Sources/Controllers/Settings/DynamicSettingsViewController.swift
@@ -151,7 +151,7 @@ class DynamicSettingsViewController: UITableViewController {
                 let controller = SimpleStreamViewController(endpoint: .currentUserBlockedList, title: InterfaceString.Settings.BlockedTitle)
                 let noResultsTitle = InterfaceString.Relationship.BlockedNoResultsTitle
                 let noResultsBody = InterfaceString.Relationship.BlockedNoResultsBody
-                controller.streamViewController.noResultsMessages = (title: noResultsTitle, body: noResultsBody)
+                controller.streamViewController.noResultsMessages = NoResultsMessages(title: noResultsTitle, body: noResultsBody)
                 controller.currentUser = currentUser
                 navigationController?.pushViewController(controller, animated: true)
             }
@@ -160,7 +160,7 @@ class DynamicSettingsViewController: UITableViewController {
                 let controller = SimpleStreamViewController(endpoint: .currentUserMutedList, title: InterfaceString.Settings.MutedTitle)
                 let noResultsTitle = InterfaceString.Relationship.MutedNoResultsTitle
                 let noResultsBody = InterfaceString.Relationship.MutedNoResultsBody
-                controller.streamViewController.noResultsMessages = (title: noResultsTitle, body: noResultsBody)
+                controller.streamViewController.noResultsMessages = NoResultsMessages(title: noResultsTitle, body: noResultsBody)
                 controller.currentUser = currentUser
                 navigationController?.pushViewController(controller, animated: true)
             }

--- a/Sources/Controllers/Settings/DynamicSettingsViewController.swift
+++ b/Sources/Controllers/Settings/DynamicSettingsViewController.swift
@@ -149,18 +149,22 @@ class DynamicSettingsViewController: UITableViewController {
         case .blocked:
             if let currentUser = currentUser {
                 let controller = SimpleStreamViewController(endpoint: .currentUserBlockedList, title: InterfaceString.Settings.BlockedTitle)
-                let noResultsTitle = InterfaceString.Relationship.BlockedNoResultsTitle
-                let noResultsBody = InterfaceString.Relationship.BlockedNoResultsBody
-                controller.streamViewController.noResultsMessages = NoResultsMessages(title: noResultsTitle, body: noResultsBody)
+                controller.streamViewController.noResultsMessages =
+                    NoResultsMessages(
+                        title: InterfaceString.Relationship.BlockedNoResultsTitle,
+                        body: InterfaceString.Relationship.BlockedNoResultsBody
+                    )
                 controller.currentUser = currentUser
                 navigationController?.pushViewController(controller, animated: true)
             }
         case .muted:
             if let currentUser = currentUser {
                 let controller = SimpleStreamViewController(endpoint: .currentUserMutedList, title: InterfaceString.Settings.MutedTitle)
-                let noResultsTitle = InterfaceString.Relationship.MutedNoResultsTitle
-                let noResultsBody = InterfaceString.Relationship.MutedNoResultsBody
-                controller.streamViewController.noResultsMessages = NoResultsMessages(title: noResultsTitle, body: noResultsBody)
+                controller.streamViewController.noResultsMessages =
+                    NoResultsMessages(
+                        title: InterfaceString.Relationship.MutedNoResultsTitle,
+                        body: InterfaceString.Relationship.MutedNoResultsBody
+                    )
                 controller.currentUser = currentUser
                 navigationController?.pushViewController(controller, animated: true)
             }

--- a/Sources/Controllers/Stream/Cells/UserAvatarsCell.swift
+++ b/Sources/Controllers/Stream/Cells/UserAvatarsCell.swift
@@ -25,7 +25,6 @@ class UserAvatarsCell: UICollectionViewCell {
         }
     }
     weak var userDelegate: UserDelegate?
-    weak var simpleStreamDelegate: SimpleStreamDelegate?
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -64,17 +63,22 @@ class UserAvatarsCell: UICollectionViewCell {
     }
 
     @IBAction func seeMoreTapped(_ sender: UIButton) {
-        if let model = userAvatarCellModel, let endpoint = model.endpoint {
-            simpleStreamDelegate?.showSimpleStream(endpoint: endpoint, title: model.seeMoreTitle, noResultsMessages: nil)
-        }
+        guard
+            let model = userAvatarCellModel,
+            let endpoint = model.endpoint
+        else { return }
+
+        let responder = target(forAction: #selector(SimpleStreamResponder.showSimpleStream(boxedEndpoint:title:noResultsMessages:)), withSender: self) as? SimpleStreamResponder
+        responder?.showSimpleStream(boxedEndpoint: BoxedElloAPI(endpoint: endpoint), title: model.seeMoreTitle, noResultsMessages: nil)
     }
 
     @IBAction func avatarTapped(_ sender: AvatarButton) {
-        if let index = avatarButtons.index(of: sender) {
-            if users.count > index {
-                let user = users[index]
-                userDelegate?.userTapped(user: user)
-            }
-        }
+        guard
+            let index = avatarButtons.index(of: sender),
+            users.count > index
+        else { return }
+
+        let user = users[index]
+        userDelegate?.userTapped(user: user)
     }
 }

--- a/Sources/Controllers/Stream/StreamDataSource.swift
+++ b/Sources/Controllers/Stream/StreamDataSource.swift
@@ -43,7 +43,6 @@ class StreamDataSource: NSObject, UICollectionViewDataSource {
     weak var categoryDelegate: CategoryDelegate?
     weak var userDelegate: UserDelegate?
     weak var relationshipDelegate: RelationshipDelegate?
-    weak var simpleStreamDelegate: SimpleStreamDelegate?
     weak var searchStreamDelegate: SearchStreamDelegate?
     weak var categoryListCellDelegate: CategoryListCellDelegate?
     weak var announcementCellDelegate: AnnouncementCellDelegate?
@@ -358,7 +357,6 @@ class StreamDataSource: NSObject, UICollectionViewDataSource {
             (cell as! StreamTextCell).webLinkDelegate = webLinkDelegate
             (cell as! StreamTextCell).userDelegate = userDelegate
         case .userAvatars:
-            (cell as! UserAvatarsCell).simpleStreamDelegate = simpleStreamDelegate
             (cell as! UserAvatarsCell).userDelegate = userDelegate
         case .userListItem:
             (cell as! UserListItemCell).relationshipControl.relationshipDelegate = relationshipDelegate

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -88,9 +88,9 @@ struct StreamNotification {
 class NoResultsMessages: NSObject {
     let title: String
     let body: String
-    init(title: String?, body: String?) {
-        self.title = title ?? ""
-        self.body = body ?? ""
+    init(title: String, body: String) {
+        self.title = title
+        self.body = body
     }
 }
 

--- a/Sources/Networking/ElloAPI.swift
+++ b/Sources/Networking/ElloAPI.swift
@@ -8,6 +8,13 @@ import Result
 
 typealias MoyaResult = Result<Moya.Response, Moya.Error>
 
+// 😭 I'm as sad as you are about this. We want the responder chain
+// and we want to pass ElloAPI arguments. So we box it.
+class BoxedElloAPI: NSObject {
+    let endpoint: ElloAPI
+    init(endpoint: ElloAPI) { self.endpoint = endpoint }
+}
+
 enum ElloAPI {
     case amazonCredentials
     case announcements


### PR DESCRIPTION
This required a bit of work due to `@objc`'s inability to accept swift only types as arguments in `#selector`. The solution is to box swift's value types in a recognizable Objective-C class. A bit ugly but it does the trick.