### PR TITLE
CreatePostDelegate -> CreatePostResponder

### DIFF
--- a/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
+++ b/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
@@ -187,9 +187,6 @@ final class PostDetailViewController: StreamableViewController {
             return
         }
 
-        // This is a bit dirty, we should not call a method on a compositionally held
-        // controller's createPostDelegate. Can this use the responder chain when we have
-        // parameters to pass?
         editPost(post, fromController: self)
     }
 

--- a/Sources/Controllers/Stream/PostbarController.swift
+++ b/Sources/Controllers/Stream/PostbarController.swift
@@ -158,15 +158,13 @@ class PostbarController: UIResponder, PostbarResponder {
     }
 
     func editCommentButtonTapped(_ indexPath: IndexPath) {
-        // This is a bit dirty, we should not call a method on a compositionally held
-        // controller's createPostDelegate. Can this use the responder chain when we have
-        // parameters to pass?
         guard
             let comment = self.commentForIndexPath(indexPath),
             let presentingController = presentingController
         else { return }
 
-        presentingController.createPostDelegate?.editComment(comment, fromController: presentingController)
+        let responder = target(forAction: #selector(CreatePostResponder.editComment(_:fromController:)), withSender: self) as? CreatePostResponder
+        responder?.editComment(comment, fromController: presentingController)
     }
 
     func lovesButtonTapped(_ cell: StreamFooterCell?, indexPath: IndexPath) {
@@ -335,29 +333,26 @@ class PostbarController: UIResponder, PostbarResponder {
             let atName = comment.author?.atName
         else { return }
 
-        // This is a bit dirty, we should not call a method on a compositionally held
-        // controller's createPostDelegate. Can this use the responder chain when we have
-        // parameters to pass?
 
         let postId = comment.loadedFromPostId
-        presentingController.createPostDelegate?.createComment(postId, text: "\(atName) ", fromController: presentingController)
+
+        let responder = target(forAction: #selector(CreatePostResponder.createComment(_:text:fromController:)), withSender: self) as? CreatePostResponder
+        responder?.createComment(postId, text: "\(atName) ", fromController: presentingController)
     }
 
     func replyToAllButtonTapped(_ indexPath: IndexPath) {
-        // This is a bit dirty, we should not call a method on a compositionally held
-        // controller's createPostDelegate. Can this use the responder chain when we have
-        // parameters to pass?
         guard
             let comment = commentForIndexPath(indexPath),
             let presentingController = presentingController
         else { return }
 
         let postId = comment.loadedFromPostId
-        PostService().loadReplyAll(postId, success: { usernames in
+        PostService().loadReplyAll(postId, success: {[weak self] usernames in
             let usernamesText = usernames.reduce("") { memo, username in
                 return memo + "@\(username) "
             }
-            presentingController.createPostDelegate?.createComment(postId, text: usernamesText, fromController: presentingController)
+            let responder = self?.target(forAction: #selector(CreatePostResponder.createComment(_:text:fromController:)), withSender: self) as? CreatePostResponder
+            responder?.createComment(postId, text: usernamesText, fromController: presentingController)
         }, failure: {
             presentingController.createCommentTapped(postId)
         })

--- a/Sources/Controllers/Stream/PostbarController.swift
+++ b/Sources/Controllers/Stream/PostbarController.swift
@@ -348,10 +348,11 @@ class PostbarController: UIResponder, PostbarResponder {
 
         let postId = comment.loadedFromPostId
         PostService().loadReplyAll(postId, success: {[weak self] usernames in
+            guard let `self` = self else { return }
             let usernamesText = usernames.reduce("") { memo, username in
                 return memo + "@\(username) "
             }
-            let responder = self?.target(forAction: #selector(CreatePostResponder.createComment(_:text:fromController:)), withSender: self) as? CreatePostResponder
+            let responder = self.target(forAction: #selector(CreatePostResponder.createComment(_:text:fromController:)), withSender: self) as? CreatePostResponder
             responder?.createComment(postId, text: usernamesText, fromController: presentingController)
         }, failure: {
             presentingController.createCommentTapped(postId)

--- a/Sources/Controllers/Stream/StreamContainerViewController.swift
+++ b/Sources/Controllers/Stream/StreamContainerViewController.swift
@@ -179,7 +179,6 @@ class StreamContainerViewController: StreamableViewController {
             let vc = StreamViewController.instantiateFromStoryboard()
             vc.currentUser = currentUser
             vc.streamKind = kind
-            vc.createPostDelegate = self
             vc.postTappedDelegate = self
             vc.userTappedDelegate = self
             vc.streamViewDelegate = self

--- a/Sources/Controllers/Stream/StreamDataSource.swift
+++ b/Sources/Controllers/Stream/StreamDataSource.swift
@@ -38,7 +38,6 @@ class StreamDataSource: NSObject, UICollectionViewDataSource {
     let categoryHeaderSizeCalculator: CategoryHeaderCellSizeCalculator
     let imageSizeCalculator: StreamImageCellSizeCalculator
 
-    weak var createPostDelegate: CreatePostDelegate?
     weak var webLinkDelegate: WebLinkDelegate?
     weak var categoryDelegate: CategoryDelegate?
     weak var userDelegate: UserDelegate?

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -177,7 +177,6 @@ final class StreamViewController: BaseElloViewController {
     var settingChangedNotification: NotificationObserver?
     var currentUserChangedNotification: NotificationObserver?
 
-    weak var createPostDelegate: CreatePostDelegate?
     weak var postTappedDelegate: PostTappedDelegate?
     weak var userTappedDelegate: UserTappedDelegate?
     weak var streamViewDelegate: StreamViewDelegate?
@@ -852,12 +851,14 @@ extension StreamViewController: StreamEditingResponder {
         if let post = dataSource.postForIndexPath(indexPath),
             currentUser.isOwn(post: post)
         {
-            createPostDelegate?.editPost(post, fromController: self)
+            let responder = target(forAction: #selector(CreatePostResponder.editPost(_:fromController:)), withSender: self) as? CreatePostResponder
+            responder?.editPost(post, fromController: self)
         }
         else if let comment = dataSource.commentForIndexPath(indexPath),
             currentUser.isOwn(comment: comment)
         {
-            createPostDelegate?.editComment(comment, fromController: self)
+            let responder = target(forAction: #selector(CreatePostResponder.editComment(_:fromController:)), withSender: self) as? CreatePostResponder
+            responder?.editComment(comment, fromController: self)
         }
     }
 }
@@ -888,7 +889,8 @@ extension StreamViewController: StreamImageCellResponder {
 extension StreamViewController {
 
     func createCommentTapped(_ postId: String) {
-        createPostDelegate?.createComment(postId, text: nil, fromController: self)
+        let responder = target(forAction: #selector(CreatePostResponder.createComment(_:text:fromController:)), withSender: self) as? CreatePostResponder
+        responder?.createComment(postId, text: nil, fromController: self)
     }
 }
 

--- a/Sources/Controllers/Stream/StreamableViewController.swift
+++ b/Sources/Controllers/Stream/StreamableViewController.swift
@@ -13,7 +13,8 @@ protocol UserTappedDelegate: class {
     func userParamTapped(_ param: String, username: String?)
 }
 
-protocol CreatePostDelegate: class {
+@objc
+protocol CreatePostResponder: class {
     func createPost(text: String?, fromController: UIViewController)
     func createComment(_ postId: String, text: String?, fromController: UIViewController)
     func editComment(_ comment: ElloComment, fromController: UIViewController)
@@ -36,7 +37,6 @@ class StreamableViewController: BaseElloViewController, PostTappedDelegate {
         streamViewController.streamViewDelegate = self
         streamViewController.userTappedDelegate = self
         streamViewController.postTappedDelegate = self
-        streamViewController.createPostDelegate = self
 
         streamViewController.willMove(toParentViewController: self)
         let containerForStream = viewForStream()
@@ -197,8 +197,8 @@ extension StreamableViewController: UserTappedDelegate {
     }
 }
 
-// MARK: CreatePostDelegate
-extension StreamableViewController: CreatePostDelegate {
+// MARK: CreatePostResponder
+extension StreamableViewController: CreatePostResponder {
     func createPost(text: String?, fromController: UIViewController) {
         let vc = OmnibarViewController(defaultText: text)
         vc.currentUser = self.currentUser

--- a/Specs/Controllers/Stream/PostbarControllerSpec.swift
+++ b/Specs/Controllers/Stream/PostbarControllerSpec.swift
@@ -9,7 +9,7 @@ import Moya
 
 
 class PostbarControllerSpec: QuickSpec {
-    class ReplyAllCreatePostDelegate: CreatePostDelegate {
+    class ReplyAllCreatePostResponder: UIWindow, CreatePostResponder {
         var postId: String?
         var post: Post?
         var comment: ElloComment?
@@ -32,6 +32,7 @@ class PostbarControllerSpec: QuickSpec {
 
     override func spec() {
         var subject: PostbarController!
+        var responder: ReplyAllCreatePostResponder!
         let currentUser: User = User.stub([
             "id": "user500",
             "lovesCount": 5,
@@ -63,13 +64,13 @@ class PostbarControllerSpec: QuickSpec {
 
             subject = PostbarController(collectionView: controller.collectionView, dataSource: dataSource, presentingController: controller)
             subject.currentUser = currentUser
-
-            showController(controller)
+            responder = ReplyAllCreatePostResponder()
+            showController(controller, window: responder)
         }
 
         describe("PostbarController") {
             describe("replyToAllButtonTapped(_:)") {
-                var delegate: ReplyAllCreatePostDelegate!
+
                 var indexPath: IndexPath!
 
                 beforeEach {
@@ -82,8 +83,6 @@ class PostbarControllerSpec: QuickSpec {
                     let newComment = ElloComment.newCommentForPost(post, currentUser: currentUser)
                     postCellItems += [StreamCellItem(jsonable: newComment, type: .createComment)]
                     indexPath = IndexPath(item: postCellItems.count - 1, section: 0)
-                    delegate = ReplyAllCreatePostDelegate()
-                    controller.createPostDelegate = delegate
                     controller.dataSource.appendUnsizedCellItems(postCellItems, withWidth: 320.0) { cellCount in
                         controller.collectionView.reloadData()
                     }
@@ -91,7 +90,7 @@ class PostbarControllerSpec: QuickSpec {
                 context("tapping replyToAll") {
                     it("opens an OmnibarViewController with usernames set") {
                         subject.replyToAllButtonTapped(indexPath)
-                        expect(delegate.text) == "@user1 @user2 "
+                        expect(responder.text) == "@user1 @user2 "
                     }
                 }
             }

--- a/Specs/QuickExtensions.swift
+++ b/Specs/QuickExtensions.swift
@@ -9,7 +9,7 @@ import Nimble_Snapshots
 
 
 var prevController: UITabBarController?
-func showController(_ viewController: UIViewController) {
+func showController(_ viewController: UIViewController, window: UIWindow = UIWindow()) {
     let frame: CGRect
     let view: UIView = viewController.view
     if view.frame.size.width > 0 && view.frame.size.height > 0 {
@@ -22,7 +22,6 @@ func showController(_ viewController: UIViewController) {
     viewController.loadViewIfNeeded()
 
     prevController?.viewControllers = []
-    let window = UIWindow()
     let parentController = UITabBarController()
     parentController.tabBar.isHidden = true
     parentController.viewControllers = [viewController]


### PR DESCRIPTION
This one is nifty for a few reasons. 1) It finally gets rid our long standing "// This is a bit dirty, we should not call a method on a compositionally held controller's createPostDelegate. Can this use the responder chain when we have parameters to pass?" comments. Yay. 2) Rather than assigning a delegate in specs we verify responder behavior by using a mock window that implements the responder functions. Not as elegant but cool that it works.