### PR TITLE
Do not modify comments when a post is replaced

### DIFF
--- a/Sources/Controllers/Stream/StreamDataSource.swift
+++ b/Sources/Controllers/Stream/StreamDataSource.swift
@@ -600,7 +600,7 @@ class StreamDataSource: NSObject, UICollectionViewDataSource {
                     indexPaths.append(IndexPath(item: index, section: 0))
                     items.append(item)
                 }
-                else if change == .delete || change == .replaced {
+                else if change == .delete {
                     if let itemComment = item.jsonable as? ElloComment, itemComment.loadedFromPostId == post.id || itemComment.postId == post.id {
                         indexPaths.append(IndexPath(item: index, section: 0))
                         items.append(item)


### PR DESCRIPTION
This change is subtle. The bug this fixes is reproducible by editing a post that has comments. Once the `Post` is edited the comments no longer show up beneath the post on a post detail.

When editing a `Post` a `PostChangedNotification` is posted with a `ContentChange.replaced`. Semantically this means that the post has been replaced with a _new_ post. Replaced posts should not modify the comments on the post. This small change fixes that.

There is a chance that I've not thought of all the implications of this change. A second set of eyes would be helpful here @colinta. Can you think of any negative or unforeseen consequences of removing the `.replaced` `ContentChange` check here? In manual testing I verified correctness when deleting a post, deleting a comment, editing a post and editing a comment. As far as I could assess the behavior for these 4 actions resulted in reasonable updates of the `Post` in following, profile and post detail.

[fixes #138763013](https://www.pivotaltracker.com/story/show/138763013)