### PR TITLE
WebLinkDelegate -> WebLinkResponder

### DIFF
--- a/Sources/Controllers/Notifications/AnnouncementCell.swift
+++ b/Sources/Controllers/Notifications/AnnouncementCell.swift
@@ -138,12 +138,14 @@ class AnnouncementCell: UICollectionViewCell {
 }
 
 extension AnnouncementCell {
+
     override func prepareForReuse() {
         config = Config()
     }
 }
 
 extension AnnouncementCell {
+
     func markAsRead() {
         let responder = target(forAction: #selector(AnnouncementCellResponder.markAnnouncementAsRead(cell:)), withSender: self) as? AnnouncementCellResponder
         responder?.markAnnouncementAsRead(cell: self)

--- a/Sources/Controllers/Notifications/NotificationCell.swift
+++ b/Sources/Controllers/Notifications/NotificationCell.swift
@@ -54,7 +54,6 @@ class NotificationCell: UICollectionViewCell, UIWebViewDelegate {
 
     typealias WebContentReady = (_ webView: UIWebView) -> Void
 
-    weak var webLinkDelegate: WebLinkDelegate?
     var webContentReady: WebContentReady?
     var onHeightMismatch: OnHeightMismatch?
 
@@ -321,7 +320,7 @@ class NotificationCell: UICollectionViewCell, UIWebViewDelegate {
             return false
         }
         else {
-            return ElloWebViewHelper.handle(request: request, webLinkDelegate: webLinkDelegate)
+            return ElloWebViewHelper.handle(request: request, origin: self)
         }
     }
 

--- a/Sources/Controllers/Profile/ProfileHeaderCell.swift
+++ b/Sources/Controllers/Profile/ProfileHeaderCell.swift
@@ -39,14 +39,6 @@ class ProfileHeaderCell: UICollectionViewCell {
     var locationView: ProfileLocationView { get { return headerView.locationView } }
     var linksView: ProfileLinksView { get { return headerView.linksView } }
 
-    weak var webLinkDelegate: WebLinkDelegate? {
-        set {
-            bioView.webLinkDelegate = newValue
-            linksView.webLinkDelegate = newValue
-        }
-        get { return bioView.webLinkDelegate }
-    }
-
     var user: User?
     var currentUser: User?
 

--- a/Sources/Controllers/Profile/Views/ProfileBioView.swift
+++ b/Sources/Controllers/Profile/Views/ProfileBioView.swift
@@ -22,8 +22,6 @@ class ProfileBioView: ProfileBaseView {
         set { grayLine.isHidden = !newValue }
     }
 
-    weak var webLinkDelegate: WebLinkDelegate?
-
     var onHeightMismatch: OnHeightMismatch?
 }
 
@@ -62,7 +60,6 @@ extension ProfileBioView {
     func prepareForReuse() {
         self.bio = ""
         grayLine.isHidden = false
-        webLinkDelegate = nil
     }
 }
 
@@ -83,7 +80,7 @@ extension ProfileBioView: UIWebViewDelegate {
     }
 
     func webView(_ webView: UIWebView, shouldStartLoadWith request: URLRequest, navigationType: UIWebViewNavigationType) -> Bool {
-        return ElloWebViewHelper.handle(request: request, webLinkDelegate: webLinkDelegate)
+        return ElloWebViewHelper.handle(request: request, origin: self)
     }
 }
 

--- a/Sources/Controllers/Profile/Views/ProfileLinksView.swift
+++ b/Sources/Controllers/Profile/Views/ProfileLinksView.swift
@@ -23,8 +23,6 @@ class ProfileLinksView: ProfileBaseView {
         }
     }
 
-    weak var webLinkDelegate: WebLinkDelegate?
-
     fileprivate var linksBox = UIView()
     fileprivate var iconsBox = UIView()
     fileprivate var linkButtons: [UIButton] = []
@@ -64,9 +62,9 @@ extension ProfileLinksView {
 }
 
 extension ProfileLinksView {
+
     func prepareForReuse() {
         externalLinks = []
-        webLinkDelegate = nil
     }
 }
 
@@ -197,7 +195,7 @@ extension ProfileLinksView {
             else { return }
 
         let request = URLRequest(url: externalLink.url as URL)
-        ElloWebViewHelper.handle(request: request, webLinkDelegate: webLinkDelegate)
+        ElloWebViewHelper.handle(request: request, origin: self)
     }
 }
 

