### PR TITLE
Show signup footer when tapping comment icon

### DIFF
--- a/Sources/Controllers/Stream/PostbarController.swift
+++ b/Sources/Controllers/Stream/PostbarController.swift
@@ -65,10 +65,6 @@ class PostbarController: UIResponder, PostbarResponder {
             return
         }
 
-        guard !dataSource.streamKind.isDetail else {
-            return
-        }
-
         guard toggleableComments else {
             cell.cancelCommentLoading()
             return
@@ -80,6 +76,15 @@ class PostbarController: UIResponder, PostbarResponder {
             let post = item.jsonable as? Post
         else {
             cell.cancelCommentLoading()
+            return
+        }
+
+        if let commentCount = post.commentsCount, commentCount == 0, currentUser == nil {
+            postNotification(LoggedOutNotifications.userActionAttempted, value: .postTool)
+            return
+        }
+
+        guard !dataSource.streamKind.isDetail else {
             return
         }
 


### PR DESCRIPTION
When logged out and when a post has zero comments, tapping the comment icon expands the signup footer.

[Fixes #140508347](https://www.pivotaltracker.com/story/show/140508347)
[Fixes #140508379](https://www.pivotaltracker.com/story/show/140508379)