### PR TITLE
Show navigation bar on native screens launched from browser

### DIFF
--- a/Sources/Controllers/Stream/StreamableViewController.swift
+++ b/Sources/Controllers/Stream/StreamableViewController.swift
@@ -55,6 +55,7 @@ class StreamableViewController: BaseElloViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        AppDelegate.restrictRotation = true
         showing = true
         willPresentStreamable(navigationBarsVisible())
     }

--- a/Sources/Controllers/WebBrowser/ElloWebBrowserViewController.swift
+++ b/Sources/Controllers/WebBrowser/ElloWebBrowserViewController.swift
@@ -5,6 +5,17 @@
 import KINWebBrowser
 import Crashlytics
 
+class BottomBarNavController: ElloNavigationController, BottomBarController {
+    var bottomBarView = UIView()
+    var navigationBarsVisible: Bool = true
+    let bottomBarVisible: Bool = true
+    var bottomBarHeight: CGFloat { return 0 }
+
+    func setNavigationBarsVisible(_ visible: Bool, animated: Bool) {
+        navigationBarsVisible = visible
+    }
+}
+
 class ElloWebBrowserViewController: KINWebBrowserViewController {
     var toolbarHidden = false
     var prevRequestURL: URL?
@@ -20,8 +31,7 @@ class ElloWebBrowserViewController: KINWebBrowserViewController {
         webBrowser.navigationItem.leftBarButtonItem = xButton
         webBrowser.navigationItem.rightBarButtonItem = shareButton
         webBrowser.actionButtonHidden = true
-
-        return ElloNavigationController(rootViewController: webBrowser)
+        return BottomBarNavController(rootViewController: webBrowser)
     }
 
     override class func navigationControllerWithWebBrowser() -> ElloNavigationController {
@@ -31,19 +41,14 @@ class ElloWebBrowserViewController: KINWebBrowserViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        AppDelegate.restrictRotation = false
         self.navigationController?.setToolbarHidden(toolbarHidden, animated: false)
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        UIApplication.shared.statusBarStyle = .default
         Crashlytics.sharedInstance().setObjectValue("ElloWebBrowser", forKey: CrashlyticsKey.streamName.rawValue)
         delegate = self
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        UIApplication.shared.statusBarStyle = .lightContent
     }
 
     func shareButtonPressed(_ barButtonItem: UIBarButtonItem) {


### PR DESCRIPTION
Unfortunately this is only a partial fix for both of these bugs. 👇 

[Fixes #139398397](https://www.pivotaltracker.com/story/show/139398397) & [Fixes #139473309](https://www.pivotaltracker.com/story/show/139473309)

When launching a native screen from an in-app browser  the screen did not have a nav bar, it does now **_but_** the status bar does not hide correctly when scrolling. Further tweaking is necessary but I felt it was better to get a 1.22 build ready than delay it for this relatively minor bug.

Additionally, the screen can be launched in landscape mode if the browser is in landscape. Rotating to portrait will lock the screen to portrait and prevent further rotation. Similar to the first bug, this is a partial fix. Better than before but also requiring additional attention.