### PR TITLE
Category delegates -> responders

### DIFF
--- a/Sources/Controllers/Onboarding/CategoriesSelectionViewController.swift
+++ b/Sources/Controllers/Onboarding/CategoriesSelectionViewController.swift
@@ -28,7 +28,6 @@ class CategoriesSelectionViewController: StreamableViewController {
         super.viewDidLoad()
 
         streamViewController.pullToRefreshEnabled = false
-        streamViewController.selectedCategoryDelegate = self
         ElloHUD.showLoadingHudInView(streamViewController.view)
         streamViewController.loadInitialPage()
     }
@@ -88,7 +87,7 @@ extension CategoriesSelectionViewController: OnboardingStepController {
     }
 }
 
-extension CategoriesSelectionViewController: SelectedCategoryDelegate {
+extension CategoriesSelectionViewController: SelectedCategoryResponder {
     func categoriesSelectionChanged(selection: [Category]) {
         let selectionCount = selection.count
         let prompt: String?

--- a/Sources/Controllers/Stream/Cells/StreamHeaderCell.swift
+++ b/Sources/Controllers/Stream/Cells/StreamHeaderCell.swift
@@ -67,7 +67,6 @@ class StreamHeaderCell: UICollectionViewCell {
         set { relationshipControl.relationshipDelegate = newValue }
     }
 
-    weak var categoryDelegate: CategoryDelegate?
 
     var avatarHeight: CGFloat = 60.0 {
         didSet { setNeedsDisplay() }
@@ -427,7 +426,8 @@ class StreamHeaderCell: UICollectionViewCell {
     }
 
     @IBAction func categoryTapped(_ sender: UIButton) {
-        categoryDelegate?.categoryCellTapped(cell: self)
+        let responder = target(forAction: #selector(CategoryResponder.categoryCellTapped(cell:)), withSender: self) as? CategoryResponder
+        responder?.categoryCellTapped(cell: self)
     }
 
     @IBAction func reposterTapped(_ sender: UIButton) {

--- a/Sources/Controllers/Stream/StreamDataSource.swift
+++ b/Sources/Controllers/Stream/StreamDataSource.swift
@@ -39,7 +39,6 @@ class StreamDataSource: NSObject, UICollectionViewDataSource {
     let imageSizeCalculator: StreamImageCellSizeCalculator
 
     weak var webLinkDelegate: WebLinkDelegate?
-    weak var categoryDelegate: CategoryDelegate?
     weak var relationshipDelegate: RelationshipDelegate?
     weak var searchStreamDelegate: SearchStreamDelegate?
     weak var categoryListCellDelegate: CategoryListCellDelegate?
@@ -335,7 +334,6 @@ class StreamDataSource: NSObject, UICollectionViewDataSource {
             (cell as! CategoryListCell).delegate = categoryListCellDelegate
         case .header, .commentHeader:
             (cell as! StreamHeaderCell).relationshipDelegate = relationshipDelegate
-            (cell as! StreamHeaderCell).categoryDelegate = categoryDelegate
         case .inviteFriends, .onboardingInviteFriends:
             (cell as! StreamInviteFriendsCell).inviteCache = inviteCache
         case .notification:


### PR DESCRIPTION
These are pretty small so I included both `CategoryResponder` and `SelectedCategoryResponder`. These compile and specs pass but it is unclear to me what causes `func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath)` in `StreamViewController` to be called. I was unable to trigger that callback through actual app use. Any ideas?