### PR TITLE
Relationship Responders

### DIFF
--- a/Ello.xcodeproj/project.pbxproj
+++ b/Ello.xcodeproj/project.pbxproj
@@ -259,6 +259,7 @@
 		123466161C65468100E61110 /* ello_logo.svg in Resources */ = {isa = PBXBuildFile; fileRef = 769051001AFD2A720011B09A /* ello_logo.svg */; };
 		12384EBB1C56B3C200608BD8 /* UIViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12384EBA1C56B3C200608BD8 /* UIViewExtensions.swift */; };
 		12384EBD1C56C8B200608BD8 /* UIViewExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12384EBC1C56C8B200608BD8 /* UIViewExtensionsSpec.swift */; };
+		123971521E4B626400481CB3 /* ResponderChainableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123971511E4B626400481CB3 /* ResponderChainableController.swift */; };
 		123B7C331DB5100F00BBD032 /* ProfileCategoriesPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123B7C321DB5100F00BBD032 /* ProfileCategoriesPresentationController.swift */; };
 		123DEBE91D3D4087007B5F86 /* PostDetailGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123DEBE81D3D4087007B5F86 /* PostDetailGenerator.swift */; };
 		123DEBEB1D3D409C007B5F86 /* ProfileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123DEBEA1D3D409C007B5F86 /* ProfileGenerator.swift */; };
@@ -1238,6 +1239,7 @@
 		123466141C650B3000E61110 /* NSItemProviderExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSItemProviderExtensions.swift; sourceTree = "<group>"; };
 		12384EBA1C56B3C200608BD8 /* UIViewExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewExtensions.swift; sourceTree = "<group>"; };
 		12384EBC1C56C8B200608BD8 /* UIViewExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewExtensionsSpec.swift; sourceTree = "<group>"; };
+		123971511E4B626400481CB3 /* ResponderChainableController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResponderChainableController.swift; sourceTree = "<group>"; };
 		123B7C321DB5100F00BBD032 /* ProfileCategoriesPresentationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileCategoriesPresentationController.swift; sourceTree = "<group>"; };
 		123DEBE81D3D4087007B5F86 /* PostDetailGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostDetailGenerator.swift; sourceTree = "<group>"; };
 		123DEBEA1D3D409C007B5F86 /* ProfileGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileGenerator.swift; sourceTree = "<group>"; };
@@ -2561,13 +2563,14 @@
 			isa = PBXGroup;
 			children = (
 				7666C95D1B10055C009AC019 /* AddFriendsViewController.swift */,
+				1DA18E111DB187DF000231CC /* CalculatedCellHeights.swift */,
 				1D1BCA531BACBAAE009075E8 /* Calculators */,
 				128D36A81A95192300622833 /* CellDequeing */,
-				1DA18E111DB187DF000231CC /* CalculatedCellHeights.swift */,
 				122B18CC1A867BCE00247A05 /* Cells */,
 				1266E50C1A9E2B9E00270E1C /* ContentFlagger.swift */,
 				1D1AF61E1A83ED6600E06C93 /* Detail */,
 				12224E571A72CEC300D087EC /* PostbarController.swift */,
+				123971511E4B626400481CB3 /* ResponderChainableController.swift */,
 				766375DF1AA911090096FA51 /* SimpleStreamViewController.swift */,
 				1D1AF6271A84437B00E06C93 /* StreamableViewController.swift */,
 				1217008B1A7841C400EBACA5 /* StreamCellItem.swift */,
@@ -5191,6 +5194,7 @@
 				12F6AE1E1A43386300493660 /* AppViewController.swift in Sources */,
 				12F6ADFD1A43380C00493660 /* ElloTabBarController.swift in Sources */,
 				1289F3921AF1468B008A938C /* ImageLabelControl.swift in Sources */,
+				123971521E4B626400481CB3 /* ResponderChainableController.swift in Sources */,
 				1DA18E521DCCF70E000231CC /* PagePromotionalService.swift in Sources */,
 				1D7152D51D74A23D005998FE /* TextHeaderCellPresenter.swift in Sources */,
 				122B19011A867C7D00247A05 /* StreamImageCell.swift in Sources */,