--- a/Sources/Controllers/Stream/Cells/CategoryHeaderCell.swift
+++ b/Sources/Controllers/Stream/Cells/CategoryHeaderCell.swift
@@ -49,8 +49,6 @@ class CategoryHeaderCell: UICollectionViewCell {
         static let failImageHeight: CGFloat = 160
     }
 
-    weak var webLinkDelegate: WebLinkDelegate?
-
     let imageView = FLAnimatedImageView()
     let imageOverlay = UIView()
     let titleLabel = UILabel()
@@ -168,7 +166,6 @@ class CategoryHeaderCell: UICollectionViewCell {
         super.prepareForReuse()
         let config = Config(style: .category)
         self.config = config
-        webLinkDelegate = nil
     }
 
     func postedByTapped() {
@@ -182,7 +179,7 @@ class CategoryHeaderCell: UICollectionViewCell {
         guard let url = callToActionURL else { return }
         Tracker.shared.categoryHeaderCallToAction(config.tracking)
         let request = URLRequest(url: url)
-        ElloWebViewHelper.handle(request: request, webLinkDelegate: webLinkDelegate)
+        ElloWebViewHelper.handle(request: request, origin: self)
     }
 }
 

--- a/Sources/Controllers/Stream/Cells/StreamTextCell.swift
+++ b/Sources/Controllers/Stream/Cells/StreamTextCell.swift
@@ -12,7 +12,6 @@ class StreamTextCell: StreamRegionableCell, UIWebViewDelegate, UIGestureRecogniz
 
     @IBOutlet weak var webView: UIWebView!
     @IBOutlet weak var leadingConstraint: NSLayoutConstraint!
-    weak var webLinkDelegate: WebLinkDelegate?
     var webContentReady: WebContentReady?
 
     override func awakeFromNib() {
@@ -70,7 +69,7 @@ class StreamTextCell: StreamRegionableCell, UIWebViewDelegate, UIGestureRecogniz
             return false
         }
         else {
-            return ElloWebViewHelper.handle(request: request, webLinkDelegate: webLinkDelegate)
+            return ElloWebViewHelper.handle(request: request, origin: self)
         }
     }
 

