### PR TITLE
Shows logged out message when user attempts interaction

### DIFF
--- a/Sources/Controllers/App/AppViewController.swift
+++ b/Sources/Controllers/App/AppViewController.swift
@@ -14,6 +14,10 @@ struct StatusBarNotifications {
     static let statusBarShouldHide = TypedNotification<(Bool)>(name: "co.ello.StatusBarNotifications.statusBarShouldHide")
 }
 
+struct LoggedOutNotifications {
+    static let userActionAttempted = TypedNotification<()>(name: "co.ello.LoggedOutNotifications.userActionAttempted")
+}
+
 
 @objc
 protocol HasAppController {

--- a/Sources/Controllers/ElloNavigationController.swift
+++ b/Sources/Controllers/ElloNavigationController.swift
@@ -143,7 +143,6 @@ extension ElloNavigationController: UIGestureRecognizerDelegate {
 
 }
 
-private let throttledTracker = debounce(0.1)
 extension ElloNavigationController: UINavigationControllerDelegate {
 
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {

--- a/Sources/Controllers/LoggedOut/LoggedOutViewController.swift
+++ b/Sources/Controllers/LoggedOut/LoggedOutViewController.swift
@@ -23,6 +23,8 @@ class LoggedOutViewController: BaseElloViewController, BottomBarController {
     var mockScreen: LoggedOutScreenProtocol?
     var screen: LoggedOutScreenProtocol { return mockScreen ?? (self.view as! LoggedOutScreenProtocol) }
 
+    fileprivate var userActionAttemptedObserver: NotificationObserver?
+
     func setNavigationBarsVisible(_ visible: Bool, animated: Bool) {
         navigationBarsVisible = visible
     }
@@ -37,6 +39,30 @@ class LoggedOutViewController: BaseElloViewController, BottomBarController {
         screen.delegate = self
         self.view = screen
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setupNotificationObservers()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        removeNotificationObservers()
+    }
+}
+
+extension LoggedOutViewController {
+
+    func setupNotificationObservers() {
+        userActionAttemptedObserver = NotificationObserver(notification: LoggedOutNotifications.userActionAttempted) { [weak self] _ in
+            self?.screen.showJoinText()
+        }
+    }
+
+    func removeNotificationObservers() {
+        userActionAttemptedObserver?.removeObserver()
+    }
+
 }
 
 extension LoggedOutViewController: LoggedOutProtocol {

--- a/Sources/Controllers/Profile/ProfileViewController.swift
+++ b/Sources/Controllers/Profile/ProfileViewController.swift
@@ -228,6 +228,10 @@ final class ProfileViewController: StreamableViewController {
     }
 
     func moreButtonTapped() {
+        guard currentUser != nil else {
+            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            return
+        }
         guard let user = user else { return }
 
         let userId = user.id
@@ -267,12 +271,20 @@ final class ProfileViewController: StreamableViewController {
 
 extension ProfileViewController: ProfileScreenDelegate {
     func mentionTapped() {
+        guard currentUser != nil else {
+            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            return
+        }
         guard let user = user else { return }
 
         createPost(text: "\(user.atName) ", fromController: self)
     }
 
     func hireTapped() {
+        guard currentUser != nil else {
+            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            return
+        }
         guard let user = user else { return }
 
         Tracker.shared.tappedHire(user)
@@ -281,6 +293,10 @@ extension ProfileViewController: ProfileScreenDelegate {
     }
 
     func editTapped() {
+        guard currentUser != nil else {
+            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            return
+        }
         onEditProfile()
     }
 
@@ -289,6 +305,10 @@ extension ProfileViewController: ProfileScreenDelegate {
     }
 
     func collaborateTapped() {
+        guard currentUser != nil else {
+            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            return
+        }
         guard let user = user else { return }
 
         Tracker.shared.tappedCollaborate(user)
@@ -439,6 +459,11 @@ extension ProfileViewController: ProfileHeaderResponder {
 extension ProfileViewController: EditProfileResponder {
 
     func onEditProfile() {
+        guard currentUser != nil else {
+            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            return
+        }
+
         guard let settings = UIStoryboard(name: "Settings", bundle: .none).instantiateInitialViewController() as? SettingsContainerViewController else { return }
         settings.currentUser = currentUser
         navigationController?.pushViewController(settings, animated: true)

--- a/Sources/Controllers/Relationship/RelationshipController.swift
+++ b/Sources/Controllers/Relationship/RelationshipController.swift
@@ -35,6 +35,12 @@ class RelationshipController {
 // MARK: RelationshipController: RelationshipDelegate
 extension RelationshipController: RelationshipDelegate {
     func relationshipTapped(_ userId: String, prev prevRelationshipPriority: RelationshipPriority, relationshipPriority: RelationshipPriority, complete: @escaping RelationshipChangeCompletion) {
+        guard currentUser != nil else {
+            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            complete(.success, .none, true)
+            return
+        }
+
         Tracker.shared.relationshipButtonTapped(relationshipPriority, userId: userId)
         if let shouldSubmit = delegate?.shouldSubmitRelationship(userId, relationshipPriority: relationshipPriority), !shouldSubmit {
             let relationship = Relationship(id: UUID().uuidString, createdAt: Date(), ownerId: "", subjectId: userId)

--- a/Sources/Controllers/Stream/Cells/SearchStreamCell.swift
+++ b/Sources/Controllers/Stream/Cells/SearchStreamCell.swift
@@ -8,7 +8,7 @@ class SearchStreamCell: UICollectionViewCell {
         static let insets: CGFloat = 10
     }
 
-    fileprivate var debounced: ThrottledBlock = debounce(0.8)
+    fileprivate var debounced = debounce(0.8)
     fileprivate let searchField = SearchTextField()
     weak var delegate: SearchStreamDelegate?
 

--- a/Sources/Controllers/Stream/Cells/SearchStreamCell.swift
+++ b/Sources/Controllers/Stream/Cells/SearchStreamCell.swift
@@ -64,8 +64,8 @@ extension SearchStreamCell: UITextFieldDelegate {
             clearSearch()
         }
         else {
-            debounced { [unowned self] in
-                self.searchForText()
+            debounced { [weak self] in
+                self?.searchForText()
             }
         }
     }

--- a/Sources/Controllers/Stream/PostbarController.swift
+++ b/Sources/Controllers/Stream/PostbarController.swift
@@ -128,6 +128,11 @@ class PostbarController: UIResponder, PostbarResponder {
     }
 
     func deleteCommentButtonTapped(_ indexPath: IndexPath) {
+        guard currentUser != nil else {
+            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            return
+        }
+
         let message = InterfaceString.Post.DeleteCommentConfirm
         let alertController = AlertViewController(message: message)
 
@@ -158,6 +163,10 @@ class PostbarController: UIResponder, PostbarResponder {
     }
 
     func editCommentButtonTapped(_ indexPath: IndexPath) {
+        guard currentUser != nil else {
+            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            return
+        }
         guard
             let comment = self.commentForIndexPath(indexPath),
             let presentingController = presentingController
@@ -168,6 +177,10 @@ class PostbarController: UIResponder, PostbarResponder {
     }
 
     func lovesButtonTapped(_ cell: StreamFooterCell?, indexPath: IndexPath) {
+        guard currentUser != nil else {
+            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            return
+        }
         guard let post = self.postForIndexPath(indexPath) else { return }
 
         cell?.lovesControl.isUserInteractionEnabled = false
@@ -223,6 +236,10 @@ class PostbarController: UIResponder, PostbarResponder {
     }
 
     func repostButtonTapped(_ indexPath: IndexPath) {
+        guard currentUser != nil else {
+            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            return
+        }
         guard let post = self.postForIndexPath(indexPath) else { return }
 
         Tracker.shared.postReposted(post)
@@ -311,6 +328,10 @@ class PostbarController: UIResponder, PostbarResponder {
     }
 
     func flagCommentButtonTapped(_ indexPath: IndexPath) {
+        guard currentUser != nil else {
+            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            return
+        }
         guard
             let comment = commentForIndexPath(indexPath),
             let presentingController = presentingController
@@ -327,6 +348,10 @@ class PostbarController: UIResponder, PostbarResponder {
     }
 
     func replyToCommentButtonTapped(_ indexPath: IndexPath) {
+        guard currentUser != nil else {
+            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            return
+        }
         guard
             let comment = commentForIndexPath(indexPath),
             let presentingController = presentingController,
@@ -341,6 +366,10 @@ class PostbarController: UIResponder, PostbarResponder {
     }
 
     func replyToAllButtonTapped(_ indexPath: IndexPath) {
+        guard currentUser != nil else {
+            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            return
+        }
         guard
             let comment = commentForIndexPath(indexPath),
             let presentingController = presentingController
@@ -360,6 +389,10 @@ class PostbarController: UIResponder, PostbarResponder {
     }
 
     func watchPostTapped(_ watching: Bool, cell: StreamCreateCommentCell, indexPath: IndexPath) {
+        guard currentUser != nil else {
+            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            return
+        }
         guard
             let comment = dataSource.commentForIndexPath(indexPath),
             let post = comment.parentPost
@@ -413,7 +446,7 @@ class PostbarController: UIResponder, PostbarResponder {
                 self.collectionView.reloadData() // insertItemsAtIndexPaths(indexPaths)
                 cell.commentsControl.isEnabled = true
 
-                if indexPaths.count == 1 && jsonables.count == 0 {
+                if self.currentUser != nil && indexPaths.count == 1 && jsonables.count == 0 {
                     self.presentingController?.createCommentTapped(post.id)
                 }
             }

--- a/Sources/Controllers/Stream/PostbarController.swift
+++ b/Sources/Controllers/Stream/PostbarController.swift
@@ -261,8 +261,7 @@ class PostbarController: UIResponder, PostbarResponder {
         presentingController?.present(alertController, animated: true, completion: .none)
     }
 
-    fileprivate func createRepost(_ post: Post, alertController: AlertViewController)
-    {
+    fileprivate func createRepost(_ post: Post, alertController: AlertViewController) {
         alertController.resetActions()
         alertController.dismissable = false
 

--- a/Sources/Controllers/Stream/StreamableViewController.swift
+++ b/Sources/Controllers/Stream/StreamableViewController.swift
@@ -280,6 +280,11 @@ extension StreamableViewController: StreamViewDelegate {
 // MARK: InviteResponder
 extension StreamableViewController: InviteResponder {
     func onInviteFriends() {
+        guard currentUser != nil else {
+            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            return
+        }
+
         Tracker.shared.inviteFriendsTapped()
         AddressBookController.promptForAddressBookAccess(fromController: self, completion: { result in
             switch result {

--- a/Sources/Utilities/FreeMethods.swift
+++ b/Sources/Utilities/FreeMethods.swift
@@ -254,35 +254,3 @@ func debounce(_ timeout: TimeInterval) -> ThrottledBlock {
         timer = Timer.scheduledTimer(timeInterval: timeout, target: proc, selector: #selector(Proc.run), userInfo: nil, repeats: false)
     }
 }
-
-func throttle(_ interval: TimeInterval, block: @escaping BasicBlock) -> BasicBlock {
-    var timer: Timer? = nil
-    let proc = Proc() {
-        timer = nil
-        block()
-    }
-
-    return {
-        if timer == nil {
-            timer = Timer.scheduledTimer(timeInterval: interval, target: proc, selector: #selector(Proc.run), userInfo: nil, repeats: false)
-        }
-    }
-}
-
-func throttle(_ interval: TimeInterval) -> ThrottledBlock {
-    var timer: Timer? = nil
-    var lastBlock: BasicBlock?
-
-    return { block in
-        lastBlock = block
-
-        if timer == nil {
-            let proc = Proc() {
-                timer = nil
-                lastBlock?()
-            }
-
-            timer = Timer.scheduledTimer(timeInterval: interval, target: proc, selector: #selector(Proc.run), userInfo: nil, repeats: false)
-        }
-    }
-}

--- a/Specs/Controllers/Relationship/RelationshipControlSpec.swift
+++ b/Specs/Controllers/Relationship/RelationshipControlSpec.swift
@@ -65,6 +65,9 @@ class RelationshipControlSpec: QuickSpec {
             }
 
             describe("button targets") {
+                beforeEach {
+                    relationshipController.currentUser = User.stub([:])
+                }
 
                 context("not muted") {
 


### PR DESCRIPTION
Wherever a `currentUser` is required, pop up the 'join now' message instead.  See commits for more details.