### PR TITLE
DynamicSettingCellDelegate -> DynamicSettingCellResponder

### DIFF
--- a/Sources/Controllers/Settings/DynamicSettingCategoryViewController.swift
+++ b/Sources/Controllers/Settings/DynamicSettingCategoryViewController.swift
@@ -113,7 +113,8 @@ extension DynamicSettingCategoryViewController: DynamicSettingCellResponder {
 
                 self.tableView.reloadRows(at: changedPaths, with: .automatic)
             },
-            failure: { (_, _) in
+            failure: { [weak self] (_, _) in
+                guard let `self` = self else { return }
                 self.tableView.reloadData()
             })
     }

--- a/Sources/Controllers/Settings/DynamicSettingCategoryViewController.swift
+++ b/Sources/Controllers/Settings/DynamicSettingCategoryViewController.swift
@@ -5,7 +5,6 @@
 class DynamicSettingCategoryViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, ControllerThatMightHaveTheCurrentUser {
     var category: DynamicSettingCategory?
     var currentUser: User?
-    weak var delegate: DynamicSettingsDelegate?
     @IBOutlet weak var tableView: UITableView!
     weak var navBar: ElloNavigationBar!
 
@@ -100,8 +99,11 @@ extension DynamicSettingCategoryViewController: DynamicSettingCellResponder {
         }
 
         ProfileService().updateUserProfile(updatedValues,
-            success: { user in
-                self.delegate?.dynamicSettingsUserChanged(user)
+            success: { [weak self] user in
+                guard let `self` = self else { return }
+                let responder = self.target(forAction: #selector(DynamicSettingsResponder.dynamicSettingsUserChanged(_:)), withSender: self) as? DynamicSettingsResponder
+
+                responder?.dynamicSettingsUserChanged(user)
 
                 let changedPaths = visibility.filter { config in
                     return self.settingChanged(config, user: user)

--- a/Sources/Controllers/Settings/DynamicSettingCategoryViewController.swift
+++ b/Sources/Controllers/Settings/DynamicSettingCategoryViewController.swift
@@ -5,6 +5,7 @@
 class DynamicSettingCategoryViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, ControllerThatMightHaveTheCurrentUser {
     var category: DynamicSettingCategory?
     var currentUser: User?
+    weak var delegate: DynamicSettingsDelegate?
     @IBOutlet weak var tableView: UITableView!
     weak var navBar: ElloNavigationBar!
 
@@ -101,9 +102,7 @@ extension DynamicSettingCategoryViewController: DynamicSettingCellResponder {
         ProfileService().updateUserProfile(updatedValues,
             success: { [weak self] user in
                 guard let `self` = self else { return }
-                let responder = self.target(forAction: #selector(DynamicSettingsResponder.dynamicSettingsUserChanged(_:)), withSender: self) as? DynamicSettingsResponder
-
-                responder?.dynamicSettingsUserChanged(user)
+                self.delegate?.dynamicSettingsUserChanged(user)
 
                 let changedPaths = visibility.filter { config in
                     return self.settingChanged(config, user: user)

--- a/Sources/Controllers/Settings/DynamicSettingCategoryViewController.swift
+++ b/Sources/Controllers/Settings/DynamicSettingCategoryViewController.swift
@@ -48,7 +48,6 @@ class DynamicSettingCategoryViewController: UIViewController, UITableViewDataSou
         {
             DynamicSettingCellPresenter.configure(cell, setting: setting, currentUser: user)
             cell.setting = setting
-            cell.delegate = self
         }
         return cell
     }
@@ -71,7 +70,7 @@ class DynamicSettingCategoryViewController: UIViewController, UITableViewDataSou
     }
 }
 
-extension DynamicSettingCategoryViewController: DynamicSettingCellDelegate {
+extension DynamicSettingCategoryViewController: DynamicSettingCellResponder {
 
     typealias SettingConfig = (setting: DynamicSetting, indexPath: IndexPath, value: Bool, isVisible: Bool)
 

--- a/Sources/Controllers/Settings/DynamicSettingCell.swift
+++ b/Sources/Controllers/Settings/DynamicSettingCell.swift
@@ -2,28 +2,31 @@
 ///  DynamicSettingCell.swift
 //
 
-protocol DynamicSettingCellDelegate: class {
+@objc
+protocol DynamicSettingCellResponder: class {
     func toggleSetting(_ setting: DynamicSetting, value: Bool)
     func deleteAccount()
 }
 
 class DynamicSettingCell: UITableViewCell {
+
     @IBOutlet weak var titleLabel: StyledLabel!
     weak var descriptionLabel: StyledLabel!
     @IBOutlet weak var toggleButton: ElloToggleButton!
     @IBOutlet weak var deleteButton: ElloToggleButton!
 
-    weak var delegate: DynamicSettingCellDelegate?
     var setting: DynamicSetting?
 
     @IBAction func toggleButtonTapped() {
-        if let setting = setting {
-            delegate?.toggleSetting(setting, value: !toggleButton.value)
-            toggleButton.value = !toggleButton.value
-        }
+        guard let setting = setting else { return }
+
+        let responder = target(forAction: #selector(DynamicSettingCellResponder.toggleSetting(_:value:)), withSender: self) as? DynamicSettingCellResponder
+        responder?.toggleSetting(setting, value: !toggleButton.value)
+        toggleButton.value = !toggleButton.value
     }
 
     @IBAction func deleteButtonTapped() {
-        delegate?.deleteAccount()
+        let responder = target(forAction: #selector(DynamicSettingCellResponder.toggleSetting(_:value:)), withSender: self) as? DynamicSettingCellResponder
+        responder?.deleteAccount()
     }
 }

--- a/Sources/Controllers/Settings/DynamicSettingsViewController.swift
+++ b/Sources/Controllers/Settings/DynamicSettingsViewController.swift
@@ -4,8 +4,7 @@
 
 private let DynamicSettingsCellHeight: CGFloat = 50
 
-@objc
-protocol DynamicSettingsResponder: class {
+protocol DynamicSettingsDelegate: class {
     func dynamicSettingsUserChanged(_ user: User)
 }
 
@@ -37,6 +36,7 @@ class DynamicSettingsViewController: UITableViewController {
 
     var dynamicCategories: [DynamicSettingCategory] = []
     var currentUser: User?
+    weak var delegate: DynamicSettingsDelegate?
     var hideLoadingHud: BasicBlock = ElloHUD.hideLoadingHud
 
     var height: CGFloat {
@@ -175,6 +175,7 @@ class DynamicSettingsViewController: UITableViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "DynamicSettingCategorySegue" {
             let controller = segue.destination as! DynamicSettingCategoryViewController
+            controller.delegate = delegate
             let selectedIndexPath = tableView.indexPathForSelectedRow
 
             switch DynamicSettingsSection(rawValue: selectedIndexPath?.section ?? 0) ?? .unknown {

--- a/Sources/Controllers/Settings/DynamicSettingsViewController.swift
+++ b/Sources/Controllers/Settings/DynamicSettingsViewController.swift
@@ -4,7 +4,8 @@
 
 private let DynamicSettingsCellHeight: CGFloat = 50
 
-protocol DynamicSettingsDelegate: class {
+@objc
+protocol DynamicSettingsResponder: class {
     func dynamicSettingsUserChanged(_ user: User)
 }
 
@@ -36,7 +37,6 @@ class DynamicSettingsViewController: UITableViewController {
 
     var dynamicCategories: [DynamicSettingCategory] = []
     var currentUser: User?
-    weak var delegate: DynamicSettingsDelegate?
     var hideLoadingHud: BasicBlock = ElloHUD.hideLoadingHud
 
     var height: CGFloat {
@@ -175,7 +175,6 @@ class DynamicSettingsViewController: UITableViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "DynamicSettingCategorySegue" {
             let controller = segue.destination as! DynamicSettingCategoryViewController
-            controller.delegate = delegate
             let selectedIndexPath = tableView.indexPathForSelectedRow
 
             switch DynamicSettingsSection(rawValue: selectedIndexPath?.section ?? 0) ?? .unknown {

--- a/Sources/Controllers/Settings/SettingsViewController.swift
+++ b/Sources/Controllers/Settings/SettingsViewController.swift
@@ -194,7 +194,8 @@ class SettingsViewController: UITableViewController, ControllerThatMightHaveTheC
             hideHud()
         }
 
-        ProfileService().loadCurrentUser(success: { user in
+        ProfileService().loadCurrentUser(success: { [weak self] user in
+            guard let `self` = self else { return }
             self.updateCurrentUser(user)
             hideHud()
         }, failure: { error in

--- a/Sources/Controllers/Settings/SettingsViewController.swift
+++ b/Sources/Controllers/Settings/SettingsViewController.swift
@@ -424,7 +424,6 @@ class SettingsViewController: UITableViewController, ControllerThatMightHaveTheC
         case "DynamicSettingsSegue":
             dynamicSettingsViewController = segue.destination as? DynamicSettingsViewController
             dynamicSettingsViewController?.currentUser = currentUser
-            dynamicSettingsViewController?.delegate = self
 
         default: break
         }
@@ -510,7 +509,7 @@ extension SettingsViewController {
     }
 }
 
-extension SettingsViewController: CredentialSettingsDelegate, DynamicSettingsDelegate {
+extension SettingsViewController: CredentialSettingsDelegate, DynamicSettingsResponder {
     func dynamicSettingsUserChanged(_ user: User) {
         updateCurrentUser(user)
     }

--- a/Sources/Controllers/Settings/SettingsViewController.swift
+++ b/Sources/Controllers/Settings/SettingsViewController.swift
@@ -425,6 +425,7 @@ class SettingsViewController: UITableViewController, ControllerThatMightHaveTheC
         case "DynamicSettingsSegue":
             dynamicSettingsViewController = segue.destination as? DynamicSettingsViewController
             dynamicSettingsViewController?.currentUser = currentUser
+            dynamicSettingsViewController?.delegate = self
 
         default: break
         }
@@ -510,7 +511,7 @@ extension SettingsViewController {
     }
 }
 
-extension SettingsViewController: CredentialSettingsDelegate, DynamicSettingsResponder {
+extension SettingsViewController: CredentialSettingsDelegate, DynamicSettingsDelegate {
     func dynamicSettingsUserChanged(_ user: User) {
         updateCurrentUser(user)
     }

--- a/Specs/Controllers/Settings/DynamicSettingCellSpec.swift
+++ b/Specs/Controllers/Settings/DynamicSettingCellSpec.swift
@@ -31,9 +31,11 @@ class DynamicSettingCellSpec: QuickSpec {
             }
 
             it("calls the delegate function") {
+
                 let fake = FakeDelegate()
                 let setting = DynamicSetting(label: "", key: "")
-                subject.delegate = fake
+                fake.addSubview(subject)
+                showView(fake)
                 subject.setting = setting
                 subject.toggleButtonTapped()
                 expect(fake.didCall).to(beTrue())
@@ -42,7 +44,8 @@ class DynamicSettingCellSpec: QuickSpec {
             it("hands the setting and value to the delegate function") {
                 let fake = FakeDelegate()
                 let setting = DynamicSetting(label: "test", key: "")
-                subject.delegate = fake
+                fake.addSubview(subject)
+                showView(fake)
                 subject.setting = setting
                 subject.toggleButtonTapped()
                 expect(fake.setting?.label) == setting.label
@@ -57,7 +60,8 @@ class DynamicSettingCellSpec: QuickSpec {
 
             it("calls the delegate function") {
                 let fake = FakeDelegate()
-                subject.delegate = fake
+                fake.addSubview(subject)
+                showView(fake)
                 subject.deleteButtonTapped()
                 expect(fake.didCall).to(beTrue())
             }
@@ -65,7 +69,7 @@ class DynamicSettingCellSpec: QuickSpec {
     }
 }
 
-private class FakeDelegate: DynamicSettingCellDelegate {
+private class FakeDelegate: UIView, DynamicSettingCellResponder {
     var didCall = false
     var setting: DynamicSetting?
     var value: Bool?


### PR DESCRIPTION
Initially I was going to convert both `DynamicSettingCellDelegate` and `DynamicSettingsDelegate` but `DynamicSettingsDelegate` really should be a delegate so I reverted it. There wasn't an obvious way to get `SettingsViewController` into the responder chain for changes to dynamic setting category toggles.