### PR TITLE
Implements deep links in logged out views, and refactors OUT link handling from `StreamViewController`

### DIFF
--- a/Sources/Controllers/App/AppViewController.swift
+++ b/Sources/Controllers/App/AppViewController.swift
@@ -437,7 +437,10 @@ extension AppViewController {
         Tracker.shared.deepLinkVisited(path)
 
         let (type, data) = ElloURI.match(path)
+        navigateToURI(path: path, type: type, data: data)
+    }
 
+    func navigateToURI(path: String, type: ElloURI, data: String) {
         guard type.shouldLoadInApp else {
             if let pathURL = URL(string: path) {
                 UIApplication.shared.openURL(pathURL)

--- a/Sources/Controllers/App/AppViewController.swift
+++ b/Sources/Controllers/App/AppViewController.swift
@@ -442,9 +442,7 @@ extension AppViewController {
 
     func navigateToURI(path: String, type: ElloURI, data: String) {
         guard type.shouldLoadInApp else {
-            if let pathURL = URL(string: path) {
-                UIApplication.shared.openURL(pathURL)
-            }
+            showExternalWebView(path)
             return
         }
 

--- a/Sources/Controllers/App/AppViewController.swift
+++ b/Sources/Controllers/App/AppViewController.swift
@@ -752,9 +752,7 @@ extension AppViewController {
             navController = nav
         }
 
-        if let navController = navController {
-            navController.pushViewController(vc, animated: true)
-        }
+        navController?.pushViewController(vc, animated: true)
     }
 
     fileprivate func selectTab(_ tab: ElloTab) {

--- a/Sources/Controllers/App/AppViewController.swift
+++ b/Sources/Controllers/App/AppViewController.swift
@@ -461,7 +461,7 @@ extension AppViewController {
             switch type {
             case .invite:
                 showJoinScreen(animated: false, invitationCode: data)
-            case .join:
+            case .join, .signup:
                 showJoinScreen(animated: false)
             case .login:
                 showLoginScreen(animated: false)
@@ -476,7 +476,7 @@ extension AppViewController {
         }
 
         switch type {
-        case .invite, .join, .login:
+        case .invite, .join, .signup, .login:
             break
         case .exploreRecommended,
              .exploreRecent,

--- a/Sources/Controllers/App/AppViewController.swift
+++ b/Sources/Controllers/App/AppViewController.swift
@@ -17,7 +17,7 @@ struct StatusBarNotifications {
 
 @objc
 protocol HasAppController {
-    var parentAppController: AppViewController? { get set }
+    var appViewController: AppViewController? { get }
 }
 
 
@@ -188,7 +188,6 @@ extension AppViewController {
         let parentNavController = ElloNavigationController(rootViewController: loggedOutController)
 
         loggedOutController.addChildViewController(childNavController)
-        loggedOutController.parentAppController = self
         childNavController.didMove(toParentViewController: loggedOutController)
 
         swapViewController(parentNavController) {}
@@ -206,7 +205,6 @@ extension AppViewController {
 
         pushPayload = .none
         let joinController = JoinViewController()
-        joinController.parentAppController = self
         joinController.invitationCode = invitationCode
         nav.setViewControllers([loggedOutController, joinController], animated: animated)
     }
@@ -223,7 +221,6 @@ extension AppViewController {
 
         pushPayload = .none
         let loginController = LoginViewController()
-        loginController.parentAppController = self
         nav.setViewControllers([loggedOutController, loginController], animated: animated)
     }
 
@@ -231,7 +228,6 @@ extension AppViewController {
         currentUser = user
 
         let vc = OnboardingViewController()
-        vc.parentAppController = self
         vc.currentUser = user
 
         swapViewController(vc) {}
@@ -320,9 +316,6 @@ extension AppViewController {
             self.visibleViewController?.removeFromParentViewController()
 
             self.addChildViewController(newViewController)
-            if let childController = newViewController as? HasAppController {
-                childController.parentAppController = self
-            }
 
             newViewController.didMove(toParentViewController: self)
 

--- a/Sources/Controllers/BaseElloViewController.swift
+++ b/Sources/Controllers/BaseElloViewController.swift
@@ -7,7 +7,7 @@ protocol ControllerThatMightHaveTheCurrentUser {
     var currentUser: User? { get set }
 }
 
-class BaseElloViewController: UIViewController, ControllerThatMightHaveTheCurrentUser {
+class BaseElloViewController: UIViewController, HasAppController, ControllerThatMightHaveTheCurrentUser {
 
     var elloNavigationItem = UINavigationItem()
 

--- a/Sources/Controllers/Categories/CategoryViewController.swift
+++ b/Sources/Controllers/Categories/CategoryViewController.swift
@@ -260,6 +260,11 @@ extension CategoryViewController: CategoryScreenDelegate {
         self.slug = category.slug
         self.title = category.name
         loadCategory()
+
+        if let index = allCategories.index(where: { $0.slug == category.slug }) {
+            screen.scrollToCategory(index: index)
+            screen.selectCategory(index: index)
+        }
         Tracker.shared.screenAppeared(self)
     }
 }

--- a/Sources/Controllers/Categories/CategoryViewController.swift
+++ b/Sources/Controllers/Categories/CategoryViewController.swift
@@ -237,7 +237,7 @@ extension CategoryViewController: CategoryScreenDelegate {
     }
 
     func select(category: Category) {
-		Tracker.shared.categoryOpened(category.slug)
+        Tracker.shared.categoryOpened(category.slug)
 
         var kind: StreamKind?
         switch category.level {
@@ -250,7 +250,6 @@ extension CategoryViewController: CategoryScreenDelegate {
         }
 
         guard let streamKind = kind else { return }
-
 
         category.randomPromotional = nil
         streamViewController.streamKind = streamKind

--- a/Sources/Controllers/ElloTabBarController.swift
+++ b/Sources/Controllers/ElloTabBarController.swift
@@ -58,7 +58,9 @@ class ElloTabBarController: UIViewController, HasAppController, ControllerThatMi
     fileprivate var newStreamContentObserver: NotificationObserver?
 
     fileprivate var visibleViewController = UIViewController()
-    var parentAppController: AppViewController?
+    var appViewController: AppViewController? {
+        return findViewController { vc in vc is AppViewController } as? AppViewController
+    }
 
     fileprivate var notificationsDot: UIView?
     var newNotificationsAvailable: Bool {
@@ -254,7 +256,7 @@ extension ElloTabBarController {
     }
 
     func systemLoggedOut(_ shouldAlert: Bool) {
-        parentAppController?.forceLogOut(shouldAlert)
+        appViewController?.forceLogOut(shouldAlert)
     }
 }
 

--- a/Sources/Controllers/Join/JoinViewController.swift
+++ b/Sources/Controllers/Join/JoinViewController.swift
@@ -4,11 +4,10 @@
 
 import OnePasswordExtension
 
-class JoinViewController: BaseElloViewController, HasAppController {
+class JoinViewController: BaseElloViewController {
     var mockScreen: JoinScreenProtocol?
     var screen: JoinScreenProtocol { return mockScreen ?? (self.view as! JoinScreenProtocol) }
 
-    var parentAppController: AppViewController?
     var invitationCode: String?
 
     override func loadView() {
@@ -19,11 +18,11 @@ class JoinViewController: BaseElloViewController, HasAppController {
     }
 
     fileprivate func showOnboardingScreen(_ user: User) {
-        parentAppController?.showOnboardingScreen(user)
+        appViewController?.showOnboardingScreen(user)
     }
 
     fileprivate func showLoginScreen(_ email: String, _ password: String) {
-        parentAppController?.showLoginScreen(animated: true)
+        appViewController?.showLoginScreen(animated: true)
     }
 }
 

--- a/Sources/Controllers/Join/JoinViewController.swift
+++ b/Sources/Controllers/Join/JoinViewController.swift
@@ -22,7 +22,7 @@ class JoinViewController: BaseElloViewController {
     }
 
     fileprivate func showLoginScreen(_ email: String, _ password: String) {
-        appViewController?.showLoginScreen(animated: true)
+        appViewController?.showLoginScreen()
     }
 }
 

--- a/Sources/Controllers/LoggedOut/LoggedOutViewController.swift
+++ b/Sources/Controllers/LoggedOut/LoggedOutViewController.swift
@@ -41,10 +41,10 @@ class LoggedOutViewController: BaseElloViewController, BottomBarController {
 
 extension LoggedOutViewController: LoggedOutProtocol {
     func showLoginScreen() {
-        appViewController?.showLoginScreen(animated: true)
+        appViewController?.showLoginScreen()
     }
 
     func showJoinScreen() {
-        appViewController?.showJoinScreen(animated: true)
+        appViewController?.showJoinScreen()
     }
 }

--- a/Sources/Controllers/LoggedOut/LoggedOutViewController.swift
+++ b/Sources/Controllers/LoggedOut/LoggedOutViewController.swift
@@ -14,8 +14,7 @@ protocol BottomBarController: class {
 }
 
 
-class LoggedOutViewController: UIViewController, HasAppController, BottomBarController {
-    var parentAppController: AppViewController?
+class LoggedOutViewController: BaseElloViewController, BottomBarController {
     var navigationBarsVisible: Bool = true
     let bottomBarVisible: Bool = true
     var bottomBarHeight: CGFloat { return screen.bottomBarHeight }
@@ -42,10 +41,10 @@ class LoggedOutViewController: UIViewController, HasAppController, BottomBarCont
 
 extension LoggedOutViewController: LoggedOutProtocol {
     func showLoginScreen() {
-        parentAppController?.showLoginScreen(animated: true)
+        appViewController?.showLoginScreen(animated: true)
     }
 
     func showJoinScreen() {
-        parentAppController?.showJoinScreen(animated: true)
+        appViewController?.showJoinScreen(animated: true)
     }
 }

--- a/Sources/Controllers/Login/LoginViewController.swift
+++ b/Sources/Controllers/Login/LoginViewController.swift
@@ -5,11 +5,9 @@
 import Alamofire
 import OnePasswordExtension
 
-class LoginViewController: BaseElloViewController, HasAppController {
+class LoginViewController: BaseElloViewController {
     var mockScreen: LoginScreenProtocol?
     var screen: LoginScreenProtocol { return mockScreen ?? (self.view as! LoginScreenProtocol) }
-
-    var parentAppController: AppViewController?
 
     override func loadView() {
         let screen = LoginScreen()
@@ -19,7 +17,7 @@ class LoginViewController: BaseElloViewController, HasAppController {
     }
 
     fileprivate func loadCurrentUser() {
-        parentAppController?.loadCurrentUser() { error in
+        appViewController?.loadCurrentUser() { error in
             self.screen.loadingHUD(visible: false)
             let errorTitle = error.elloErrorMessage ?? InterfaceString.Login.LoadUserError
             self.screen.showError(errorTitle)

--- a/Sources/Controllers/Onboarding/CategoriesSelectionViewController.swift
+++ b/Sources/Controllers/Onboarding/CategoriesSelectionViewController.swift
@@ -69,14 +69,18 @@ extension CategoriesSelectionViewController: OnboardingStepController {
         }
 
         UserService().setUser(categories: categories)
-            .onSuccess { _ in
+            .onSuccess { [weak self] _ in
+                guard let `self` = self else { return }
+
                 // onboarding can be considered "done", even if they abort the app
                 Onboarding.shared().updateVersionToLatest()
 
                 self.onboardingData.categories = categories
                 proceedClosure(.continue)
             }
-            .onFail { _ in
+            .onFail { [weak self] _ in
+                guard let `self` = self else { return }
+
                 let alertController = AlertViewController(error: InterfaceString.GenericError)
                 self.appViewController?.present(alertController, animated: true, completion: nil)
                 proceedClosure(.error)

--- a/Sources/Controllers/Onboarding/CategoriesSelectionViewController.swift
+++ b/Sources/Controllers/Onboarding/CategoriesSelectionViewController.swift
@@ -2,10 +2,9 @@
 ///  CategoriesSelectionViewController.swift
 //
 
-class CategoriesSelectionViewController: StreamableViewController, HasAppController {
+class CategoriesSelectionViewController: StreamableViewController {
     var mockScreen: Screen?
     var screen: Screen { return mockScreen ?? (self.view as! Screen) }
-    var parentAppController: AppViewController?
     var selectedCategories: [Category] = []
     var onboardingViewController: OnboardingViewController?
     var onboardingData: OnboardingData!
@@ -79,7 +78,7 @@ extension CategoriesSelectionViewController: OnboardingStepController {
             }
             .onFail { _ in
                 let alertController = AlertViewController(error: InterfaceString.GenericError)
-                self.parentAppController?.present(alertController, animated: true, completion: nil)
+                self.appViewController?.present(alertController, animated: true, completion: nil)
                 proceedClosure(.error)
             }
     }

--- a/Sources/Controllers/Onboarding/CreateProfileViewController.swift
+++ b/Sources/Controllers/Onboarding/CreateProfileViewController.swift
@@ -5,8 +5,11 @@
 class CreateProfileViewController: UIViewController, HasAppController {
     var mockScreen: CreateProfileScreenProtocol?
     var screen: CreateProfileScreenProtocol { return mockScreen ?? (self.view as! CreateProfileScreenProtocol) }
-    var parentAppController: AppViewController?
     var currentUser: User?
+
+    var appViewController: AppViewController? {
+        return findViewController { vc in vc is AppViewController } as? AppViewController
+    }
 
     var onboardingViewController: OnboardingViewController?
     var onboardingData: OnboardingData!
@@ -153,7 +156,7 @@ extension CreateProfileViewController: OnboardingStepController {
             avatarImage: avatarImage, coverImage: coverImage,
             properties: properties,
             success: { _avatarURL, _coverImageURL, user in
-                self.parentAppController?.currentUser = user
+                self.appViewController?.currentUser = user
                 self.goToNextStep(abort, proceedClosure: proceedClosure) },
             failure: { error, _ in
                 proceedClosure(.error)
@@ -168,13 +171,13 @@ extension CreateProfileViewController: OnboardingStepController {
                     message = InterfaceString.GenericError
                 }
                 let alertController = AlertViewController(error: message)
-                self.parentAppController?.present(alertController, animated: true, completion: nil)
+                self.appViewController?.present(alertController, animated: true, completion: nil)
             })
     }
 
     func goToNextStep(_ abort: Bool, proceedClosure: @escaping (_ success: OnboardingViewController.OnboardingProceed) -> Void) {
         guard
-            let presenter = onboardingViewController?.parentAppController, !abort else {
+            let presenter = onboardingViewController?.appViewController, !abort else {
             proceedClosure(.abort)
             return
         }

--- a/Sources/Controllers/Onboarding/InviteFriendsViewController.swift
+++ b/Sources/Controllers/Onboarding/InviteFriendsViewController.swift
@@ -6,7 +6,6 @@ class InviteFriendsViewController: StreamableViewController {
     let addressBook: AddressBookProtocol
     var mockScreen: Screen?
     var screen: Screen { return mockScreen ?? (self.view as! Screen) }
-    var parentAppController: AppViewController?
     var searchString = SearchString(text: "")
     var onboardingViewController: OnboardingViewController?
     var onboardingData: OnboardingData!

--- a/Sources/Controllers/Onboarding/OnboardingViewController.swift
+++ b/Sources/Controllers/Onboarding/OnboardingViewController.swift
@@ -5,7 +5,7 @@
 import PINRemoteImage
 
 
-class OnboardingViewController: BaseElloViewController, HasAppController {
+class OnboardingViewController: BaseElloViewController {
     fileprivate enum OnboardingDirection: CGFloat {
         case left = -1
         case right = 1
@@ -19,7 +19,6 @@ class OnboardingViewController: BaseElloViewController, HasAppController {
     var mockScreen: OnboardingScreenProtocol?
     var screen: OnboardingScreenProtocol { return mockScreen ?? (self.view as! OnboardingScreenProtocol) }
 
-    var parentAppController: AppViewController?
     var inviteFriendsController: InviteFriendsViewController? {
         willSet {
             guard inviteFriendsController == nil else {
@@ -126,13 +125,11 @@ private extension OnboardingViewController {
 
     func setupOnboardingControllers() {
         let categoriesController = CategoriesSelectionViewController()
-        categoriesController.parentAppController = parentAppController
         categoriesController.onboardingViewController = self
         categoriesController.currentUser = currentUser
         addOnboardingViewController(categoriesController)
 
         let createProfileController = CreateProfileViewController()
-        createProfileController.parentAppController = parentAppController
         createProfileController.onboardingViewController = self
         createProfileController.currentUser = currentUser
         addOnboardingViewController(createProfileController)
@@ -253,7 +250,7 @@ extension OnboardingViewController {
     }
 
     fileprivate func doneOnboarding() {
-        parentAppController?.doneOnboarding()
+        appViewController?.doneOnboarding()
     }
 
     func goToController(_ viewController: UIViewController) {

--- a/Sources/Controllers/Profile/Categories/ProfileCategoriesViewController.swift
+++ b/Sources/Controllers/Profile/Categories/ProfileCategoriesViewController.swift
@@ -41,7 +41,7 @@ extension ProfileCategoriesViewController: UIViewControllerTransitioningDelegate
 extension ProfileCategoriesViewController: ProfileCategoriesDelegate {
 
     func categoryTapped(_ category: Category) {
-		Tracker.shared.categoryOpened(category.slug)
+        Tracker.shared.categoryOpened(category.slug)
         let vc = CategoryViewController(slug: category.slug, name: category.name)
         vc.currentUser = currentUser
 

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -53,7 +53,7 @@ protocol UserDelegate: class {
 }
 
 protocol WebLinkDelegate: class {
-    func webLinkTapped(type: ElloURI, data: String)
+    func webLinkTapped(path: String, type: ElloURI, data: String)
 }
 
 @objc
@@ -983,68 +983,13 @@ extension StreamViewController: UserDelegate {
 // MARK: StreamViewController: WebLinkDelegate
 extension StreamViewController: WebLinkDelegate {
 
-    func webLinkTapped(type: ElloURI, data: String) {
-        switch type {
-        case .confirm,
-             .faceMaker,
-             .freedomOfSpeech,
-             .invitations,
-             .invite,
-             .join,
-             .login,
-             .nativeRedirect,
-             .onboarding,
-             .passwordResetError,
-             .profileFollowers,
-             .profileFollowing,
-             .profileLoves,
-             .randomSearch,
-             .requestInvitations,
-             .resetMyPassword,
-             .searchPeople,
-             .searchPosts,
-             .unblock:
-            break
-        case .downloads,
-             .external,
-             .forgotMyPassword,
-             .manifesto,
-             .requestInvite,
-             .requestInvitation,
-             .subdomain,
-             .whoMadeThis,
-             .wtf:
-            postNotification(ExternalWebNotification, value: data)
-        case .discover:
-            DeepLinking.showDiscover(navVC: navigationController, currentUser: currentUser)
-        case .category,
-             .discoverRandom,
-             .discoverRecent,
-             .discoverRelated,
-             .discoverTrending,
-             .exploreRecommended,
-             .exploreRecent,
-             .exploreTrending:
-            DeepLinking.showCategory(navVC: navigationController, currentUser: currentUser, slug: data)
-        case .email: break // this is handled in ElloWebViewHelper
-        case .betaPublicProfiles,
-             .enter,
-             .exit,
-             .root,
-             .explore:
-            break // do nothing since we should already be in app
-        case .friends, .following, .noise, .starred: selectTab(.stream)
-        case .notifications: selectTab(.notifications)
-        case .post,
-             .pushNotificationComment,
-             .pushNotificationPost:
-            DeepLinking.showPostDetail(navVC: navigationController, currentUser: currentUser, token: data)
-        case .profile,
-             .pushNotificationUser:
-            DeepLinking.showProfile(navVC: navigationController, currentUser: currentUser, username: data)
-        case .search: DeepLinking.showSearch(navVC: navigationController, currentUser: currentUser, terms: data)
-        case .settings: DeepLinking.showSettings(navVC: navigationController, currentUser: currentUser)
-        }
+    func webLinkTapped(path: String, type: ElloURI, data: String) {
+        guard
+            let parentController = parent as? HasAppController,
+            let appViewController = parentController.appViewController
+        else { return }
+
+        appViewController.navigateToURI(path: path, type: type, data: data)
     }
 
     fileprivate func selectTab(_ tab: ElloTab) {

--- a/Sources/Controllers/WebBrowser/ElloWebBrowserViewController.swift
+++ b/Sources/Controllers/WebBrowser/ElloWebBrowserViewController.swift
@@ -109,6 +109,7 @@ extension ElloWebBrowserViewController : WebLinkDelegate {
              .invitations,
              .invite,
              .join,
+             .signup,
              .login,
              .manifesto,
              .nativeRedirect,

--- a/Sources/Controllers/WebBrowser/ElloWebBrowserViewController.swift
+++ b/Sources/Controllers/WebBrowser/ElloWebBrowserViewController.swift
@@ -97,7 +97,7 @@ extension ElloWebBrowserViewController: KINWebBrowserDelegate {
 
 // MARK: ElloWebBrowserViewController : WebLinkDelegate
 extension ElloWebBrowserViewController : WebLinkDelegate {
-    func webLinkTapped(type: ElloURI, data: String) {
+    func webLinkTapped(path: String, type: ElloURI, data: String) {
         switch type {
         case .confirm,
              .downloads,

--- a/Sources/Model/Regions/Asset.swift
+++ b/Sources/Model/Regions/Asset.swift
@@ -72,7 +72,7 @@ final class Asset: JSONAble {
         return false
     }
 
-	var oneColumnAttachment: Attachment? {
+    var oneColumnAttachment: Attachment? {
         return self.hdpi
     }
 

--- a/Sources/Networking/ElloAPI.swift
+++ b/Sources/Networking/ElloAPI.swift
@@ -215,8 +215,11 @@ extension ElloAPI {
              .searchForPosts, .searchForUsers,
              .userStreamPosts, .userStreamFollowing, .userStreamFollowers, .loves,
              .postComments, .postLovers, .postReposters, .postDetail,
-             .join, .deleteSubscriptions:
+             .join, .deleteSubscriptions, .userStream:
             return true
+        case let .infiniteScroll(_, elloApi):
+            let api = elloApi()
+            return api.supportsAnonymousToken
         default:
             return false
         }

--- a/Sources/Networking/ElloURI.swift
+++ b/Sources/Networking/ElloURI.swift
@@ -56,6 +56,7 @@ enum ElloURI: String {
     case requestInvitations = "request_invitations"
     case resetMyPassword = "reset-my-password"
     case root = "?$"
+    case signup = "signup"
     case subdomain = "\\/\\/.+(?<!(w{3}|staging))\\."
     case starred = "starred"
     case unblock = "unblock"
@@ -262,6 +263,7 @@ enum ElloURI: String {
         invitations,
         invite,
         join,
+        signup,
         login,
         manifesto,
         nativeRedirect,

--- a/Sources/Networking/ElloURI.swift
+++ b/Sources/Networking/ElloURI.swift
@@ -86,6 +86,16 @@ enum ElloURI: String {
         }
     }
 
+    var requiresLogin: Bool {
+        switch self {
+        case .settings, .notifications, .following, .starred, .friends, .noise,
+             .invitations, .onboarding, .unblock:
+            return true
+        default:
+            return false
+        }
+    }
+
     var shouldLoadInApp: Bool {
         switch self {
         case .confirm,

--- a/Sources/Utilities/ElloWebViewHelper.swift
+++ b/Sources/Utilities/ElloWebViewHelper.swift
@@ -23,7 +23,7 @@ struct ElloWebViewHelper {
             }
             else {
                 if fromWebView && type.loadsInWebViewFromWebView { return true }
-                webLinkDelegate?.webLinkTapped(type: type, data: data)
+                webLinkDelegate?.webLinkTapped(path: requestUrlString, type: type, data: data)
                 return false
             }
         }

--- a/Specs/Controllers/Stream/StreamViewControllerSpec.swift
+++ b/Specs/Controllers/Stream/StreamViewControllerSpec.swift
@@ -167,7 +167,7 @@ class StreamViewControllerSpec: QuickSpec {
                             link = url
                         }
 
-                        controller.webLinkTapped(type: ElloURI.external, data: "http://www.example.com")
+                        controller.webLinkTapped(path: "http://www.example.com", type: ElloURI.external, data: "http://www.example.com")
                         expect(link) == "http://www.example.com"
                     }
 

--- a/Specs/Controllers/Stream/StreamViewControllerSpec.swift
+++ b/Specs/Controllers/Stream/StreamViewControllerSpec.swift
@@ -9,6 +9,10 @@ import SSPullToRefresh
 
 
 class StreamViewControllerSpec: QuickSpec {
+    class MockHasAppViewController: UINavigationController, HasAppController {
+        let appViewController: AppViewController? = AppViewController()
+    }
+
     override func spec() {
 
         var controller: StreamViewController!
@@ -159,23 +163,34 @@ class StreamViewControllerSpec: QuickSpec {
                 }
 
                 describe("webLinkTapped(_:data:)") {
+                    var hasAppVC: MockHasAppViewController!
 
-                    it("posts a notification if type .External") {
-
-                        var link = ""
-                        externalWebObserver = NotificationObserver(notification: ExternalWebNotification) { url in
-                            link = url
-                        }
-
-                        controller.webLinkTapped(path: "http://www.example.com", type: ElloURI.external, data: "http://www.example.com")
-                        expect(link) == "http://www.example.com"
+                    beforeEach {
+                        // wire up the StreamViewController's hierarchy
+                        // the parent controller needs to be a `HasAppController`
+                        // but it doesn't need to be wired into an `AppViewController`,
+                        // it just needs to return it via the protocol
+                        hasAppVC = MockHasAppViewController(rootViewController: controller)
+                        showController(hasAppVC.appViewController!)
                     }
 
-                    xit("presents a profile if type .Profile") {
+                    it("opens external browser if type .external") {
+                        controller.webLinkTapped(path: "http://www.example.com", type: ElloURI.external, data: "http://www.example.com")
+                        let presented = hasAppVC.appViewController!.presentedViewController
+                        expect(presented).notTo(beNil())
+                        if let browser = (presented as! UINavigationController).viewControllers.first {
+                            expect(browser).to(beAKindOf(ElloWebBrowserViewController.self))
+                        }
+                        else {
+                            fail("did not present ElloWebBrowserViewController")
+                        }
+                    }
+
+                    xit("presents a profile if type .profile") {
                         // not yet implemented
                     }
 
-                    xit("shows a post detail if type .Post") {
+                    xit("shows a post detail if type .post") {
                         // not yet implemented
                     }
 

--- a/Specs/Networking/AuthStateSpec.swift
+++ b/Specs/Networking/AuthStateSpec.swift
@@ -13,7 +13,7 @@ class AuthStateSpec: QuickSpec {
             describe("supports(AuthState)") {
                 let noTokenReqd: [ElloAPI] = [.auth(email: "", password: ""), .reAuth(token: ""), .anonymousCredentials]
                 let anonymous: [ElloAPI] = [.availability(content: [:]), .join(email: "", username: "", password: "", invitationCode: nil)]
-                let authdOnly: [ElloAPI] = [.amazonCredentials, .noiseStream, .currentUserStream, .userStream(userParam: "")]
+                let authdOnly: [ElloAPI] = [.amazonCredentials, .noiseStream, .currentUserStream, .currentUserStream]
                 let expectations: [(AuthState, supported: [ElloAPI], unsupported: [ElloAPI])] = [
                     (.noToken, supported: noTokenReqd, unsupported: authdOnly),
                     (.anonymous, supported: noTokenReqd + anonymous, unsupported: authdOnly),

--- a/Specs/Networking/ElloURISpec.swift
+++ b/Specs/Networking/ElloURISpec.swift
@@ -271,6 +271,7 @@ class ElloURISpec: QuickSpec {
                         "with FreedomOfSpeech urls": (input: "freedom-of-speech", output: .freedomOfSpeech),
                         "with Invitations urls": (input: "invitations", output: .invitations),
                         "with Join urls": (input: "join", output: .join),
+                        "with Signup urls": (input: "signup", output: .signup),
                         "with Login urls": (input: "login", output: .login),
                         "with Manifesto urls": (input: "manifesto", output: .manifesto),
                         "with NativeRedirect urls": (input: "native_redirect", output: .nativeRedirect),


### PR DESCRIPTION
:v: Yay to centralized link handling!  Since `AppViewController` was already handling all the deep links, I wondered why we didn't rely on it within `StreamViewController`, too, and couldn't find a good reason.  Posts and Profiles are pushed onto the visible view controller.