### PR TITLE
Adds support for multiple debug servers

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,19 +15,28 @@ namespace :generate do
   task :keys do
     has_all_keys = true
     keys = [
-      ['StagingOauthKey', 'STAGING_CLIENT_KEY'],
-      ['StagingOauthSecret', 'STAGING_CLIENT_SECRET'],
-      ['StagingDomain', 'STAGING_DOMAIN'],
-      ['StagingHttpProtocol', 'STAGING_HTTP_PROTOCOL'],
-      ['StagingSegmentKey', 'STAGING_SEGMENT_KEY'],
       ['OauthKey', 'PROD_CLIENT_KEY'],
       ['OauthSecret', 'PROD_CLIENT_SECRET'],
-      ['TeamId', 'ELLO_TEAM_ID'],
       ['Domain', 'PROD_DOMAIN'],
-      ['HttpProtocol', 'PROD_HTTP_PROTOCOL'],
+      ['SegmentKey', 'PROD_SEGMENT_KEY'],
+
+      ['NinjaOauthKey', 'NINJA_CLIENT_KEY'],
+      ['NinjaOauthSecret', 'NINJA_CLIENT_SECRET'],
+      ['NinjaDomain', 'NINJA_DOMAIN'],
+
+      ['Stage1OauthKey', 'STAGE1_CLIENT_KEY'],
+      ['Stage1OauthSecret', 'STAGE1_CLIENT_SECRET'],
+      ['Stage1Domain', 'STAGE1_DOMAIN'],
+
+      ['Stage2OauthKey', 'STAGE2_CLIENT_KEY'],
+      ['Stage2OauthSecret', 'STAGE2_CLIENT_SECRET'],
+      ['Stage2Domain', 'STAGE2_DOMAIN'],
+
+      ['StagingSegmentKey', 'STAGING_SEGMENT_KEY'],
+
+      ['TeamId', 'ELLO_TEAM_ID'],
       ['SodiumChloride', 'INVITE_FRIENDS_SALT'],
       ['CrashlyticsKey', 'CRASHLYTICS_KEY'],
-      ['SegmentKey', 'PROD_SEGMENT_KEY'],
     ]
     keys.each do |name, env_name|
       has_all_keys = has_all_keys && check_env(env_name)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -18,8 +18,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        if GroupDefaults[DebugSettings.useStaging].bool == true {
-            APIKeys.shared = APIKeys.staging
+        if let debugServer = DebugServer.fromDefaults {
+            APIKeys.shared = debugServer.apiKeys
         }
 
         Keyboard.setup()

--- a/Sources/Controllers/App/AppViewController.swift
+++ b/Sources/Controllers/App/AppViewController.swift
@@ -811,7 +811,7 @@ extension AppViewController {
         #if DEBUG
             return true
         #else
-            return AuthToken().isStaff
+            return AuthToken().isStaff || DebugServer.fromDefaults != nil
         #endif
     }
 

--- a/Sources/Controllers/App/DebugController.swift
+++ b/Sources/Controllers/App/DebugController.swift
@@ -14,6 +14,7 @@ struct DebugSettings {
 enum DebugServer: String {
     static var fromDefaults: DebugServer? {
         guard
+            !AppSetup.sharedState.isTesting,
             let name = GroupDefaults[DebugSettings.useStaging].string,
             let server = DebugServer(rawValue: name)
         else { return nil }

--- a/Sources/Networking/APIKeys.swift
+++ b/Sources/Networking/APIKeys.swift
@@ -11,7 +11,6 @@ struct APIKeys {
     let key: String
     let secret: String
     let segmentKey: String
-    let httpProtocol: String
     let domain: String
 
     // MARK: Shared Keys
@@ -21,17 +20,31 @@ struct APIKeys {
             key: ElloKeys().oauthKey(),
             secret: ElloKeys().oauthSecret(),
             segmentKey: ElloKeys().segmentKey(),
-            httpProtocol: ElloKeys().httpProtocol(),
             domain: ElloKeys().domain()
             )
     }()
-    static let staging: APIKeys = {
+    static let ninja: APIKeys = {
         return APIKeys(
-            key: ElloKeys().stagingOauthKey(),
-            secret: ElloKeys().stagingOauthSecret(),
+            key: ElloKeys().ninjaOauthKey(),
+            secret: ElloKeys().ninjaOauthSecret(),
             segmentKey: ElloKeys().stagingSegmentKey(),
-            httpProtocol: ElloKeys().stagingHttpProtocol(),
-            domain: ElloKeys().stagingDomain()
+            domain: ElloKeys().ninjaDomain()
+            )
+    }()
+    static let stage1: APIKeys = {
+        return APIKeys(
+            key: ElloKeys().stage1OauthKey(),
+            secret: ElloKeys().stage1OauthSecret(),
+            segmentKey: ElloKeys().stagingSegmentKey(),
+            domain: ElloKeys().stage1Domain()
+            )
+    }()
+    static let stage2: APIKeys = {
+        return APIKeys(
+            key: ElloKeys().stage2OauthKey(),
+            secret: ElloKeys().stage2OauthSecret(),
+            segmentKey: ElloKeys().stagingSegmentKey(),
+            domain: ElloKeys().stage2Domain()
             )
     }()
 
@@ -39,11 +52,10 @@ struct APIKeys {
 
     // MARK: Initializers
 
-    init(key: String, secret: String, segmentKey: String, httpProtocol: String, domain: String) {
+    init(key: String, secret: String, segmentKey: String, domain: String) {
         self.key = key
         self.secret = secret
         self.segmentKey = segmentKey
-        self.httpProtocol = httpProtocol
         self.domain = domain
     }
 }

--- a/Sources/Networking/ElloURI.swift
+++ b/Sources/Networking/ElloURI.swift
@@ -127,7 +127,7 @@ enum ElloURI: String {
         }
     }
 
-    static var baseURL: String { return "\(APIKeys.shared.httpProtocol)://\(APIKeys.shared.domain)" }
+    static var baseURL: String { return APIKeys.shared.domain }
 
     // this is taken directly from app/models/user.rb
     static let usernameRegex = "([\\w\\-]+)"

--- a/Specs/Model/PostSpec.swift
+++ b/Specs/Model/PostSpec.swift
@@ -13,8 +13,7 @@ class PostSpec: QuickSpec {
         beforeEach {
             let testingKeys = APIKeys(
                 key: "", secret: "", segmentKey: "",
-                httpProtocol: "https",
-                domain: "ello.co"
+                domain: "https://ello.co"
                 )
             APIKeys.shared = testingKeys
         }

--- a/Specs/Model/Regions/AssetSpec.swift
+++ b/Specs/Model/Regions/AssetSpec.swift
@@ -154,8 +154,7 @@ class AssetSpec: QuickSpec {
                 beforeEach {
                     let testingKeys = APIKeys(
                         key: "", secret: "", segmentKey: "",
-                        httpProtocol: "https",
-                        domain: "ello.co"
+                        domain: "https://ello.co"
                     )
                     APIKeys.shared = testingKeys
                 }

--- a/Specs/Model/Regions/ImageAttachmentSpec.swift
+++ b/Specs/Model/Regions/ImageAttachmentSpec.swift
@@ -20,8 +20,7 @@ class AttachmentSpec: QuickSpec {
             beforeEach {
                 let testingKeys = APIKeys(
                     key: "", secret: "", segmentKey: "",
-                    httpProtocol: "https",
-                    domain: "ello.co"
+                    domain: "https://ello.co"
                     )
                 APIKeys.shared = testingKeys
             }

--- a/Specs/Networking/ElloURISpec.swift
+++ b/Specs/Networking/ElloURISpec.swift
@@ -20,8 +20,7 @@ class ElloURISpec: QuickSpec {
                 it("can be constructed with ello-staging and http") {
                     let testingKeys = APIKeys(
                         key: "", secret: "", segmentKey: "",
-                        httpProtocol: "http",
-                        domain: "ello-staging.herokuapp.com"
+                        domain: "http://ello-staging.herokuapp.com"
                         )
                     APIKeys.shared = testingKeys
                     expect(ElloURI.baseURL).to(equal("http://ello-staging.herokuapp.com"))
@@ -30,8 +29,7 @@ class ElloURISpec: QuickSpec {
                 it("can be constructed with ello.co and https") {
                     let testingKeys = APIKeys(
                         key: "", secret: "", segmentKey: "",
-                        httpProtocol: "https",
-                        domain: "ello.co"
+                        domain: "https://ello.co"
                         )
                     APIKeys.shared = testingKeys
                     expect(ElloURI.baseURL).to(equal("https://ello.co"))
@@ -80,8 +78,7 @@ class ElloURISpec: QuickSpec {
                 beforeEach {
                     let testingKeys = APIKeys(
                         key: "", secret: "", segmentKey: "",
-                        httpProtocol: "https",
-                        domain: "ello-staging.herokuapp.com"
+                        domain: "https://ello-staging.herokuapp.com"
                         )
                     APIKeys.shared = testingKeys
                 }


### PR DESCRIPTION
**N.B.** I removed the `httpProtocol` and `domain` pair in favor of a combined `domain` that includes the protocol.  This was easier than having these separate, esp. since they were *never used separately*.

Your .env file should now look like this:

    NINJA_CLIENT_KEY=[ninja key]
    NINJA_CLIENT_SECRET=[ninja secret]
    NINJA_DOMAIN=https://ninja

    STAGE1_CLIENT_KEY=[stage1 key]
    STAGE1_CLIENT_SECRET=[stage1 secret]
    STAGE1_DOMAIN=https://stage1

    STAGE2_CLIENT_KEY=[stage2 key]
    STAGE2_CLIENT_SECRET=[stage2 secret]
    STAGE2_DOMAIN=https://stage2

    # all stage servers
    STAGING_SEGMENT_KEY=[staging segment key]

    PROD_CLIENT_KEY=[prod key]
    PROD_CLIENT_SECRET=[prod secret]
    PROD_DOMAIN=https://ello.co
    PROD_SEGMENT_KEY=[prod segment key]

Instead of toggling a debug server on/off, the user is presented with an alert that lets you *choose* which server you want to use.  Then the app is force-crashed, and next time the app is launched the selected server will be used.

[Finishes #141335381](https://www.pivotaltracker.com/story/show/141335381)