### PR TITLE
Removes the "convert <br> to TextRegion" feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,11 @@ install:
 - bundle exec pod keys set HttpProtocol $ELLO_HTTP_PROTOCOL Ello
 - bundle exec pod keys set SegmentKey $ELLO_SEGMENT_KEY Ello
 - bundle exec pod keys set TeamId ABC123 Ello
+- bundle exec pod keys set StagingOauthKey "any" Ello
+- bundle exec pod keys set StagingOauthSecret "any" Ello
+- bundle exec pod keys set StagingDomain "any.com" Ello
+- bundle exec pod keys set StagingHttpProtocol "http" Ello
+- bundle exec pod keys set StagingSegmentKey "any" Ello
 - bundle exec pod repo update --silent
 - bundle exec pod install
 before_script:

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,6 @@ namespace :generate do
       ['StagingOauthSecret', 'STAGING_CLIENT_SECRET'],
       ['StagingDomain', 'STAGING_DOMAIN'],
       ['StagingHttpProtocol', 'STAGING_HTTP_PROTOCOL'],
-      ['StagingCrashlyticsKey', 'CRASHLYTICS_KEY'],
       ['StagingSegmentKey', 'STAGING_SEGMENT_KEY'],
       ['OauthKey', 'PROD_CLIENT_KEY'],
       ['OauthSecret', 'PROD_CLIENT_SECRET'],

--- a/Sources/model/Regions/RegionKindStreamCellTypeAddition.swift
+++ b/Sources/model/Regions/RegionKindStreamCellTypeAddition.swift
@@ -12,30 +12,27 @@ extension RegionKind {
         case .text:
             if let textRegion = regionable as? TextRegion {
                 let content = textRegion.content
-                let paragraphs: [String] = content.components(separatedBy: "</p>").flatMap { (para: String) -> [String] in
-                    guard para.trimmed() != "" else { return [] }
 
-                    var subparas = para.components(separatedBy: "<br>")
-                    guard
-                        subparas.count > 1
-                    else { return [para + "</p>"] }
-
-                    let first = subparas.removeFirst()
-                    return ["\(first)</p>"] + subparas.map({ "<p>\($0)</p>"})
-                }.map { line in
-                    let max = 7500
-                    guard line.characters.count < max + 10 else {
-                        let startIndex = line.characters.startIndex
-                        let endIndex = line.characters.index(line.characters.startIndex, offsetBy: max)
-                        return String(line.characters[startIndex..<endIndex]) + "&hellip;</p>" }
-                    return line
+                var paragraphs: [String] = content.components(separatedBy: "</p>")
+                if paragraphs.last == "" {
+                    _ = paragraphs.removeLast()
                 }
-                return paragraphs.flatMap { (para: String) -> StreamCellType? in
-                    if para == "" {
+                let truncatedParagraphs = paragraphs.map { line -> String in
+                        let max = 7500
+                        guard line.characters.count < max + 10 else {
+                            let startIndex = line.characters.startIndex
+                            let endIndex = line.characters.index(line.characters.startIndex, offsetBy: max)
+                            return String(line.characters[startIndex..<endIndex]) + "&hellip;</p>"
+                        }
+                        return line + "</p>"
+                    }
+
+                return truncatedParagraphs.flatMap { (text: String) -> StreamCellType? in
+                    if text == "" {
                         return nil
                     }
 
-                    let newRegion = TextRegion(content: para)
+                    let newRegion = TextRegion(content: text)
                     newRegion.isRepost = textRegion.isRepost
                     return .text(data: newRegion)
                 }

--- a/Specs/Controllers/Stream/StreamDataSourceSpec.swift
+++ b/Specs/Controllers/Stream/StreamDataSourceSpec.swift
@@ -458,7 +458,8 @@ class StreamDataSourceSpec: QuickSpec {
                 }
 
                 it("does not return cell items for other posts") {
-                    let post = subject.postForIndexPath(IndexPath(item: 9, section: 0))!
+                    let lastItem = subject.visibleCellItems.count - 1
+                    let post = subject.postForIndexPath(IndexPath(item: lastItem, section: 0))!
                     let items = subject.cellItemsForPost(post)
                     expect(post.id) == "777"
                     expect(items.count) == 4

--- a/Specs/Model/Regions/RegionKindStreamCellTypeAdditionSpec.swift
+++ b/Specs/Model/Regions/RegionKindStreamCellTypeAdditionSpec.swift
@@ -82,7 +82,7 @@ class RegionKindStreamCellTypeAdditionSpec: QuickSpec {
                 }
             }
 
-            it("should split break tags") {
+            it("should not split break tags") {
                 let kind = RegionKind.text
                 let content1 = "text1"
                 let content2 = "text2"
@@ -90,31 +90,24 @@ class RegionKindStreamCellTypeAdditionSpec: QuickSpec {
                     "content": "<p>\(content1)<br>\(content2)</p>"
                     ])
                 let streamCellTypes = kind.streamCellTypes(region)
-                expect(streamCellTypes.count) == 2
+                expect(streamCellTypes.count) == 1
                 if case let .text(data) = streamCellTypes[0], let textRegion = data as? TextRegion {
-                    expect(textRegion.content) == "<p>\(content1)</p>"
+                    expect(textRegion.content) == region.content
                 }
                 else {
                     fail("wrong cell type \(streamCellTypes[0])")
-                }
-
-                if case let .text(data) = streamCellTypes[1], let textRegion = data as? TextRegion {
-                    expect(textRegion.content) == "<p>\(content2)</p>"
-                }
-                else {
-                    fail("wrong cell type \(streamCellTypes[1])")
                 }
             }
 
             it("should truncate ridiculous text") {
                 let kind = RegionKind.text
                 let region = TextRegion.stub([
-                    "content": "<p>" + String(repeating: "lorem", count: 8000/5) + "</p>"
+                    "content": "<p>" + String(repeating: "a", count: 8000) + "</p>"
                     ])
                 let streamCellTypes = kind.streamCellTypes(region)
                 expect(streamCellTypes.count) == 1
                 if case let .text(data) = streamCellTypes[0], let textRegion = data as? TextRegion {
-                    expect(textRegion.content).to(beginWith("<p>lorem"))
+                    expect(textRegion.content).to(beginWith("<p>aaaaa"))
                     expect(textRegion.content).to(endWith("&hellip;</p>"))
                 }
                 else {


### PR DESCRIPTION
This was resulting in extra blank lines.  The downside is that if a user posts a
*really really* long post using `<br>` instead of `<p>`, that post will be
truncated.  The character limit is long, though: 7500.

Also added the `Staging*` keys to travis.