--- a/Sources/Controllers/Onboarding/CategoriesSelectionViewController.swift
+++ b/Sources/Controllers/Onboarding/CategoriesSelectionViewController.swift
@@ -52,6 +52,7 @@ class CategoriesSelectionViewController: StreamableViewController {
 }
 
 extension CategoriesSelectionViewController: OnboardingStepController {
+
     func onboardingStepBegin() {
         let prompt = NSString(format: InterfaceString.Onboard.PickTemplate as NSString, 3) as String
         onboardingViewController?.hasAbortButton = false
@@ -88,6 +89,7 @@ extension CategoriesSelectionViewController: OnboardingStepController {
 }
 
 extension CategoriesSelectionViewController: SelectedCategoryResponder {
+
     func categoriesSelectionChanged(selection: [Category]) {
         let selectionCount = selection.count
         let prompt: String?

--- a/Sources/Controllers/Profile/ProfileProtocols.swift
+++ b/Sources/Controllers/Profile/ProfileProtocols.swift
@@ -15,7 +15,6 @@ protocol ProfileScreenProtocol: StreamableScreenProtocol {
     func updateHeaderHeightConstraints(max: CGFloat, scrollAdjusted: CGFloat)
     func updateRelationshipControl(user: User)
     func updateRelationshipPriority(_ relationshipPriority: RelationshipPriority)
-    var relationshipDelegate: RelationshipDelegate? { get set }
     var topInsetView: UIView { get }
     var coverImage: UIImage? { get set }
     var coverImageURL: URL? { get set }

--- a/Sources/Controllers/Profile/ProfileScreen.swift
+++ b/Sources/Controllers/Profile/ProfileScreen.swift
@@ -21,11 +21,6 @@ class ProfileScreen: StreamableScreen, ProfileScreenProtocol {
         static let editButtonMargin: CGFloat = 10
     }
 
-    weak var relationshipDelegate: RelationshipDelegate? {
-        get { return self.relationshipControl.relationshipDelegate }
-        set { self.relationshipControl.relationshipDelegate = newValue }
-    }
-
     var coverImage: UIImage? {
         get { return coverImageView.image }
         set { coverImageView.image = newValue }

--- a/Sources/Controllers/Profile/ProfileViewController.swift
+++ b/Sources/Controllers/Profile/ProfileViewController.swift
@@ -111,7 +111,6 @@ final class ProfileViewController: StreamableViewController {
         setupNavigationItems()
         ElloHUD.showLoadingHudInView(streamViewController.view)
         streamViewController.loadInitialPage()
-        screen.relationshipDelegate = streamViewController.dataSource.relationshipDelegate
 
         if let user = user {
             updateUser(user)
@@ -232,9 +231,16 @@ final class ProfileViewController: StreamableViewController {
 
         let userId = user.id
         let userAtName = user.atName
-        let prevRelationshipPriority = user.relationshipPriority
-        streamViewController.relationshipController?.launchBlockModal(userId, userAtName: userAtName, relationshipPriority: prevRelationshipPriority) { newRelationshipPriority in
-            user.relationshipPriority = newRelationshipPriority
+        let prevRelationshipPriority = RelationshipPriorityWrapper(priority: user.relationshipPriority)
+
+        let responder = target(forAction: #selector(RelationshipResponder.launchBlockModal(_:userAtName:relationshipPriority:changeClosure:)), withSender: self) as? RelationshipResponder
+
+        responder?.launchBlockModal(
+            userId,
+            userAtName: userAtName,
+            relationshipPriority: prevRelationshipPriority
+        ) { newRelationshipPriority in
+            user.relationshipPriority = newRelationshipPriority.priority
         }
     }
 

--- a/Sources/Controllers/Relationship/RelationshipController.swift
+++ b/Sources/Controllers/Relationship/RelationshipController.swift
@@ -78,7 +78,7 @@ extension RelationshipController: RelationshipResponder {
             currentUserId: currentUserId,
             userId: userId,
             relationshipPriority: newRelationshipPriority.priority,
-            success: {[weak self] (data, responseConfig) in
+            success: { [weak self] (data, responseConfig) in
                 guard let `self` = self else { return }
                 if let relationship = data as? Relationship {
                     complete(RelationshipRequestStatusWrapper(status: .success), relationship, responseConfig.isFinalValue)
@@ -119,7 +119,7 @@ extension RelationshipController: RelationshipResponder {
                     prevRelationshipPriority = newRelationshipPriority
                 }
             },
-            failure: {[weak self] (error, statusCode) in
+            failure: { [weak self] (error, statusCode) in
                 guard let `self` = self else { return }
                 complete(RelationshipRequestStatusWrapper(status: .failure), nil, true)
                 let responder = self.target(forAction: #selector(RelationshipControllerResponder.relationshipChanged(_:status:relationship:)), withSender: self) as? RelationshipControllerResponder

--- a/Sources/Controllers/Relationship/RelationshipController.swift
+++ b/Sources/Controllers/Relationship/RelationshipController.swift
@@ -32,10 +32,6 @@ class RelationshipController: UIResponder {
     var currentUser: User?
     var responderChainable: ResponderChainableController?
 
-    override var canBecomeFirstResponder: Bool {
-        return true
-    }
-
     override var next: UIResponder? {
         return responderChainable?.next()
     }

--- a/Sources/Controllers/Relationship/RelationshipController.swift
+++ b/Sources/Controllers/Relationship/RelationshipController.swift
@@ -47,7 +47,7 @@ extension RelationshipController: RelationshipResponder {
         relationshipPriority: RelationshipPriorityWrapper,
         complete: @escaping RelationshipChangeCompletion)
     {
-		guard currentUser != nil else {
+        guard currentUser != nil else {
             postNotification(LoggedOutNotifications.userActionAttempted, value: ())
             complete(RelationshipRequestStatusWrapper(status: .success), .none, true)
             return

--- a/Sources/Controllers/Relationship/RelationshipController.swift
+++ b/Sources/Controllers/Relationship/RelationshipController.swift
@@ -67,7 +67,7 @@ extension RelationshipController: RelationshipResponder {
     {
         let vc = BlockUserModalViewController(config: BlockUserModalConfig(userId: userId, userAtName: userAtName, relationshipPriority: relationshipPriority.priority, changeClosure: changeClosure))
         vc.currentUser = currentUser
-        responderChainable?.controller.present(vc, animated: true, completion: nil)
+        responderChainable?.controller?.present(vc, animated: true, completion: nil)
     }
 
     func updateRelationship(

--- a/Sources/Controllers/Relationship/RelationshipController.swift
+++ b/Sources/Controllers/Relationship/RelationshipController.swift
@@ -49,7 +49,7 @@ extension RelationshipController: RelationshipResponder {
     {
 		guard currentUser != nil else {
             postNotification(LoggedOutNotifications.userActionAttempted, value: ())
-            complete(.success, .none, true)
+            complete(RelationshipRequestStatusWrapper(status: .success), .none, true)
             return
         }
         Tracker.shared.relationshipButtonTapped(relationshipPriority.priority, userId: userId)

--- a/Sources/Controllers/Relationship/RelationshipController.swift
+++ b/Sources/Controllers/Relationship/RelationshipController.swift
@@ -41,7 +41,12 @@ class RelationshipController: UIResponder {
 // MARK: RelationshipController: RelationshipResponder
 extension RelationshipController: RelationshipResponder {
 
-    func relationshipTapped(_ userId: String, prev prevRelationshipPriority: RelationshipPriorityWrapper, relationshipPriority: RelationshipPriorityWrapper, complete: @escaping RelationshipChangeCompletion) {
+    func relationshipTapped(
+        _ userId: String,
+        prev prevRelationshipPriority: RelationshipPriorityWrapper,
+        relationshipPriority: RelationshipPriorityWrapper,
+        complete: @escaping RelationshipChangeCompletion)
+    {
         Tracker.shared.relationshipButtonTapped(relationshipPriority.priority, userId: userId)
         let responder = self.target(forAction: #selector(RelationshipControllerResponder.shouldSubmitRelationship(_:relationshipPriority:)), withSender: self) as? RelationshipControllerResponder
         if let shouldSubmit = responder?.shouldSubmitRelationship(userId, relationshipPriority: relationshipPriority), !shouldSubmit {

--- a/Sources/Controllers/Stream/Cells/StreamHeaderCell.swift
+++ b/Sources/Controllers/Stream/Cells/StreamHeaderCell.swift
@@ -62,12 +62,6 @@ class StreamHeaderCell: UICollectionViewCell {
         }
     }
 
-    weak var relationshipDelegate: RelationshipDelegate? {
-        get { return relationshipControl.relationshipDelegate }
-        set { relationshipControl.relationshipDelegate = newValue }
-    }
-
-
     var avatarHeight: CGFloat = 60.0 {
         didSet { setNeedsDisplay() }
     }

--- a/Sources/Controllers/Stream/Cells/UserAvatarsCell.swift
+++ b/Sources/Controllers/Stream/Cells/UserAvatarsCell.swift
@@ -24,7 +24,7 @@ class UserAvatarsCell: UICollectionViewCell {
             }
         }
     }
-    
+
     override func awakeFromNib() {
         super.awakeFromNib()
         style()

--- a/Sources/Controllers/Stream/PostbarController.swift
+++ b/Sources/Controllers/Stream/PostbarController.swift
@@ -102,7 +102,7 @@ class PostbarController: UIResponder, PostbarResponder {
             streamService.loadMoreCommentsForPost(
                 post.id,
                 streamKind: dataSource.streamKind,
-                success: {[weak self] (comments, responseConfig) in
+                success: { [weak self] (comments, responseConfig) in
                     guard let `self` = self else { return }
                     if let updatedIndexPath = self.dataSource.indexPathForItem(item) {
                         item.state = .expanded
@@ -413,7 +413,7 @@ class PostbarController: UIResponder, PostbarResponder {
 
         self.dataSource.insertUnsizedCellItems(items,
             withWidth: self.collectionView.frame.width,
-            startingIndexPath: commentsStartingIndexPath) {[weak self] (indexPaths) in
+            startingIndexPath: commentsStartingIndexPath) { [weak self] (indexPaths) in
                 guard let `self` = self else { return }
                 self.collectionView.reloadData() // insertItemsAtIndexPaths(indexPaths)
                 cell.commentsControl.isEnabled = true

--- a/Sources/Controllers/Stream/PostbarController.swift
+++ b/Sources/Controllers/Stream/PostbarController.swift
@@ -155,8 +155,8 @@ class PostbarController: UIResponder, PostbarResponder {
         alertController.addAction(yesAction)
         alertController.addAction(noAction)
 
-        logPresentingAlert(responderChainable?.controller.readableClassName() ?? "PostbarController")
-        responderChainable?.controller.present(alertController, animated: true, completion: .none)
+        logPresentingAlert(responderChainable?.controller?.readableClassName() ?? "PostbarController")
+        responderChainable?.controller?.present(alertController, animated: true, completion: .none)
     }
 
     func editCommentButtonTapped(_ indexPath: IndexPath) {
@@ -241,8 +241,8 @@ class PostbarController: UIResponder, PostbarResponder {
         alertController.addAction(yesAction)
         alertController.addAction(noAction)
 
-        logPresentingAlert(responderChainable?.controller.readableClassName() ?? "PostbarController")
-        responderChainable?.controller.present(alertController, animated: true, completion: .none)
+        logPresentingAlert(responderChainable?.controller?.readableClassName() ?? "PostbarController")
+        responderChainable?.controller?.present(alertController, animated: true, completion: .none)
     }
 
     fileprivate func createRepost(_ post: Post, alertController: AlertViewController)
@@ -300,14 +300,14 @@ class PostbarController: UIResponder, PostbarResponder {
         let activityVC = UIActivityViewController(activityItems: [shareURL], applicationActivities: [SafariActivity()])
         if UI_USER_INTERFACE_IDIOM() == .phone {
             activityVC.modalPresentationStyle = .fullScreen
-            logPresentingAlert(responderChainable?.controller.readableClassName() ?? "PostbarController")
-            responderChainable?.controller.present(activityVC, animated: true) { }
+            logPresentingAlert(responderChainable?.controller?.readableClassName() ?? "PostbarController")
+            responderChainable?.controller?.present(activityVC, animated: true) { }
         }
         else {
             activityVC.modalPresentationStyle = .popover
             activityVC.popoverPresentationController?.sourceView = sourceView
-            logPresentingAlert(responderChainable?.controller.readableClassName() ?? "PostbarController")
-            responderChainable?.controller.present(activityVC, animated: true) { }
+            logPresentingAlert(responderChainable?.controller?.readableClassName() ?? "PostbarController")
+            responderChainable?.controller?.present(activityVC, animated: true) { }
         }
     }
 

--- a/Sources/Controllers/Stream/PostbarController.swift
+++ b/Sources/Controllers/Stream/PostbarController.swift
@@ -419,7 +419,7 @@ class PostbarController: UIResponder, PostbarResponder {
                 cell.commentsControl.isEnabled = true
 
                 if let controller = self.responderChainable?.controller,
-                    indexPaths.count == 1 && jsonables.count == 0
+                    indexPaths.count == 1, jsonables.count == 0
                 {
                     let responder = self.target(forAction: #selector(CreatePostResponder.createComment(_:text:fromController:)), withSender: self) as? CreatePostResponder
                     responder?.createComment(post.id, text: nil, fromController: controller)

--- a/Sources/Controllers/Stream/PostbarController.swift
+++ b/Sources/Controllers/Stream/PostbarController.swift
@@ -29,10 +29,10 @@ class PostbarController: UIResponder, PostbarResponder {
     }
 
     override var next: UIResponder? {
-        return presentingController?.nextAfterPostbar
+        return responderChainable?.next()
     }
 
-    weak var presentingController: StreamViewController?
+    var responderChainable: ResponderChainableController?
     var collectionView: UICollectionView
     let dataSource: StreamDataSource
     var currentUser: User?
@@ -40,10 +40,9 @@ class PostbarController: UIResponder, PostbarResponder {
     // on the post detail screen, the comments don't show/hide
     var toggleableComments: Bool = true
 
-    init(collectionView: UICollectionView, dataSource: StreamDataSource, presentingController: StreamViewController) {
+    init(collectionView: UICollectionView, dataSource: StreamDataSource) {
         self.collectionView = collectionView
         self.dataSource = dataSource
-        self.presentingController = presentingController
     }
 
     // MARK:
@@ -52,9 +51,9 @@ class PostbarController: UIResponder, PostbarResponder {
         guard let post = postForIndexPath(indexPath) else { return }
 
         Tracker.shared.viewsButtonTapped(post: post)
-        // This is a bit dirty, we should not call a method on a compositionally held
-        // controller's postTappedDelegate. Need to chat about this with the crew.
-        presentingController?.postTappedDelegate?.postTapped(post)
+
+        let responder = target(forAction: #selector(PostTappedResponder.postTapped(_:)), withSender: self) as? PostTappedResponder
+        responder?.postTapped(post)
     }
 
     func commentsButtonTapped(_ cell: StreamFooterCell, imageLabelControl: ImageLabelControl) {
@@ -75,55 +74,58 @@ class PostbarController: UIResponder, PostbarResponder {
             return
         }
 
-        if let indexPath = collectionView.indexPath(for: cell),
+        guard
+            let indexPath = collectionView.indexPath(for: cell),
             let item = dataSource.visibleStreamCellItem(at: indexPath),
             let post = item.jsonable as? Post
-        {
-            imageLabelControl.isSelected = cell.commentsOpened
-            cell.commentsControl.isEnabled = false
-
-            if !cell.commentsOpened {
-                _ = self.dataSource.removeCommentsFor(post: post)
-                self.collectionView.reloadData()
-                item.state = .collapsed
-                imageLabelControl.isEnabled = true
-                imageLabelControl.finishAnimation()
-                imageLabelControl.isHighlighted = false
-            }
-            else {
-                item.state = .loading
-                imageLabelControl.isHighlighted = true
-                imageLabelControl.animate()
-                let streamService = StreamService()
-                streamService.loadMoreCommentsForPost(
-                    post.id,
-                    streamKind: dataSource.streamKind,
-                    success: { (comments, responseConfig) in
-                        if let updatedIndexPath = self.dataSource.indexPathForItem(item) {
-                            item.state = .expanded
-                            imageLabelControl.finishAnimation()
-                            let nextIndexPath = IndexPath(item: updatedIndexPath.row + 1, section: updatedIndexPath.section)
-                            self.commentLoadSuccess(post, comments: comments, indexPath: nextIndexPath, cell: cell)
-                        }
-                    },
-                    failure: { _ in
-                        item.state = .collapsed
-                        imageLabelControl.finishAnimation()
-                        cell.cancelCommentLoading()
-                        print("comment load failure")
-                    },
-                    noContent: {
-                        item.state = .expanded
-                        imageLabelControl.finishAnimation()
-                        if let updatedIndexPath = self.dataSource.indexPathForItem(item) {
-                            let nextIndexPath = IndexPath(item: updatedIndexPath.row + 1, section: updatedIndexPath.section)
-                            self.commentLoadSuccess(post, comments: [], indexPath: nextIndexPath, cell: cell)
-                        }
-                    })
-            }
-        }
         else {
             cell.cancelCommentLoading()
+            return
+        }
+
+        imageLabelControl.isSelected = cell.commentsOpened
+        cell.commentsControl.isEnabled = false
+
+        if !cell.commentsOpened {
+            self.dataSource.removeCommentsFor(post: post)
+            self.collectionView.reloadData()
+            item.state = .collapsed
+            imageLabelControl.isEnabled = true
+            imageLabelControl.finishAnimation()
+            imageLabelControl.isHighlighted = false
+        }
+        else {
+            item.state = .loading
+            imageLabelControl.isHighlighted = true
+            imageLabelControl.animate()
+            let streamService = StreamService()
+            streamService.loadMoreCommentsForPost(
+                post.id,
+                streamKind: dataSource.streamKind,
+                success: {[weak self] (comments, responseConfig) in
+                    guard let `self` = self else { return }
+                    if let updatedIndexPath = self.dataSource.indexPathForItem(item) {
+                        item.state = .expanded
+                        imageLabelControl.finishAnimation()
+                        let nextIndexPath = IndexPath(item: updatedIndexPath.row + 1, section: updatedIndexPath.section)
+                        self.commentLoadSuccess(post, comments: comments, indexPath: nextIndexPath, cell: cell)
+                    }
+                },
+                failure: { _ in
+                    item.state = .collapsed
+                    imageLabelControl.finishAnimation()
+                    cell.cancelCommentLoading()
+                    print("comment load failure")
+                },
+                noContent: { [weak self] in
+                    guard let `self` = self else { return }
+                    item.state = .expanded
+                    imageLabelControl.finishAnimation()
+                    if let updatedIndexPath = self.dataSource.indexPathForItem(item) {
+                        let nextIndexPath = IndexPath(item: updatedIndexPath.row + 1, section: updatedIndexPath.section)
+                        self.commentLoadSuccess(post, comments: [], indexPath: nextIndexPath, cell: cell)
+                    }
+                })
         }
     }
 
@@ -153,14 +155,14 @@ class PostbarController: UIResponder, PostbarResponder {
         alertController.addAction(yesAction)
         alertController.addAction(noAction)
 
-        logPresentingAlert(presentingController?.readableClassName() ?? "PostbarController")
-        presentingController?.present(alertController, animated: true, completion: .none)
+        logPresentingAlert(responderChainable?.controller.readableClassName() ?? "PostbarController")
+        responderChainable?.controller.present(alertController, animated: true, completion: .none)
     }
 
     func editCommentButtonTapped(_ indexPath: IndexPath) {
         guard
-            let comment = self.commentForIndexPath(indexPath),
-            let presentingController = presentingController
+            let comment = commentForIndexPath(indexPath),
+            let presentingController = responderChainable?.controller
         else { return }
 
         let responder = target(forAction: #selector(CreatePostResponder.editComment(_:fromController:)), withSender: self) as? CreatePostResponder
@@ -169,7 +171,6 @@ class PostbarController: UIResponder, PostbarResponder {
 
     func lovesButtonTapped(_ cell: StreamFooterCell?, indexPath: IndexPath) {
         guard let post = self.postForIndexPath(indexPath) else { return }
-
         cell?.lovesControl.isUserInteractionEnabled = false
 
         if post.loved { unlovePost(post, cell: cell) }
@@ -240,8 +241,8 @@ class PostbarController: UIResponder, PostbarResponder {
         alertController.addAction(yesAction)
         alertController.addAction(noAction)
 
-        logPresentingAlert(presentingController?.readableClassName() ?? "PostbarController")
-        presentingController?.present(alertController, animated: true, completion: .none)
+        logPresentingAlert(responderChainable?.controller.readableClassName() ?? "PostbarController")
+        responderChainable?.controller.present(alertController, animated: true, completion: .none)
     }
 
     fileprivate func createRepost(_ post: Post, alertController: AlertViewController)
@@ -299,21 +300,21 @@ class PostbarController: UIResponder, PostbarResponder {
         let activityVC = UIActivityViewController(activityItems: [shareURL], applicationActivities: [SafariActivity()])
         if UI_USER_INTERFACE_IDIOM() == .phone {
             activityVC.modalPresentationStyle = .fullScreen
-            logPresentingAlert(presentingController?.readableClassName() ?? "PostbarController")
-            presentingController?.present(activityVC, animated: true) { }
+            logPresentingAlert(responderChainable?.controller.readableClassName() ?? "PostbarController")
+            responderChainable?.controller.present(activityVC, animated: true) { }
         }
         else {
             activityVC.modalPresentationStyle = .popover
             activityVC.popoverPresentationController?.sourceView = sourceView
-            logPresentingAlert(presentingController?.readableClassName() ?? "PostbarController")
-            presentingController?.present(activityVC, animated: true) { }
+            logPresentingAlert(responderChainable?.controller.readableClassName() ?? "PostbarController")
+            responderChainable?.controller.present(activityVC, animated: true) { }
         }
     }
 
     func flagCommentButtonTapped(_ indexPath: IndexPath) {
         guard
             let comment = commentForIndexPath(indexPath),
-            let presentingController = presentingController
+            let presentingController = responderChainable?.controller
         else { return }
 
         let flagger = ContentFlagger(
@@ -329,7 +330,7 @@ class PostbarController: UIResponder, PostbarResponder {
     func replyToCommentButtonTapped(_ indexPath: IndexPath) {
         guard
             let comment = commentForIndexPath(indexPath),
-            let presentingController = presentingController,
+            let presentingController = responderChainable?.controller,
             let atName = comment.author?.atName
         else { return }
 
@@ -343,19 +344,22 @@ class PostbarController: UIResponder, PostbarResponder {
     func replyToAllButtonTapped(_ indexPath: IndexPath) {
         guard
             let comment = commentForIndexPath(indexPath),
-            let presentingController = presentingController
+            let presentingController = responderChainable?.controller
         else { return }
 
         let postId = comment.loadedFromPostId
-        PostService().loadReplyAll(postId, success: {[weak self] usernames in
+        PostService().loadReplyAll(postId, success: { [weak self] usernames in
             guard let `self` = self else { return }
             let usernamesText = usernames.reduce("") { memo, username in
                 return memo + "@\(username) "
             }
             let responder = self.target(forAction: #selector(CreatePostResponder.createComment(_:text:fromController:)), withSender: self) as? CreatePostResponder
             responder?.createComment(postId, text: usernamesText, fromController: presentingController)
-        }, failure: {
-            presentingController.createCommentTapped(postId)
+        }, failure: { [weak self] in
+            guard let `self` = self else { return }
+            guard let controller = self.responderChainable?.controller else { return }
+            let responder = self.target(forAction: #selector(CreatePostResponder.createComment(_:text:fromController:)), withSender: self) as? CreatePostResponder
+            responder?.createComment(postId, text: nil, fromController: controller)
         })
     }
 
@@ -409,12 +413,16 @@ class PostbarController: UIResponder, PostbarResponder {
 
         self.dataSource.insertUnsizedCellItems(items,
             withWidth: self.collectionView.frame.width,
-            startingIndexPath: commentsStartingIndexPath) { (indexPaths) in
+            startingIndexPath: commentsStartingIndexPath) {[weak self] (indexPaths) in
+                guard let `self` = self else { return }
                 self.collectionView.reloadData() // insertItemsAtIndexPaths(indexPaths)
                 cell.commentsControl.isEnabled = true
 
-                if indexPaths.count == 1 && jsonables.count == 0 {
-                    self.presentingController?.createCommentTapped(post.id)
+                if let controller = self.responderChainable?.controller,
+                    indexPaths.count == 1 && jsonables.count == 0
+                {
+                    let responder = self.target(forAction: #selector(CreatePostResponder.createComment(_:text:fromController:)), withSender: self) as? CreatePostResponder
+                    responder?.createComment(post.id, text: nil, fromController: controller)
                 }
             }
     }

--- a/Sources/Controllers/Stream/ResponderChainableController.swift
+++ b/Sources/Controllers/Stream/ResponderChainableController.swift
@@ -1,0 +1,8 @@
+////
+///  ResponderChainableController.swift
+//
+
+struct ResponderChainableController {
+    weak var controller: UIViewController?
+    var next: () -> UIResponder?
+}

--- a/Sources/Controllers/Stream/StreamContainerViewController.swift
+++ b/Sources/Controllers/Stream/StreamContainerViewController.swift
@@ -179,7 +179,6 @@ class StreamContainerViewController: StreamableViewController {
             let vc = StreamViewController.instantiateFromStoryboard()
             vc.currentUser = currentUser
             vc.streamKind = kind
-            vc.postTappedDelegate = self
             vc.userTappedDelegate = self
             vc.streamViewDelegate = self
             vc.collectionView.scrollsToTop = false

--- a/Sources/Controllers/Stream/StreamDataSource.swift
+++ b/Sources/Controllers/Stream/StreamDataSource.swift
@@ -39,7 +39,6 @@ class StreamDataSource: NSObject, UICollectionViewDataSource {
     let imageSizeCalculator: StreamImageCellSizeCalculator
 
     weak var webLinkDelegate: WebLinkDelegate?
-    weak var relationshipDelegate: RelationshipDelegate?
     weak var searchStreamDelegate: SearchStreamDelegate?
     var inviteCache = InviteCache()
 
@@ -239,6 +238,7 @@ class StreamDataSource: NSObject, UICollectionViewDataSource {
         return nil
     }
 
+    @discardableResult
     func removeCommentsFor(post: Post) -> [IndexPath] {
         let indexPaths = self.commentIndexPathsForPost(post)
         temporarilyUnfilter() {
@@ -329,12 +329,9 @@ class StreamDataSource: NSObject, UICollectionViewDataSource {
         case .categoryPromotionalHeader,
              .pagePromotionalHeader:
             (cell as! CategoryHeaderCell).webLinkDelegate = webLinkDelegate
-        case .header, .commentHeader:
-            (cell as! StreamHeaderCell).relationshipDelegate = relationshipDelegate
         case .inviteFriends, .onboardingInviteFriends:
             (cell as! StreamInviteFriendsCell).inviteCache = inviteCache
         case .notification:
-            (cell as! NotificationCell).relationshipControl.relationshipDelegate = relationshipDelegate
             (cell as! NotificationCell).webLinkDelegate = webLinkDelegate
         case .profileHeader:
             (cell as! ProfileHeaderCell).webLinkDelegate = webLinkDelegate
@@ -342,8 +339,6 @@ class StreamDataSource: NSObject, UICollectionViewDataSource {
             (cell as! SearchStreamCell).delegate = searchStreamDelegate
         case .text:
             (cell as! StreamTextCell).webLinkDelegate = webLinkDelegate
-        case .userListItem:
-            (cell as! UserListItemCell).relationshipControl.relationshipDelegate = relationshipDelegate
         default:
             break
         }

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -615,6 +615,10 @@ final class StreamViewController: BaseElloViewController {
     }
 
     var nextAfterPostbar: UIResponder? {
+        return relationshipController
+    }
+
+    var nextAfterRelationshipController: UIResponder? {
         return super.next
     }
 

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -82,6 +82,7 @@ protocol AnnouncementResponder: class {
     func markAnnouncementAsRead(announcement: Announcement)
 }
 
+
 // MARK: StreamNotification
 struct StreamNotification {
     static let AnimateCellHeightNotification = TypedNotification<StreamImageCell>(name: "AnimateCellHeightNotification")
@@ -140,7 +141,6 @@ final class StreamViewController: BaseElloViewController {
 
     var dataSource: StreamDataSource!
     var postbarController: PostbarController?
-    var relationshipController: RelationshipController?
     var responseConfig: ResponseConfig?
     var pagingEnabled = false
     fileprivate var scrollToPaginateGuard = false
@@ -182,7 +182,6 @@ final class StreamViewController: BaseElloViewController {
     var settingChangedNotification: NotificationObserver?
     var currentUserChangedNotification: NotificationObserver?
 
-    weak var postTappedDelegate: PostTappedDelegate?
     weak var userTappedDelegate: UserTappedDelegate?
     weak var streamViewDelegate: StreamViewDelegate?
     var searchStreamDelegate: SearchStreamDelegate? {
@@ -236,7 +235,6 @@ final class StreamViewController: BaseElloViewController {
 
     override func didSetCurrentUser() {
         dataSource.currentUser = currentUser
-        relationshipController?.currentUser = currentUser
         postbarController?.currentUser = currentUser
         super.didSetCurrentUser()
     }
@@ -614,26 +612,26 @@ final class StreamViewController: BaseElloViewController {
         return postbarController
     }
 
-    var nextAfterPostbar: UIResponder? {
-        return relationshipController
-    }
-
-    var nextAfterRelationshipController: UIResponder? {
-        return super.next
-    }
-
     fileprivate func setupCollectionView() {
-        let postbarController = PostbarController(collectionView: collectionView, dataSource: dataSource, presentingController: self)
+        let postbarController = PostbarController(collectionView: collectionView, dataSource: dataSource)
         postbarController.currentUser = currentUser
+
+        // next is a closure due to the need
+        // to lazily evaluate it at runtime. `super.next` is not available
+        // at assignment but is present when the responder is used later on
+        let chainableController = ResponderChainableController(
+            controller: self,
+            next: { [weak self] in
+                return self?.superNext
+            }
+        )
+
+        postbarController.responderChainable = chainableController
         self.postbarController = postbarController
 
-        let relationshipController = RelationshipController(presentingController: self)
-        relationshipController.currentUser = self.currentUser
-        self.relationshipController = relationshipController
 
         // set delegates
         dataSource.webLinkDelegate = self
-        dataSource.relationshipDelegate = relationshipController
 
         collectionView.dataSource = dataSource
         collectionView.delegate = self
@@ -689,7 +687,7 @@ final class StreamViewController: BaseElloViewController {
 
 }
 
-// MARK: DELEGATE EXTENSIONS
+// MARK: DELEGATE & RESPONDER EXTENSIONS
 
 
 // MARK: StreamViewController: GridListToggleDelegate
@@ -875,7 +873,8 @@ extension StreamViewController: StreamImageCellResponder {
 
         if streamKind.isGridView || cell.isGif {
             if let post = post {
-                postTappedDelegate?.postTapped(post)
+                let responder = target(forAction: #selector(PostTappedResponder.postTapped(_:)), withSender: self) as? PostTappedResponder
+                responder?.postTapped(post)
             }
         }
         else if let imageViewer = imageViewer {
@@ -885,15 +884,6 @@ extension StreamViewController: StreamImageCellResponder {
                 Tracker.shared.viewedImage(asset, post: post)
             }
         }
-    }
-}
-
-// MARK: StreamViewController: Commenting
-extension StreamViewController {
-
-    func createCommentTapped(_ postId: String) {
-        let responder = target(forAction: #selector(CreatePostResponder.createComment(_:text:fromController:)), withSender: self) as? CreatePostResponder
-        responder?.createComment(postId, text: nil, fromController: self)
     }
 }
 
@@ -1035,16 +1025,19 @@ extension StreamViewController: UICollectionViewDelegate {
             if let lastComment = dataSource.commentForIndexPath(indexPath),
                 let post = lastComment.loadedFromPost
             {
-                postTappedDelegate?.postTapped(post, scrollToComment: lastComment)
+                let responder = target(forAction: #selector(PostTappedResponder.postTapped(_:scrollToComment:)), withSender: self) as? PostTappedResponder
+                responder?.postTapped(post, scrollToComment: lastComment)
             }
         }
         else if let post = dataSource.postForIndexPath(indexPath) {
-            postTappedDelegate?.postTapped(post)
+            let responder = target(forAction: #selector(PostTappedResponder.postTapped(_:)), withSender: self) as? PostTappedResponder
+            responder?.postTapped(post)
         }
         else if let notification = dataSource.jsonableForIndexPath(indexPath) as? Notification,
             let postId = notification.postId
         {
-            postTappedDelegate?.postTapped(postId: postId)
+            let responder = target(forAction: #selector(PostTappedResponder.postTapped(postId:)), withSender: self) as? PostTappedResponder
+            responder?.postTapped(postId: postId)
         }
         else if let notification = dataSource.jsonableForIndexPath(indexPath) as? Notification,
             let user = notification.subject as? User
@@ -1059,7 +1052,8 @@ extension StreamViewController: UICollectionViewDelegate {
             ElloWebViewHelper.handle(request: request, webLinkDelegate: self)
         }
         else if let comment = dataSource.commentForIndexPath(indexPath) {
-            createCommentTapped(comment.loadedFromPostId)
+            let responder = target(forAction: #selector(CreatePostResponder.createComment(_:text:fromController:)), withSender: self) as? CreatePostResponder
+            responder?.createComment(comment.loadedFromPostId, text: nil, fromController: self)
         }
         else if let item = dataSource.visibleStreamCellItem(at: indexPath),
             let category = dataSource.jsonableForIndexPath(indexPath) as? Category

--- a/Sources/Controllers/Stream/StreamableViewController.swift
+++ b/Sources/Controllers/Stream/StreamableViewController.swift
@@ -28,11 +28,6 @@ protocol InviteResponder: class {
     func sendInvite(person: LocalPerson, isOnboarding: Bool, completion: @escaping ElloEmptyCompletion)
 }
 
-struct ResponderChainableController {
-    let controller: UIViewController
-    var next: () -> UIResponder?
-}
-
 class StreamableViewController: BaseElloViewController {
     @IBOutlet weak var viewContainer: UIView!
     fileprivate var showing = false

--- a/Sources/Controllers/Stream/StreamableViewController.swift
+++ b/Sources/Controllers/Stream/StreamableViewController.swift
@@ -49,8 +49,6 @@ class StreamableViewController: BaseElloViewController {
 
     var scrollLogic: ElloScrollLogic!
 
-
-
     func viewForStream() -> UIView {
         return viewContainer
     }

--- a/Sources/Controllers/Stream/StreamableViewController.swift
+++ b/Sources/Controllers/Stream/StreamableViewController.swift
@@ -2,7 +2,8 @@
 ///  StreamableViewController.swift
 //
 
-protocol PostTappedDelegate: class {
+@objc
+protocol PostTappedResponder: class {
     func postTapped(_ post: Post)
     func postTapped(_ post: Post, scrollToComment: ElloComment?)
     func postTapped(postId: String)
@@ -27,7 +28,12 @@ protocol InviteResponder: class {
     func sendInvite(person: LocalPerson, isOnboarding: Bool, completion: @escaping ElloEmptyCompletion)
 }
 
-class StreamableViewController: BaseElloViewController, PostTappedDelegate {
+struct ResponderChainableController {
+    let controller: UIViewController
+    var next: () -> UIResponder?
+}
+
+class StreamableViewController: BaseElloViewController {
     @IBOutlet weak var viewContainer: UIView!
     fileprivate var showing = false
     let streamViewController = StreamViewController.instantiateFromStoryboard()
@@ -36,7 +42,6 @@ class StreamableViewController: BaseElloViewController, PostTappedDelegate {
         streamViewController.currentUser = currentUser
         streamViewController.streamViewDelegate = self
         streamViewController.userTappedDelegate = self
-        streamViewController.postTappedDelegate = self
 
         streamViewController.willMove(toParentViewController: self)
         let containerForStream = viewForStream()
@@ -48,6 +53,8 @@ class StreamableViewController: BaseElloViewController, PostTappedDelegate {
     }
 
     var scrollLogic: ElloScrollLogic!
+
+
 
     func viewForStream() -> UIView {
         return viewContainer
@@ -142,8 +149,10 @@ class StreamableViewController: BaseElloViewController, PostTappedDelegate {
             bottomBarController.setNavigationBarsVisible(false, animated: true)
         }
     }
+}
 
-// MARK: PostTappedDelegate
+// MARK: PostTappedResponder
+extension StreamableViewController: PostTappedResponder {
 
     func postTapped(_ post: Post) {
         self.postTapped(postId: post.id, scrollToComment: nil)
@@ -279,6 +288,7 @@ extension StreamableViewController: StreamViewDelegate {
 
 // MARK: InviteResponder
 extension StreamableViewController: InviteResponder {
+
     func onInviteFriends() {
         Tracker.shared.inviteFriendsTapped()
         AddressBookController.promptForAddressBookAccess(fromController: self, completion: { result in

--- a/Sources/model/RelationshipPriority.swift
+++ b/Sources/model/RelationshipPriority.swift
@@ -2,6 +2,12 @@
 ///  RelationshipPriority.swift
 //
 
+class RelationshipPriorityWrapper: NSObject {
+    let priority: RelationshipPriority
+    init(priority: RelationshipPriority) {
+        self.priority = priority
+    }
+}
 
 enum RelationshipPriority: String {
     case following = "friend"

--- a/Specs/Controllers/Profile/ProfileViewControllerSpec.swift
+++ b/Specs/Controllers/Profile/ProfileViewControllerSpec.swift
@@ -177,6 +177,7 @@ class ProfileViewControllerSpec: QuickSpec {
                 var user: User!
                 var subject: ProfileViewController!
 
+
                 beforeEach {
                     user = User.stub(["id": "42"])
                     subject = ProfileViewController(userParam: user.id)

--- a/Specs/Controllers/Relationship/BlockUserModalViewControllerSpec.swift
+++ b/Specs/Controllers/Relationship/BlockUserModalViewControllerSpec.swift
@@ -13,8 +13,17 @@ class BlockUserModalViewControllerSpec: QuickSpec {
         describe("BlockUserModalViewController") {
             let currentUser: User = stub([:])
             var subject: BlockUserModalViewController!
-            let relationshipController = RelationshipController(presentingController: UIViewController())
+            let controller = UIViewController()
+            let chainable = ResponderChainableController(
+                controller: controller,
+                next: {
+                    return controller.next
+                }
+            )
+
+            let relationshipController = RelationshipController()
             relationshipController.currentUser = currentUser
+            relationshipController.responderChainable = chainable
 
             describe("initialization") {
 

--- a/Specs/Controllers/Relationship/RelationshipControlSpec.swift
+++ b/Specs/Controllers/Relationship/RelationshipControlSpec.swift
@@ -8,19 +8,29 @@ import Nimble
 import Moya
 import Nimble_Snapshots
 
+class FakeResponder: UIWindow {
+    var relationshipController: RelationshipController?
+    override var next: UIResponder? {
+        return relationshipController
+    }
+}
 
 class RelationshipControlSpec: QuickSpec {
     override func spec() {
         describe("RelationshipControl") {
             var subject: RelationshipControl!
-            var presentingController: UIViewController!
+            var presentingController: StreamableViewController!
             var relationshipController: RelationshipController!
+            let viewContainer = UIView()
+
             beforeEach {
                 subject = RelationshipControl()
-                presentingController = UIViewController()
+                presentingController = StreamableViewController()
+                presentingController.viewContainer = viewContainer
+                presentingController.viewDidLoad()
+                presentingController.view.addSubview(subject) // <-- super ghetto
+                relationshipController = presentingController.relationshipController
                 showController(presentingController)
-                relationshipController = RelationshipController(presentingController: presentingController)
-                subject.relationshipDelegate = relationshipController
             }
 
             describe("snapshots") {
@@ -140,7 +150,7 @@ class RelationshipControlSpec: QuickSpec {
                         it("launches the block modal") {
                             subject.relationshipPriority = .mute
                             subject.followingButton.sendActions(for: .touchUpInside)
-                            let presentedVC = relationshipController.presentingController?.presentedViewController as? BlockUserModalViewController
+                            let presentedVC = relationshipController.responderChainable?.controller.presentedViewController as? BlockUserModalViewController
                             expect(presentedVC).notTo(beNil())
                         }
                     }

--- a/Specs/Controllers/Relationship/RelationshipControlSpec.swift
+++ b/Specs/Controllers/Relationship/RelationshipControlSpec.swift
@@ -149,7 +149,7 @@ class RelationshipControlSpec: QuickSpec {
                         it("launches the block modal") {
                             subject.relationshipPriority = .mute
                             subject.followingButton.sendActions(for: .touchUpInside)
-                            let presentedVC = relationshipController.responderChainable?.controller.presentedViewController as? BlockUserModalViewController
+                            let presentedVC = relationshipController.responderChainable?.controller?.presentedViewController as? BlockUserModalViewController
                             expect(presentedVC).notTo(beNil())
                         }
                     }

--- a/Specs/Controllers/Relationship/RelationshipControlSpec.swift
+++ b/Specs/Controllers/Relationship/RelationshipControlSpec.swift
@@ -27,7 +27,6 @@ class RelationshipControlSpec: QuickSpec {
                 subject = RelationshipControl()
                 presentingController = StreamableViewController()
                 presentingController.viewContainer = viewContainer
-                presentingController.viewDidLoad()
                 presentingController.view.addSubview(subject) // <-- super ghetto
                 relationshipController = presentingController.relationshipController
                 showController(presentingController)

--- a/Specs/Controllers/Relationship/RelationshipControllerSpec.swift
+++ b/Specs/Controllers/Relationship/RelationshipControllerSpec.swift
@@ -64,7 +64,7 @@ class RelationshipControllerSpec: QuickSpec {
                     subject.launchBlockModal("user-id", userAtName: "@666", relationshipPriority: RelationshipPriorityWrapper(priority: .following)) {
                         _ in
                     }
-                    let presentedVC = subject.responderChainable?.controller.presentedViewController as? BlockUserModalViewController
+                    let presentedVC = subject.responderChainable?.controller?.presentedViewController as? BlockUserModalViewController
                     expect(presentedVC).to(beAKindOf(BlockUserModalViewController.self))
                 }
 

--- a/Specs/Controllers/Stream/PostbarControllerSpec.swift
+++ b/Specs/Controllers/Stream/PostbarControllerSpec.swift
@@ -62,9 +62,13 @@ class PostbarControllerSpec: QuickSpec {
             controller.dataSource = dataSource
             controller.collectionView.dataSource = dataSource
 
-            subject = PostbarController(collectionView: controller.collectionView, dataSource: dataSource, presentingController: controller)
+            subject = PostbarController(collectionView: controller.collectionView, dataSource: dataSource)
             subject.currentUser = currentUser
             responder = ReplyAllCreatePostResponder()
+            subject.responderChainable = ResponderChainableController(
+                controller: controller,
+                next: { return responder }
+            )
             showController(controller, window: responder)
         }
 


### PR DESCRIPTION
This was the most intricate of the conversions. The interplay between `RelationshipController`, `RelationshipControl` and their delegate/responders required a lot of Swift value type wrapping and code refactoring. `RelationshiopController` is now held by `BaseElloViewController` due to `BlockModalViewController`'s need for it to be in the responder chain.

Future work may include renaming the `RelationshipPriority` and `RelationshipRequestStatus` wrappers for more clarity.