### PR TITLE
Log tracking events depending on logged out event type

### DIFF
--- a/Sources/Controllers/App/AppViewController.swift
+++ b/Sources/Controllers/App/AppViewController.swift
@@ -14,8 +14,13 @@ struct StatusBarNotifications {
     static let statusBarShouldHide = TypedNotification<(Bool)>(name: "co.ello.StatusBarNotifications.statusBarShouldHide")
 }
 
+enum LoggedOutAction {
+    case relationshipChange
+    case postTool
+}
+
 struct LoggedOutNotifications {
-    static let userActionAttempted = TypedNotification<()>(name: "co.ello.LoggedOutNotifications.userActionAttempted")
+    static let userActionAttempted = TypedNotification<LoggedOutAction>(name: "co.ello.LoggedOutNotifications.userActionAttempted")
 }
 
 

--- a/Sources/Controllers/LoggedOut/LoggedOutViewController.swift
+++ b/Sources/Controllers/LoggedOut/LoggedOutViewController.swift
@@ -54,7 +54,13 @@ class LoggedOutViewController: BaseElloViewController, BottomBarController {
 extension LoggedOutViewController {
 
     func setupNotificationObservers() {
-        userActionAttemptedObserver = NotificationObserver(notification: LoggedOutNotifications.userActionAttempted) { [weak self] _ in
+        userActionAttemptedObserver = NotificationObserver(notification: LoggedOutNotifications.userActionAttempted) { [weak self] action in
+            switch action {
+            case .relationshipChange:
+                Tracker.shared.loggedOutRelationshipAction()
+            case .postTool:
+                Tracker.shared.loggedOutPostTool()
+            }
             self?.screen.showJoinText()
         }
     }

--- a/Sources/Controllers/Profile/ProfileViewController.swift
+++ b/Sources/Controllers/Profile/ProfileViewController.swift
@@ -230,7 +230,7 @@ final class ProfileViewController: StreamableViewController {
 
     func moreButtonTapped() {
         guard currentUser != nil else {
-            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            postNotification(LoggedOutNotifications.userActionAttempted, value: .postTool)
             return
         }
         guard let user = user else { return }
@@ -280,7 +280,7 @@ final class ProfileViewController: StreamableViewController {
 extension ProfileViewController: ProfileScreenDelegate {
     func mentionTapped() {
         guard currentUser != nil else {
-            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            postNotification(LoggedOutNotifications.userActionAttempted, value: .postTool)
             return
         }
         guard let user = user else { return }
@@ -290,7 +290,7 @@ extension ProfileViewController: ProfileScreenDelegate {
 
     func hireTapped() {
         guard currentUser != nil else {
-            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            postNotification(LoggedOutNotifications.userActionAttempted, value: .postTool)
             return
         }
         guard let user = user else { return }
@@ -302,7 +302,7 @@ extension ProfileViewController: ProfileScreenDelegate {
 
     func editTapped() {
         guard currentUser != nil else {
-            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            postNotification(LoggedOutNotifications.userActionAttempted, value: .postTool)
             return
         }
         onEditProfile()
@@ -314,7 +314,7 @@ extension ProfileViewController: ProfileScreenDelegate {
 
     func collaborateTapped() {
         guard currentUser != nil else {
-            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            postNotification(LoggedOutNotifications.userActionAttempted, value: .postTool)
             return
         }
         guard let user = user else { return }
@@ -468,7 +468,7 @@ extension ProfileViewController: EditProfileResponder {
 
     func onEditProfile() {
         guard currentUser != nil else {
-            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            postNotification(LoggedOutNotifications.userActionAttempted, value: .postTool)
             return
         }
 

--- a/Sources/Controllers/Relationship/RelationshipController.swift
+++ b/Sources/Controllers/Relationship/RelationshipController.swift
@@ -48,7 +48,7 @@ extension RelationshipController: RelationshipResponder {
         complete: @escaping RelationshipChangeCompletion)
     {
         guard currentUser != nil else {
-            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            postNotification(LoggedOutNotifications.userActionAttempted, value: .relationshipChange)
             complete(RelationshipRequestStatusWrapper(status: .success), .none, true)
             return
         }

--- a/Sources/Controllers/Stream/PostbarController.swift
+++ b/Sources/Controllers/Stream/PostbarController.swift
@@ -131,7 +131,7 @@ class PostbarController: UIResponder, PostbarResponder {
 
     func deleteCommentButtonTapped(_ indexPath: IndexPath) {
         guard currentUser != nil else {
-            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            postNotification(LoggedOutNotifications.userActionAttempted, value: .postTool)
             return
         }
 
@@ -166,7 +166,7 @@ class PostbarController: UIResponder, PostbarResponder {
 
     func editCommentButtonTapped(_ indexPath: IndexPath) {
         guard currentUser != nil else {
-            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            postNotification(LoggedOutNotifications.userActionAttempted, value: .postTool)
             return
         }
         guard
@@ -180,7 +180,7 @@ class PostbarController: UIResponder, PostbarResponder {
 
     func lovesButtonTapped(_ cell: StreamFooterCell?, indexPath: IndexPath) {
         guard currentUser != nil else {
-            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            postNotification(LoggedOutNotifications.userActionAttempted, value: .postTool)
             return
         }
         guard let post = self.postForIndexPath(indexPath) else { return }
@@ -238,7 +238,7 @@ class PostbarController: UIResponder, PostbarResponder {
 
     func repostButtonTapped(_ indexPath: IndexPath) {
         guard currentUser != nil else {
-            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            postNotification(LoggedOutNotifications.userActionAttempted, value: .postTool)
             return
         }
         guard let post = self.postForIndexPath(indexPath) else { return }
@@ -329,7 +329,7 @@ class PostbarController: UIResponder, PostbarResponder {
 
     func flagCommentButtonTapped(_ indexPath: IndexPath) {
         guard currentUser != nil else {
-            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            postNotification(LoggedOutNotifications.userActionAttempted, value: .postTool)
             return
         }
         guard
@@ -349,7 +349,7 @@ class PostbarController: UIResponder, PostbarResponder {
 
     func replyToCommentButtonTapped(_ indexPath: IndexPath) {
         guard currentUser != nil else {
-            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            postNotification(LoggedOutNotifications.userActionAttempted, value: .postTool)
             return
         }
         guard
@@ -367,7 +367,7 @@ class PostbarController: UIResponder, PostbarResponder {
 
     func replyToAllButtonTapped(_ indexPath: IndexPath) {
         guard currentUser != nil else {
-            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            postNotification(LoggedOutNotifications.userActionAttempted, value: .postTool)
             return
         }
         guard
@@ -393,7 +393,7 @@ class PostbarController: UIResponder, PostbarResponder {
 
     func watchPostTapped(_ watching: Bool, cell: StreamCreateCommentCell, indexPath: IndexPath) {
         guard currentUser != nil else {
-            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            postNotification(LoggedOutNotifications.userActionAttempted, value: .postTool)
             return
         }
         guard

--- a/Sources/Controllers/Stream/StreamableViewController.swift
+++ b/Sources/Controllers/Stream/StreamableViewController.swift
@@ -285,7 +285,7 @@ extension StreamableViewController: InviteResponder {
 
     func onInviteFriends() {
         guard currentUser != nil else {
-            postNotification(LoggedOutNotifications.userActionAttempted, value: ())
+            postNotification(LoggedOutNotifications.userActionAttempted, value: .postTool)
             return
         }
 

--- a/Sources/Utilities/Tracker.swift
+++ b/Sources/Utilities/Tracker.swift
@@ -583,3 +583,14 @@ extension Tracker {
     }
 
 }
+
+// MARK: LoggedOut
+extension Tracker {
+    func loggedOutRelationshipAction() {
+        agent.track("logged out follow button")
+    }
+
+    func loggedOutPostTool() {
+        agent.track("logged out post tool")
+    }
+}


### PR DESCRIPTION
@caseydoran thoughts on the names of these events?  They don't match webapp, because the app behavior isn't the same (we don't open a registration modal).