### PR TITLE
Removes redundant tracking

### DIFF
--- a/Sources/Controllers/Notifications/NotificationsViewController.swift
+++ b/Sources/Controllers/Notifications/NotificationsViewController.swift
@@ -104,7 +104,6 @@ class NotificationsViewController: StreamableViewController, NotificationDelegat
         }
 
         generator?.load(reload: true)
-        Tracker.shared.screenAppeared(self)
     }
 
     func reloadAnnouncements() {


### PR DESCRIPTION
I noticed this when I was verifying the pull-to-refresh tracking, that caused Notifications to be double-tracked.