### PR TITLE
Tracks post detail page views when viewing a cached post

### DIFF
--- a/Sources/Controllers/App/AppViewController.swift
+++ b/Sources/Controllers/App/AppViewController.swift
@@ -371,7 +371,7 @@ extension AppViewController {
 
     fileprivate func prepareToShowViewController(_ newViewController: UIViewController) {
         let controller = (newViewController as? UINavigationController)?.topViewController ?? newViewController
-        Tracker.shared.screenAppeared(controller)
+        controller.trackScreenAppeared()
 
         view.addSubview(newViewController.view)
         newViewController.view.frame = self.view.bounds

--- a/Sources/Controllers/BaseElloViewController.swift
+++ b/Sources/Controllers/BaseElloViewController.swift
@@ -67,7 +67,7 @@ class BaseElloViewController: UIViewController, HasAppController, ControllerThat
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        Tracker.shared.screenAppeared(self)
+        trackScreenAppeared()
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Sources/Controllers/Categories/CategoryViewController.swift
+++ b/Sources/Controllers/Categories/CategoryViewController.swift
@@ -7,6 +7,10 @@ final class CategoryViewController: StreamableViewController {
     override func trackerProps() -> [String: AnyObject]? {
         return ["category": slug as AnyObject]
     }
+    override func trackerStreamInfo() -> (String, String?)? {
+        guard let streamId = category?.id else { return nil }
+        return ("category", streamId)
+    }
 
     var mockScreen: CategoryScreenProtocol?
     var screen: CategoryScreenProtocol {
@@ -265,6 +269,6 @@ extension CategoryViewController: CategoryScreenDelegate {
             screen.scrollToCategory(index: index)
             screen.selectCategory(index: index)
         }
-        Tracker.shared.screenAppeared(self)
+        trackScreenAppeared()
     }
 }

--- a/Sources/Controllers/Notifications/NotificationsViewController.swift
+++ b/Sources/Controllers/Notifications/NotificationsViewController.swift
@@ -151,7 +151,7 @@ class NotificationsViewController: StreamableViewController, NotificationsScreen
         streamViewController.removeAllCellItems()
         streamViewController.loadInitialPage()
 
-        Tracker.shared.screenAppeared(self)
+        trackScreenAppeared()
     }
 
     func respondToNotification(_ components: [String]) {

--- a/Sources/Controllers/Onboarding/OnboardingViewController.swift
+++ b/Sources/Controllers/Onboarding/OnboardingViewController.swift
@@ -206,7 +206,7 @@ extension OnboardingViewController {
     }
 
     fileprivate func showFirstViewController(_ viewController: UIViewController) {
-        Tracker.shared.screenAppeared(viewController)
+        viewController.trackScreenAppeared()
 
         prepareOnboardingController(viewController)
 
@@ -285,7 +285,7 @@ extension OnboardingViewController {
             return
         }
 
-        Tracker.shared.screenAppeared(nextViewController)
+        nextViewController.trackScreenAppeared()
 
         visibleViewController.willMove(toParentViewController: nil)
         addChildViewController(nextViewController)

--- a/Sources/Controllers/Profile/ProfileViewController.swift
+++ b/Sources/Controllers/Profile/ProfileViewController.swift
@@ -13,6 +13,10 @@ final class ProfileViewController: StreamableViewController {
         }
         return nil
     }
+    override func trackerStreamInfo() -> (String, String?)? {
+        guard let streamId = user?.id else { return nil }
+        return ("profile", streamId)
+    }
 
     var _tabBarItem: UITabBarItem?
     override var tabBarItem: UITabBarItem? {

--- a/Sources/Controllers/Search/SearchViewController.swift
+++ b/Sources/Controllers/Search/SearchViewController.swift
@@ -13,6 +13,9 @@ class SearchViewController: StreamableViewController {
         }
         return "Search for \(searchFor)"
     }
+    override func trackerStreamInfo() -> (String, String?)? {
+        return ("search", nil)
+    }
 
     var searchText: String?
     var isPostSearch = true
@@ -126,7 +129,7 @@ extension SearchViewController: SearchScreenDelegate {
     func trackSearch() {
         guard let text = searchText else { return }
 
-        Tracker.shared.screenAppeared(self)
+        trackScreenAppeared()
 
         if isPostSearch {
             if text.hasPrefix("#") {

--- a/Sources/Controllers/Stream/Detail/PostDetailGenerator.swift
+++ b/Sources/Controllers/Stream/Detail/PostDetailGenerator.swift
@@ -80,7 +80,7 @@ private extension PostDetailGenerator {
     func sendPostView(_ doneOperation: AsyncOperation, reload: Bool = false) {
         guard let post = post, doneOperation.isFinished && !reload else { return }
 
-        PostService().sendPostView(id: post.id, token: post.token, email: currentUser?.profile?.email)
+        PostService().sendPostDetailView(id: post.id, email: currentUser?.profile?.email)
     }
 
     func loadPost(_ doneOperation: AsyncOperation, reload: Bool = false) {

--- a/Sources/Controllers/Stream/Detail/PostDetailGenerator.swift
+++ b/Sources/Controllers/Stream/Detail/PostDetailGenerator.swift
@@ -80,7 +80,7 @@ private extension PostDetailGenerator {
     func sendPostView(_ doneOperation: AsyncOperation, reload: Bool = false) {
         guard let post = post, doneOperation.isFinished && !reload else { return }
 
-        PostService().sendPostDetailView(id: post.id, email: currentUser?.profile?.email)
+        PostService().sendPostDetailView(id: post.id, userId: currentUser?.id)
     }
 
     func loadPost(_ doneOperation: AsyncOperation, reload: Bool = false) {

--- a/Sources/Controllers/Stream/Detail/PostDetailGenerator.swift
+++ b/Sources/Controllers/Stream/Detail/PostDetailGenerator.swift
@@ -43,6 +43,7 @@ final class PostDetailGenerator: StreamGenerator {
             setPlaceHolders()
         }
         setInitialPost(doneOperation)
+        sendPostView(doneOperation, reload: reload)
         loadPost(doneOperation, reload: reload)
         displayCommentBar(doneOperation)
         loadPostComments(doneOperation)
@@ -74,6 +75,12 @@ private extension PostDetailGenerator {
             destination?.replacePlaceholder(type: .postHeader, items: postItems) {}
             doneOperation.run()
         }
+    }
+
+    func sendPostView(_ doneOperation: AsyncOperation, reload: Bool = false) {
+        guard let post = post, doneOperation.isFinished && !reload else { return }
+
+        PostService().sendPostView(id: post.id, token: post.token, email: currentUser?.profile?.email)
     }
 
     func loadPost(_ doneOperation: AsyncOperation, reload: Bool = false) {

--- a/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
+++ b/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
@@ -11,6 +11,10 @@ final class PostDetailViewController: StreamableViewController {
         }
         return ["id": postParam as AnyObject]
     }
+    override func trackerStreamInfo() -> (String, String?)? {
+        guard let streamId = post?.id else { return nil }
+        return ("post", streamId)
+    }
 
     var post: Post?
     var postParam: String

--- a/Sources/Controllers/Stream/SimpleStreamViewController.swift
+++ b/Sources/Controllers/Stream/SimpleStreamViewController.swift
@@ -8,6 +8,10 @@ class SimpleStreamViewController: StreamableViewController {
     override func trackerName() -> String? {
         return endpoint.trackerName
     }
+    override func trackerStreamInfo() -> (String, String?)? {
+        guard let streamKind = endpoint.trackerStreamKind else { return nil }
+        return (streamKind, endpoint.trackerStreamId)
+    }
 
     var navigationBar: ElloNavigationBar!
     let endpoint: ElloAPI

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -782,7 +782,7 @@ extension StreamViewController: SSPullToRefreshViewDelegate {
         if toState == .loading {
             if pullToRefreshEnabled {
                 if let controller = parent as? BaseElloViewController {
-                    Tracker.shared.screenAppeared(controller)
+                    controller.trackScreenAppeared()
                 }
                 self.loadInitialPage(reload: true)
             }
@@ -1176,7 +1176,7 @@ extension StreamViewController: UIScrollViewDelegate {
 
         if jsonables.count > 0 {
             if let controller = parent as? BaseElloViewController {
-                Tracker.shared.screenAppeared(controller)
+                controller.trackScreenAppeared()
             }
 
             let items = StreamCellItemParser().parse(jsonables, streamKind: streamKind, currentUser: currentUser)

--- a/Sources/Controllers/Stream/StreamableViewController.swift
+++ b/Sources/Controllers/Stream/StreamableViewController.swift
@@ -91,7 +91,7 @@ class StreamableViewController: BaseElloViewController {
         let posts = streamViewController.dataSource.visibleCellItems.flatMap { streamCellItem in
             return streamCellItem.jsonable as? Post
         }
-        PostService().sendPostViews(posts: posts, streamId: streamId, streamKind: streamKind, email: currentUser?.profile?.email)
+        PostService().sendPostViews(posts: posts, streamId: streamId, streamKind: streamKind, userId: currentUser?.id)
     }
 
     fileprivate func willPresentStreamable(_ navBarsVisible: Bool) {

--- a/Sources/Controllers/Stream/StreamableViewController.swift
+++ b/Sources/Controllers/Stream/StreamableViewController.swift
@@ -80,6 +80,20 @@ class StreamableViewController: BaseElloViewController {
         )
     }
 
+    func trackerStreamInfo() -> (String, String?)? {
+        return nil
+    }
+
+    override func trackScreenAppeared() {
+        super.trackScreenAppeared()
+
+        guard let (streamKind, streamId) = trackerStreamInfo() else { return }
+        let posts = streamViewController.dataSource.visibleCellItems.flatMap { streamCellItem in
+            return streamCellItem.jsonable as? Post
+        }
+        PostService().sendPostViews(posts: posts, streamId: streamId, streamKind: streamKind, email: currentUser?.profile?.email)
+    }
+
     fileprivate func willPresentStreamable(_ navBarsVisible: Bool) {
         postNotification(StatusBarNotifications.statusBarShouldHide, value: !navBarsVisible)
         UIView.setAnimationsEnabled(false)

--- a/Sources/Networking/ElloAPI.swift
+++ b/Sources/Networking/ElloAPI.swift
@@ -714,7 +714,7 @@ extension ElloAPI: Moya.TargetType {
             ]
         case let .postView(postId, postToken, email):
             return [
-                "email": email ?? "nil",
+                "email": email,
                 "posts": postToken,
                 "id": postId,
                 "kind": "post",

--- a/Sources/Networking/ElloAPI.swift
+++ b/Sources/Networking/ElloAPI.swift
@@ -56,7 +56,7 @@ enum ElloAPI {
     case pagePromotionals
     case postComments(postId: String)
     case postDetail(postParam: String, commentCount: Int)
-    case postViews(streamId: String?, streamKind: String, postIds: [String], currentUserEmail: String?)
+    case postViews(streamId: String?, streamKind: String, postIds: Set<String>, currentUserId: String?)
     case postLovers(postId: String)
     case postReplyAll(postId: String)
     case postReposters(postId: String)
@@ -712,16 +712,16 @@ extension ElloAPI: Moya.TargetType {
             return [
                 "comment_count": commentCount as AnyObject
             ]
-        case let .postViews(streamId, streamKind, postIds, email):
+        case let .postViews(streamId, streamKind, postIds, userId):
             let streamIdDict: [String: String] = streamId.map { streamId in return ["id": streamId]} ?? [:]
-            let emailDict: [String: String] = email.map { email in return ["email": email]} ?? [:]
+            let userIdDict: [String: String] = userId.map { userId in return ["user_id": userId]} ?? [:]
             return [
                 "post_ids": postIds.reduce("") { memo, id in
                     if memo == "" { return id }
-                    else { return ",\(id)" }
+                    else { return "\(memo),\(id)" }
                 },
                 "kind": streamKind,
-            ] + streamIdDict + emailDict
+            ] + streamIdDict + userIdDict
         case .currentUserStream:
             return [
                 "post_count": 10 as AnyObject

--- a/Sources/Networking/ElloAPI.swift
+++ b/Sources/Networking/ElloAPI.swift
@@ -56,6 +56,7 @@ enum ElloAPI {
     case pagePromotionals
     case postComments(postId: String)
     case postDetail(postParam: String, commentCount: Int)
+    case postView(postId: String, postToken: String, currentUserEmail: String?)
     case postLovers(postId: String)
     case postReplyAll(postId: String)
     case postReposters(postId: String)
@@ -115,7 +116,8 @@ enum ElloAPI {
         switch self {
         case .anonymousCredentials,
              .auth,
-             .reAuth:
+             .reAuth,
+             .postView:
             return .noContentType  // We do not current have a "Credentials" model, we interact directly with the keychain
         case .announcements:
             return .announcementsType
@@ -217,7 +219,7 @@ extension ElloAPI {
              .categories, .category, .categoryPosts, .discover, .pagePromotionals,
              .searchForPosts, .searchForUsers,
              .userStreamPosts, .userStreamFollowing, .userStreamFollowers, .loves,
-             .postComments, .postLovers, .postReposters, .postDetail,
+             .postComments, .postLovers, .postReposters, .postDetail, .postView,
              .join, .deleteSubscriptions, .userStream:
             return true
         case let .infiniteScroll(_, elloApi):
@@ -385,6 +387,8 @@ extension ElloAPI: Moya.TargetType {
             return "/api/\(ElloAPI.apiVersion)/posts/\(postId)/comments"
         case let .postDetail(postParam, _):
             return "/api/\(ElloAPI.apiVersion)/posts/\(postParam)"
+        case .postView:
+            return "/api/\(ElloAPI.apiVersion)/post_views"
         case let .postLovers(postId):
             return "/api/\(ElloAPI.apiVersion)/posts/\(postId)/lovers"
         case let .postReplyAll(postId):
@@ -469,6 +473,7 @@ extension ElloAPI: Moya.TargetType {
              .inviteFriends,
              .notificationsNewContent,
              .profileDelete,
+             .postView,
              .pushSubscriptions,
              .flagComment,
              .flagPost,
@@ -707,6 +712,13 @@ extension ElloAPI: Moya.TargetType {
             return [
                 "comment_count": commentCount as AnyObject
             ]
+        case let .postView(postId, postToken, email):
+            return [
+                "email": email ?? "nil",
+                "posts": postToken,
+                "id": postId,
+                "kind": "post",
+            ]
         case .currentUserStream:
             return [
                 "post_count": 10 as AnyObject
@@ -805,17 +817,3 @@ func += <KeyType, ValueType> (left: inout Dictionary<KeyType, ValueType>, right:
         left.updateValue(v, forKey: k)
     }
 }
-
-//extension Moya.ParameterEncoding: Equatable {}
-//
-//func == (lhs: Moya.ParameterEncoding, rhs: Moya.ParameterEncoding) -> Bool {
-//    switch (lhs, rhs) {
-//    case (.url, .url),
-//         (.json, .json),
-//         (.PropertyList, .PropertyList),
-//         (.Custom, .Custom):
-//        return true
-//    default:
-//        return false
-//    }
-//}

--- a/Sources/Networking/ElloAPIDescription.swift
+++ b/Sources/Networking/ElloAPIDescription.swift
@@ -76,6 +76,8 @@ extension ElloAPI: CustomStringConvertible, CustomDebugStringConvertible {
             return "postComments(postId: \(postId))"
         case let .postDetail(postParam, commentCount):
             return "postDetail(postParam: \(postParam), commentCount: \(commentCount))"
+        case let .postView(postId, postToken, currentUserEmail):
+            return "postView(postId: \(postId), postToken: \(postToken), currentUserEmail: \(currentUserEmail))"
         case let .postLovers(postId):
             return "postLovers(postId: \(postId))"
         case let .postReplyAll(postId):
@@ -200,6 +202,8 @@ extension ElloAPI: CustomStringConvertible, CustomDebugStringConvertible {
             return "postComments"
         case .postDetail:
             return "postDetail"
+        case .postView:
+            return "postView"
         case .postLovers:
             return "postLovers"
         case .postReplyAll:

--- a/Sources/Networking/ElloAPIDescription.swift
+++ b/Sources/Networking/ElloAPIDescription.swift
@@ -23,6 +23,22 @@ extension ElloAPI: CustomStringConvertible, CustomDebugStringConvertible {
             return nil
         }
     }
+    var trackerStreamKind: String? {
+        switch self {
+        case .loves:
+            return "love"
+        default:
+            return nil
+        }
+    }
+    var trackerStreamId: String? {
+        switch self {
+        case let .loves(userId):
+            return userId
+        default:
+            return nil
+        }
+    }
 
     var debugDescription: String {
         switch self {
@@ -76,8 +92,8 @@ extension ElloAPI: CustomStringConvertible, CustomDebugStringConvertible {
             return "postComments(postId: \(postId))"
         case let .postDetail(postParam, commentCount):
             return "postDetail(postParam: \(postParam), commentCount: \(commentCount))"
-        case let .postView(postId, postToken, currentUserEmail):
-            return "postView(postId: \(postId), postToken: \(postToken), currentUserEmail: \(currentUserEmail))"
+        case let .postViews(streamId, streamKind, postTokens, currentUserEmail):
+            return "postViews(streamId: \(streamId), streamKind: \(streamKind), postTokens: \(postTokens), currentUserEmail: \(currentUserEmail))"
         case let .postLovers(postId):
             return "postLovers(postId: \(postId))"
         case let .postReplyAll(postId):
@@ -202,8 +218,8 @@ extension ElloAPI: CustomStringConvertible, CustomDebugStringConvertible {
             return "postComments"
         case .postDetail:
             return "postDetail"
-        case .postView:
-            return "postView"
+        case .postViews:
+            return "postViews"
         case .postLovers:
             return "postLovers"
         case .postReplyAll:

--- a/Sources/Networking/ElloAPIDescription.swift
+++ b/Sources/Networking/ElloAPIDescription.swift
@@ -92,8 +92,8 @@ extension ElloAPI: CustomStringConvertible, CustomDebugStringConvertible {
             return "postComments(postId: \(postId))"
         case let .postDetail(postParam, commentCount):
             return "postDetail(postParam: \(postParam), commentCount: \(commentCount))"
-        case let .postViews(streamId, streamKind, postTokens, currentUserEmail):
-            return "postViews(streamId: \(streamId), streamKind: \(streamKind), postTokens: \(postTokens), currentUserEmail: \(currentUserEmail))"
+        case let .postViews(streamId, streamKind, postTokens, currentUserId):
+            return "postViews(streamId: \(streamId), streamKind: \(streamKind), postTokens: \(postTokens), currentUserId: \(currentUserId))"
         case let .postLovers(postId):
             return "postLovers(postId: \(postId))"
         case let .postReplyAll(postId):

--- a/Sources/Networking/PostService.swift
+++ b/Sources/Networking/PostService.swift
@@ -41,6 +41,17 @@ struct PostService {
         return promise.future
     }
 
+    func sendPostView(
+        id postId: String,
+        token postToken: String,
+        email: String?)
+    {
+        ElloProvider.shared.elloRequest(
+            ElloAPI.postView(postId: postId, postToken: postToken, currentUserEmail: email),
+            success: { _ in },
+            failure: { _ in })
+    }
+
     func loadPostComments(
         _ postId: String,
         success: @escaping PostCommentsSuccessCompletion,

--- a/Sources/Networking/PostService.swift
+++ b/Sources/Networking/PostService.swift
@@ -41,10 +41,10 @@ struct PostService {
 
     func sendPostDetailView(
         id postId: String,
-        email: String?)
+        userId: String?)
     {
         ElloProvider.shared.elloRequest(
-            ElloAPI.postViews(streamId: postId, streamKind: "post", postIds: [postId], currentUserEmail: email),
+            ElloAPI.postViews(streamId: postId, streamKind: "post", postIds: [postId], currentUserId: userId),
             success: { _ in })
     }
 
@@ -52,12 +52,13 @@ struct PostService {
         posts: [Post],
         streamId: String?,
         streamKind: String,
-        email: String?)
+        userId: String?)
     {
         guard posts.count > 0 else { return }
 
+        let postIds = Set(posts.map { $0.id })
         ElloProvider.shared.elloRequest(
-            ElloAPI.postViews(streamId: streamId, streamKind: streamKind, postIds: posts.map { $0.id }, currentUserEmail: email),
+            ElloAPI.postViews(streamId: streamId, streamKind: streamKind, postIds: postIds, currentUserId: userId),
             success: { _ in })
     }
 

--- a/Sources/Networking/PostService.swift
+++ b/Sources/Networking/PostService.swift
@@ -15,8 +15,6 @@ typealias DeletePostSuccessCompletion = () -> Void
 
 struct PostService {
 
-    init(){}
-
     func loadPost(
         _ postParam: String,
         needsComments: Bool) -> Future<Post>

--- a/Sources/Networking/PostService.swift
+++ b/Sources/Networking/PostService.swift
@@ -41,15 +41,26 @@ struct PostService {
         return promise.future
     }
 
-    func sendPostView(
+    func sendPostDetailView(
         id postId: String,
-        token postToken: String,
         email: String?)
     {
         ElloProvider.shared.elloRequest(
-            ElloAPI.postView(postId: postId, postToken: postToken, currentUserEmail: email),
-            success: { _ in },
-            failure: { _ in })
+            ElloAPI.postViews(streamId: postId, streamKind: "post", postIds: [postId], currentUserEmail: email),
+            success: { _ in })
+    }
+
+    func sendPostViews(
+        posts: [Post],
+        streamId: String?,
+        streamKind: String,
+        email: String?)
+    {
+        guard posts.count > 0 else { return }
+
+        ElloProvider.shared.elloRequest(
+            ElloAPI.postViews(streamId: streamId, streamKind: streamKind, postIds: posts.map { $0.id }, currentUserEmail: email),
+            success: { _ in })
     }
 
     func loadPostComments(

--- a/Sources/Utilities/Tracker.swift
+++ b/Sources/Utilities/Tracker.swift
@@ -296,6 +296,10 @@ extension UIViewController {
     // return 'nil' to disable tracking, e.g. in StreamViewController
     func trackerName() -> String? { return readableClassName() }
     func trackerProps() -> [String: AnyObject]? { return nil }
+
+    func trackScreenAppeared() {
+        Tracker.shared.screenAppeared(self)
+    }
 }
 
 // MARK: View Appearance

--- a/Specs/Networking/ElloAPISpec.swift
+++ b/Specs/Networking/ElloAPISpec.swift
@@ -74,6 +74,7 @@ class ElloAPISpec: QuickSpec {
                         (.pagePromotionals, "/api/v2/page_promotionals"),
                         (.postComments(postId: "fake-id"), "/api/v2/posts/fake-id/comments"),
                         (.postDetail(postParam: "some-param", commentCount: 10), "/api/v2/posts/some-param"),
+                        (.postView(id: "", token: "", currentUserEmail: ""), "/api/v2/post_views"),
                         (.postLovers(postId: "1"), "/api/v2/posts/1/lovers"),
                         (.postReplyAll(postId: "1"), "/api/v2/posts/1/commenters_usernames"),
                         (.postReposters(postId: "1"), "/api/v2/posts/1/reposters"),
@@ -433,6 +434,23 @@ class ElloAPISpec: QuickSpec {
                 it("PostComments") {
                     let params = ElloAPI.postComments(postId: "comments-id").parameters!
                     expect(params["per_page"] as? Int) == 10
+                }
+
+                describe("PostView") {
+                    it("with email") {
+                        let params = ElloAPI.postView(id: "123", "token": "abcdef", currentUserEmail: "email").parameters!
+                        expect(params["posts"] as? String) == "abcdef"
+                        expect(params["email"] as? String) == "email"
+                        expect(params["kind"] as? String) == "post"
+                        expect(params["id"] as? String) == "123"
+                    }
+                    it("anonymous") {
+                        let params = ElloAPI.postView(id: "123", "token": "abcdef", currentUserEmail: nil).parameters!
+                        expect(params["posts"] as? String) == "123"
+                        expect(params["email"] as? String).to(beNil())
+                        expect(params["kind"] as? String) == "post"
+                        expect(params["id"] as? String) == "123"
+                    }
                 }
 
                 describe("PostDetail") {

--- a/Specs/Networking/ElloAPISpec.swift
+++ b/Specs/Networking/ElloAPISpec.swift
@@ -74,7 +74,7 @@ class ElloAPISpec: QuickSpec {
                         (.pagePromotionals, "/api/v2/page_promotionals"),
                         (.postComments(postId: "fake-id"), "/api/v2/posts/fake-id/comments"),
                         (.postDetail(postParam: "some-param", commentCount: 10), "/api/v2/posts/some-param"),
-                        (.postViews(streamId: "", streamKind: "", postIds: [""], currentUserEmail: ""), "/api/v2/post_views"),
+                        (.postViews(streamId: "", streamKind: "", postIds: Set<String>(), currentUserId: ""), "/api/v2/post_views"),
                         (.postLovers(postId: "1"), "/api/v2/posts/1/lovers"),
                         (.postReplyAll(postId: "1"), "/api/v2/posts/1/commenters_usernames"),
                         (.postReposters(postId: "1"), "/api/v2/posts/1/reposters"),
@@ -438,30 +438,30 @@ class ElloAPISpec: QuickSpec {
 
                 describe("postViews endpoint") {
                     it("with email") {
-                        let params = ElloAPI.postViews(streamId: "123", streamKind: "post", postIds: ["666"], currentUserEmail: "email").parameters!
-                        expect(params["post_ids"] as? String) == "666"
-                        expect(params["email"] as? String) == "email"
+                        let params = ElloAPI.postViews(streamId: "123", streamKind: "post", postIds: Set(["555"]), currentUserId: "666").parameters!
+                        expect(params["post_ids"] as? String) == "555"
+                        expect(params["user_id"] as? String) == "666"
                         expect(params["kind"] as? String) == "post"
                         expect(params["id"] as? String) == "123"
                     }
                     it("with no streamId") {
-                        let params = ElloAPI.postViews(streamId: nil, streamKind: "post", postIds: ["666"], currentUserEmail: "email").parameters!
-                        expect(params["post_ids"] as? String) == "666"
-                        expect(params["email"] as? String) == "email"
+                        let params = ElloAPI.postViews(streamId: nil, streamKind: "post", postIds: Set(["555"]), currentUserId: "666").parameters!
+                        expect(params["post_ids"] as? String) == "555"
+                        expect(params["user_id"] as? String) == "666"
                         expect(params["kind"] as? String) == "post"
                         expect(params["id"]).to(beNil())
                     }
                     it("with many posts") {
-                        let params = ElloAPI.postViews(streamId: "123", streamKind: "post", postIds: ["666", "777"], currentUserEmail: "email").parameters!
-                        expect(params["post_ids"] as? String) == "666,777"
-                        expect(params["email"] as? String) == "email"
+                        let params = ElloAPI.postViews(streamId: "123", streamKind: "post", postIds: Set(["555", "777"]), currentUserId: "666").parameters!
+                        expect(params["post_ids"] as? String).to(satisfyAnyOf(equal("555,777"), equal("777,555")))
+                        expect(params["user_id"] as? String) == "666"
                         expect(params["kind"] as? String) == "post"
                         expect(params["id"] as? String) == "123"
                     }
                     it("anonymous") {
-                        let params = ElloAPI.postViews(streamId: "123", streamKind: "post", postIds: ["666"], currentUserEmail: nil).parameters!
-                        expect(params["post_ids"] as? String) == "666"
-                        expect(params["email"] as? String).to(beNil())
+                        let params = ElloAPI.postViews(streamId: "123", streamKind: "post", postIds: Set(["555"]), currentUserId: nil).parameters!
+                        expect(params["post_ids"] as? String) == "555"
+                        expect(params["user_id"] as? String).to(beNil())
                         expect(params["kind"] as? String) == "post"
                         expect(params["id"] as? String) == "123"
                     }

--- a/Specs/Networking/ElloAPISpec.swift
+++ b/Specs/Networking/ElloAPISpec.swift
@@ -74,7 +74,7 @@ class ElloAPISpec: QuickSpec {
                         (.pagePromotionals, "/api/v2/page_promotionals"),
                         (.postComments(postId: "fake-id"), "/api/v2/posts/fake-id/comments"),
                         (.postDetail(postParam: "some-param", commentCount: 10), "/api/v2/posts/some-param"),
-                        (.postView(postId: "", postToken: "", currentUserEmail: ""), "/api/v2/post_views"),
+                        (.postViews(streamId: "", streamKind: "", postIds: [""], currentUserEmail: ""), "/api/v2/post_views"),
                         (.postLovers(postId: "1"), "/api/v2/posts/1/lovers"),
                         (.postReplyAll(postId: "1"), "/api/v2/posts/1/commenters_usernames"),
                         (.postReposters(postId: "1"), "/api/v2/posts/1/reposters"),
@@ -436,17 +436,31 @@ class ElloAPISpec: QuickSpec {
                     expect(params["per_page"] as? Int) == 10
                 }
 
-                describe("PostView") {
+                describe("postViews endpoint") {
                     it("with email") {
-                        let params = ElloAPI.postView(postId: "123", postToken: "abcdef", currentUserEmail: "email").parameters!
-                        expect(params["posts"] as? String) == "abcdef"
+                        let params = ElloAPI.postViews(streamId: "123", streamKind: "post", postIds: ["666"], currentUserEmail: "email").parameters!
+                        expect(params["post_ids"] as? String) == "666"
+                        expect(params["email"] as? String) == "email"
+                        expect(params["kind"] as? String) == "post"
+                        expect(params["id"] as? String) == "123"
+                    }
+                    it("with no streamId") {
+                        let params = ElloAPI.postViews(streamId: nil, streamKind: "post", postIds: ["666"], currentUserEmail: "email").parameters!
+                        expect(params["post_ids"] as? String) == "666"
+                        expect(params["email"] as? String) == "email"
+                        expect(params["kind"] as? String) == "post"
+                        expect(params["id"]).to(beNil())
+                    }
+                    it("with many posts") {
+                        let params = ElloAPI.postViews(streamId: "123", streamKind: "post", postIds: ["666", "777"], currentUserEmail: "email").parameters!
+                        expect(params["post_ids"] as? String) == "666,777"
                         expect(params["email"] as? String) == "email"
                         expect(params["kind"] as? String) == "post"
                         expect(params["id"] as? String) == "123"
                     }
                     it("anonymous") {
-                        let params = ElloAPI.postView(postId: "123", postToken: "abcdef", currentUserEmail: nil).parameters!
-                        expect(params["posts"] as? String) == "abcdef"
+                        let params = ElloAPI.postViews(streamId: "123", streamKind: "post", postIds: ["666"], currentUserEmail: nil).parameters!
+                        expect(params["post_ids"] as? String) == "666"
                         expect(params["email"] as? String).to(beNil())
                         expect(params["kind"] as? String) == "post"
                         expect(params["id"] as? String) == "123"

--- a/Specs/Networking/ElloAPISpec.swift
+++ b/Specs/Networking/ElloAPISpec.swift
@@ -74,7 +74,7 @@ class ElloAPISpec: QuickSpec {
                         (.pagePromotionals, "/api/v2/page_promotionals"),
                         (.postComments(postId: "fake-id"), "/api/v2/posts/fake-id/comments"),
                         (.postDetail(postParam: "some-param", commentCount: 10), "/api/v2/posts/some-param"),
-                        (.postView(id: "", token: "", currentUserEmail: ""), "/api/v2/post_views"),
+                        (.postView(postId: "", postToken: "", currentUserEmail: ""), "/api/v2/post_views"),
                         (.postLovers(postId: "1"), "/api/v2/posts/1/lovers"),
                         (.postReplyAll(postId: "1"), "/api/v2/posts/1/commenters_usernames"),
                         (.postReposters(postId: "1"), "/api/v2/posts/1/reposters"),
@@ -438,15 +438,15 @@ class ElloAPISpec: QuickSpec {
 
                 describe("PostView") {
                     it("with email") {
-                        let params = ElloAPI.postView(id: "123", "token": "abcdef", currentUserEmail: "email").parameters!
+                        let params = ElloAPI.postView(postId: "123", postToken: "abcdef", currentUserEmail: "email").parameters!
                         expect(params["posts"] as? String) == "abcdef"
                         expect(params["email"] as? String) == "email"
                         expect(params["kind"] as? String) == "post"
                         expect(params["id"] as? String) == "123"
                     }
                     it("anonymous") {
-                        let params = ElloAPI.postView(id: "123", "token": "abcdef", currentUserEmail: nil).parameters!
-                        expect(params["posts"] as? String) == "123"
+                        let params = ElloAPI.postView(postId: "123", postToken: "abcdef", currentUserEmail: nil).parameters!
+                        expect(params["posts"] as? String) == "abcdef"
                         expect(params["email"] as? String).to(beNil())
                         expect(params["kind"] as? String) == "post"
                         expect(params["id"] as? String) == "123"


### PR DESCRIPTION
Adds `sendPostView` to PostDetailGenerator and `postView` endpoint to ElloAPI

`sendPostView` is only called if the post was loaded from memory, and not during a reload
postView is just one possible implementation of the `post_views` endpoint, and it
hard codes the values of `kind`.  In the future we could change it to support different
`post_views.kind` values.

Finishes [#140890503](https://www.pivotaltracker.com/story/show/140890503)