--- a/Sources/Controllers/Stream/StreamDataSource.swift
+++ b/Sources/Controllers/Stream/StreamDataSource.swift
@@ -38,7 +38,6 @@ class StreamDataSource: NSObject, UICollectionViewDataSource {
     let categoryHeaderSizeCalculator: CategoryHeaderCellSizeCalculator
     let imageSizeCalculator: StreamImageCellSizeCalculator
 
-    weak var webLinkDelegate: WebLinkDelegate?
     weak var searchStreamDelegate: SearchStreamDelegate?
     var inviteCache = InviteCache()
 
@@ -326,19 +325,10 @@ class StreamDataSource: NSObject, UICollectionViewDataSource {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: streamCellItem.type.name, for: indexPath)
 
         switch streamCellItem.type {
-        case .categoryPromotionalHeader,
-             .pagePromotionalHeader:
-            (cell as! CategoryHeaderCell).webLinkDelegate = webLinkDelegate
         case .inviteFriends, .onboardingInviteFriends:
             (cell as! StreamInviteFriendsCell).inviteCache = inviteCache
-        case .notification:
-            (cell as! NotificationCell).webLinkDelegate = webLinkDelegate
-        case .profileHeader:
-            (cell as! ProfileHeaderCell).webLinkDelegate = webLinkDelegate
         case .search:
             (cell as! SearchStreamCell).delegate = searchStreamDelegate
-        case .text:
-            (cell as! StreamTextCell).webLinkDelegate = webLinkDelegate
         default:
             break
         }

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -54,8 +54,9 @@ protocol UserResponder: class {
     func userTapped(user: User)
 }
 
-protocol WebLinkDelegate: class {
-    func webLinkTapped(path: String, type: ElloURI, data: String)
+@objc
+protocol WebLinkResponder: class {
+    func webLinkTapped(path: String, type: ElloURIWrapper, data: String)
 }
 
 @objc
@@ -629,10 +630,6 @@ final class StreamViewController: BaseElloViewController {
         postbarController.responderChainable = chainableController
         self.postbarController = postbarController
 
-
-        // set delegates
-        dataSource.webLinkDelegate = self
-
         collectionView.dataSource = dataSource
         collectionView.delegate = self
         automaticallyAdjustsScrollViewInsets = false
@@ -955,16 +952,16 @@ extension StreamViewController: UserResponder {
     }
 }
 
-// MARK: StreamViewController: WebLinkDelegate
-extension StreamViewController: WebLinkDelegate {
+// MARK: StreamViewController: WebLinkResponder
+extension StreamViewController: WebLinkResponder {
 
-    func webLinkTapped(path: String, type: ElloURI, data: String) {
+    func webLinkTapped(path: String, type: ElloURIWrapper, data: String) {
         guard
             let parentController = parent as? HasAppController,
             let appViewController = parentController.appViewController
         else { return }
 
-        appViewController.navigateToURI(path: path, type: type, data: data)
+        appViewController.navigateToURI(path: path, type: type.uri, data: data)
     }
 
     fileprivate func selectTab(_ tab: ElloTab) {
@@ -974,6 +971,7 @@ extension StreamViewController: WebLinkDelegate {
 
 // MARK: StreamViewController: AnnouncementCellResponder
 extension StreamViewController: AnnouncementCellResponder {
+
     func markAnnouncementAsRead(cell: UICollectionViewCell) {
         guard
             let indexPath = collectionView.indexPath(for: cell),
@@ -1049,7 +1047,7 @@ extension StreamViewController: UICollectionViewDelegate {
         {
             Tracker.shared.announcementOpened(announcement)
             let request = URLRequest(url: callToAction)
-            ElloWebViewHelper.handle(request: request, webLinkDelegate: self)
+            ElloWebViewHelper.handle(request: request, origin: self)
         }
         else if let comment = dataSource.commentForIndexPath(indexPath) {
             let responder = target(forAction: #selector(CreatePostResponder.createComment(_:text:fromController:)), withSender: self) as? CreatePostResponder

--- a/Sources/Controllers/WebBrowser/ElloWebBrowserViewController.swift
+++ b/Sources/Controllers/WebBrowser/ElloWebBrowserViewController.swift
@@ -86,7 +86,7 @@ extension ElloWebBrowserViewController: KINWebBrowserDelegate {
 
     func webBrowser(_ webBrowser: KINWebBrowserViewController!, shouldStartLoadWith request: URLRequest!) -> Bool {
         prevRequestURL = request.url
-        return ElloWebViewHelper.handle(request: request, webLinkDelegate: self, fromWebView: true)
+        return ElloWebViewHelper.handle(request: request, origin: self, fromWebView: true)
     }
 
     func willDismissWebBrowser(_ webView: KINWebBrowserViewController) {
@@ -95,10 +95,11 @@ extension ElloWebBrowserViewController: KINWebBrowserDelegate {
 
 }
 
-// MARK: ElloWebBrowserViewController : WebLinkDelegate
-extension ElloWebBrowserViewController : WebLinkDelegate {
-    func webLinkTapped(path: String, type: ElloURI, data: String) {
-        switch type {
+// MARK: ElloWebBrowserViewController : WebLinkResponder
+extension ElloWebBrowserViewController : WebLinkResponder {
+
+    func webLinkTapped(path: String, type: ElloURIWrapper, data: String) {
+        switch type.uri {
         case .confirm,
              .downloads,
              .email,

--- a/Sources/Networking/ElloURI.swift
+++ b/Sources/Networking/ElloURI.swift
@@ -5,6 +5,11 @@
 import Foundation
 import Keys
 
+class ElloURIWrapper: NSObject {
+    let uri: ElloURI
+    init(uri: ElloURI) { self.uri = uri }
+}
+
 enum ElloURI: String {
     // matching stream or page in app
     case discover = "discover(/featured|/recommended)?/?$"

--- a/Sources/Utilities/ElloWebViewHelper.swift
+++ b/Sources/Utilities/ElloWebViewHelper.swift
@@ -6,11 +6,11 @@ struct ElloWebViewHelper {
     static let jsCommandProtocol = "ello://"
 
     @discardableResult
-    static func handle(request: URLRequest, webLinkDelegate: WebLinkDelegate?, fromWebView: Bool = false) -> Bool {
+    static func handle(request: URLRequest, origin: UIResponder?, fromWebView: Bool = false) -> Bool {
         guard let requestUrlString = request.url?.absoluteString
         else { return true }
 
-        if requestUrlString.hasPrefix(jsCommandProtocol) {
+        if requestUrlString.hasPrefix(ElloWebViewHelper.jsCommandProtocol) {
             return false
         }
         else if requestUrlString.range(of: "(https?:\\/\\/|mailto:)", options: String.CompareOptions.regularExpression) != nil {
@@ -23,7 +23,8 @@ struct ElloWebViewHelper {
             }
             else {
                 if fromWebView && type.loadsInWebViewFromWebView { return true }
-                webLinkDelegate?.webLinkTapped(path: requestUrlString, type: type, data: data)
+                let responder = origin?.target(forAction: #selector(WebLinkResponder.webLinkTapped(path:type:data:)), withSender: origin) as? WebLinkResponder
+                responder?.webLinkTapped(path: requestUrlString, type: ElloURIWrapper(uri: type), data: data)
                 return false
             }
         }

--- a/Specs/Controllers/Stream/StreamViewControllerSpec.swift
+++ b/Specs/Controllers/Stream/StreamViewControllerSpec.swift
@@ -146,16 +146,10 @@ class StreamViewControllerSpec: QuickSpec {
 
         context("protocol conformance") {
 
-            var externalWebObserver: NotificationObserver?
+            context("WebLinkResponder") {
 
-            afterEach {
-                externalWebObserver?.removeObserver()
-            }
-
-            context("WebLinkDelegate") {
-
-                it("is a weblinkdelegate") {
-                    expect(controller as WebLinkDelegate).notTo(beNil())
+                it("is a WebLinkResponder") {
+                    expect(controller as WebLinkResponder).notTo(beNil())
                 }
 
                 describe("webLinkTapped(_:data:)") {
@@ -171,7 +165,7 @@ class StreamViewControllerSpec: QuickSpec {
                     }
 
                     it("opens external browser if type .external") {
-                        controller.webLinkTapped(path: "http://www.example.com", type: ElloURI.external, data: "http://www.example.com")
+                        controller.webLinkTapped(path: "http://www.example.com", type: ElloURIWrapper(uri: .external), data: "http://www.example.com")
                         let presented = hasAppVC.appViewController!.presentedViewController
                         expect(presented).notTo(beNil())
                         if let browser = (presented as! UINavigationController).viewControllers.first {

--- a/Specs/Utilities/ElloWebViewHelperSpec.swift
+++ b/Specs/Utilities/ElloWebViewHelperSpec.swift
@@ -16,37 +16,37 @@ class ElloWebViewHelperSpec: QuickSpec {
 
                 it("returns false with ello://notifications") {
                     let request = URLRequest(url: URL(string: "ello://notifications")!)
-                    expect(ElloWebViewHelper.handle(request: request, webLinkDelegate: nil)) == false
+                    expect(ElloWebViewHelper.handle(request: request, origin: nil)) == false
                 }
 
                 it("returns false with mailto:archer@isis.com") {
                     let request = URLRequest(url: URL(string: "mailto:archer@isis.com")!)
-                    expect(ElloWebViewHelper.handle(request: request, webLinkDelegate: nil)) == false
+                    expect(ElloWebViewHelper.handle(request: request, origin: nil)) == false
                 }
 
                 it("returns false with http://ello.co/downloads") {
                     let request = URLRequest(url: URL(string: "http://ello.co/downloads")!)
-                    expect(ElloWebViewHelper.handle(request: request, webLinkDelegate: nil)) == false
+                    expect(ElloWebViewHelper.handle(request: request, origin: nil)) == false
                 }
 
                 it("returns false with http://ello.co/wtf") {
                     let request = URLRequest(url: URL(string: "http://ello.co/wtf")!)
-                    expect(ElloWebViewHelper.handle(request: request, webLinkDelegate: nil)) == false
+                    expect(ElloWebViewHelper.handle(request: request, origin: nil)) == false
                 }
 
                 it("returns false with http://wallpapers.ello.co/anything") {
                     let request = URLRequest(url: URL(string: "http://wallpapers.ello.co/anything")!)
-                    expect(ElloWebViewHelper.handle(request: request, webLinkDelegate: nil)) == false
+                    expect(ElloWebViewHelper.handle(request: request, origin: nil)) == false
                 }
 
                 it("returns false with http://www.google.com") {
                     let request = URLRequest(url: URL(string: "http://www.google.com")!)
-                    expect(ElloWebViewHelper.handle(request: request, webLinkDelegate: nil)) == false
+                    expect(ElloWebViewHelper.handle(request: request, origin: nil)) == false
                 }
 
                 it("returns true with file://path_to_something") {
                     let request = URLRequest(url: URL(string: "file://path_to_something")!)
-                    expect(ElloWebViewHelper.handle(request: request, webLinkDelegate: nil)) == true
+                    expect(ElloWebViewHelper.handle(request: request, origin: nil)) == true
                 }
 
             }
@@ -55,22 +55,22 @@ class ElloWebViewHelperSpec: QuickSpec {
 
                 it("returns true with http://ello.co/downloads") {
                     let request = URLRequest(url: URL(string: "http://ello.co/downloads")!)
-                    expect(ElloWebViewHelper.handle(request: request, webLinkDelegate: nil, fromWebView: true)) == true
+                    expect(ElloWebViewHelper.handle(request: request, origin: nil, fromWebView: true)) == true
                 }
 
                 it("returns true with http://ello.co/wtf") {
                     let request = URLRequest(url: URL(string: "http://ello.co/wtf")!)
-                    expect(ElloWebViewHelper.handle(request: request, webLinkDelegate: nil, fromWebView: true)) == true
+                    expect(ElloWebViewHelper.handle(request: request, origin: nil, fromWebView: true)) == true
                 }
 
                 it("returns true with http://wallpapers.ello.co/anything") {
                     let request = URLRequest(url: URL(string: "http://wallpapers.ello.co/anything")!)
-                    expect(ElloWebViewHelper.handle(request: request, webLinkDelegate: nil, fromWebView: true)) == true
+                    expect(ElloWebViewHelper.handle(request: request, origin: nil, fromWebView: true)) == true
                 }
 
                 it("returns true with http://www.google.com") {
                     let request = URLRequest(url: URL(string: "http://www.google.com")!)
-                    expect(ElloWebViewHelper.handle(request: request, webLinkDelegate: nil, fromWebView: true)) == true
+                    expect(ElloWebViewHelper.handle(request: request, origin: nil, fromWebView: true)) == true
                 }
 
             }


### PR DESCRIPTION
Straightforward enough except for the new `origin` argument to `ElloWebViewHelper.handle()` which allows `ElloWebViewHelper` to remain a static struct rather than implementing `UIResponder`. 