### PR TITLE
Tracking changes from Justin

### DIFF
--- a/Sources/Controllers/App/AppViewController.swift
+++ b/Sources/Controllers/App/AppViewController.swift
@@ -31,6 +31,8 @@ protocol HasAppController {
 
 
 class AppViewController: BaseElloViewController {
+    override func trackerName() -> String? { return nil }
+
     var mockScreen: AppScreenProtocol?
     var screen: AppScreenProtocol { return mockScreen ?? (self.view as! AppScreenProtocol) }
 

--- a/Sources/Controllers/App/DebugTrackingController.swift
+++ b/Sources/Controllers/App/DebugTrackingController.swift
@@ -95,7 +95,9 @@ class DebugAgent: AnalyticsAgent {
     }
 
     private func dismiss() {
-        animate {
+        animate(completion: { _ in
+            self.logTextView.text = ""
+        }) {
             self.logView.frame.origin.y = -self.logView.frame.height
         }
 

--- a/Sources/Controllers/ElloTabBarController.swift
+++ b/Sources/Controllers/ElloTabBarController.swift
@@ -47,6 +47,8 @@ enum ElloTab: Int {
 }
 
 class ElloTabBarController: UIViewController, HasAppController, ControllerThatMightHaveTheCurrentUser, BottomBarController {
+    override func trackerName() -> String? { return nil }
+
     let tabBar = ElloTabBar()
     fileprivate var systemLoggedOutObserver: NotificationObserver?
     fileprivate var streamLoadedObserver: NotificationObserver?


### PR DESCRIPTION
We were looking at tracking data, and realized that `Screen AppViewController` and `Screen ElloTabBarController` events were in there, but they are just noise, so this prevents them from being tracked.