### PR TITLE
Fix memory related crash on non-retina iPad

### DIFF
--- a/ShareExtension/ShareTrackerOverrides.swift
+++ b/ShareExtension/ShareTrackerOverrides.swift
@@ -29,3 +29,8 @@ class Window {
     static func isWide(_ width: Float) -> Bool { return false }
     static var width: Float { return 0 }
 }
+
+class DeviceScreen {
+    static var isRetina: Bool { return true }
+    static var scale: Float { return 2 }
+}

--- a/Sources/Extensions/ScreenExtensions.swift
+++ b/Sources/Extensions/ScreenExtensions.swift
@@ -43,3 +43,21 @@ class Window {
         }
     }
 }
+
+class DeviceScreen {
+    static var isRetina: Bool {
+        return scale > 1
+    }
+
+    fileprivate static var _scale: CGFloat?
+    static var scale: CGFloat {
+        get {
+            return DeviceScreen._scale ?? UIScreen.main.scale
+        }
+        set {
+            if AppSetup.sharedState.isTesting {
+                DeviceScreen._scale = newValue
+            }
+        }
+    }
+}

--- a/Sources/Model/Regions/Asset.swift
+++ b/Sources/Model/Regions/Asset.swift
@@ -89,20 +89,20 @@ final class Asset: JSONAble {
 
     var oneColumnAttachment: Attachment? {
         if video != nil { return video }
-        return Window.isWide(Window.width) ? xhdpi : hdpi
+        return Window.isWide(Window.width) && DeviceScreen.isRetina  ? xhdpi : hdpi
     }
 
     var oneColumnPreviewAttachment: Attachment? {
-        return Window.isWide(Window.width) ? xhdpi : hdpi
+        return Window.isWide(Window.width) && DeviceScreen.isRetina ? xhdpi : hdpi
     }
 
     var gridLayoutAttachment: Attachment? {
         if video != nil { return video }
-        return Window.isWide(Window.width) ? hdpi : mdpi
+        return Window.isWide(Window.width) && DeviceScreen.isRetina ? hdpi : mdpi
     }
 
     var gridLayoutPreviewAttachment: Attachment? {
-        return Window.isWide(Window.width) ? hdpi : mdpi
+        return Window.isWide(Window.width) && DeviceScreen.isRetina ? hdpi : mdpi
     }
 
     var hasVideo: Bool {

--- a/Specs/Model/Regions/AssetSpec.swift
+++ b/Specs/Model/Regions/AssetSpec.swift
@@ -50,15 +50,26 @@ class AssetSpec: QuickSpec {
                     expect(videoAsset.oneColumnAttachment) == video
                 }
 
-                it("defaults to hdpi when narrow") {
+                it("returns hdpi when narrow") {
                     expect(noVideoAsset.oneColumnAttachment) == hdpi
                 }
 
-                it("defaults to xhdpi when wide") {
+                it("returns xhdpi when wide") {
                     let tmp = Window.width
                     Window.width = 2000
                     expect(noVideoAsset.oneColumnAttachment) == xhdpi
                     Window.width = tmp
+                }
+
+                it("returns hdpi when wide on non-retina screen") {
+                    let tmpWidth = Window.width
+                    let tmpScale = DeviceScreen.scale
+                    Window.width = 2000
+                    DeviceScreen.scale = 1
+
+                    expect(noVideoAsset.oneColumnAttachment) == hdpi
+                    Window.width = tmpWidth
+                    DeviceScreen.scale = tmpScale
                 }
             }
 
@@ -68,11 +79,22 @@ class AssetSpec: QuickSpec {
                     expect(videoAsset.oneColumnPreviewAttachment) == hdpi
                 }
 
-                it("defaults to xhdpi when wide") {
+                it("returns xhdpi when wide") {
                     let tmp = Window.width
                     Window.width = 2000
                     expect(videoAsset.oneColumnPreviewAttachment) == xhdpi
                     Window.width = tmp
+                }
+
+                it("returns hdpi when wide on non-retina screen") {
+                    let tmpWidth = Window.width
+                    let tmpScale = DeviceScreen.scale
+                    Window.width = 2000
+                    DeviceScreen.scale = 1
+
+                    expect(noVideoAsset.oneColumnPreviewAttachment) == hdpi
+                    Window.width = tmpWidth
+                    DeviceScreen.scale = tmpScale
                 }
             }
 
@@ -82,14 +104,25 @@ class AssetSpec: QuickSpec {
                     expect(videoAsset.gridLayoutAttachment) == video
                 }
 
-                it("defaults to hdpi when wide") {
+                it("returns hdpi when wide") {
                     let tmp = Window.width
                     Window.width = 2000
                     expect(noVideoAsset.gridLayoutAttachment) == hdpi
                     Window.width = tmp
                 }
 
-                it("defaults to mdpi when not wide") {
+                it("returns mdpi when wide on non-retina screen") {
+                    let tmpWidth = Window.width
+                    let tmpScale = DeviceScreen.scale
+                    Window.width = 2000
+                    DeviceScreen.scale = 1
+
+                    expect(noVideoAsset.gridLayoutAttachment) == mdpi
+                    Window.width = tmpWidth
+                    DeviceScreen.scale = tmpScale
+                }
+
+                it("returns mdpi when not wide") {
                     expect(noVideoAsset.gridLayoutAttachment) == mdpi
                 }
             }
@@ -101,6 +134,17 @@ class AssetSpec: QuickSpec {
                     Window.width = 2000
                     expect(videoAsset.gridLayoutPreviewAttachment) == hdpi
                     Window.width = tmp
+                }
+
+                it("returns mdpi when wide on non-retina screen") {
+                    let tmpWidth = Window.width
+                    let tmpScale = DeviceScreen.scale
+                    Window.width = 2000
+                    DeviceScreen.scale = 1
+
+                    expect(noVideoAsset.gridLayoutPreviewAttachment) == mdpi
+                    Window.width = tmpWidth
+                    DeviceScreen.scale = tmpScale
                 }
 
                 it("returns mdpi when NOT wide") {


### PR DESCRIPTION
Non-retina iPads seem to crash at some point after loading a bunch of xhdpi images. Use hdpi instead of xhdpi on non-retina devices that are iPad width (>= 768).

[Fixes #141974207](https://www.pivotaltracker.com/story/show/141974207)
[Fixes #141973357](https://www.pivotaltracker.com/story/show/141973357)
[Fixes #141965649](https://www.pivotaltracker.com/story/show/141965649)
[Fixes #141965467](https://www.pivotaltracker.com/story/show/141965467)