### PR TITLE
Refactor interface image assignment

### DIFF
--- a/Sources/Controllers/Hire/HireScreen.swift
+++ b/Sources/Controllers/Hire/HireScreen.swift
@@ -101,7 +101,7 @@ class HireScreen: StreamableScreen {
         successView.alpha = 0
         successLabel.textColor = .black
         successLabel.font = UIFont.defaultFont(18)
-        successImage.image = InterfaceImage.validationOK.normalImage
+        successImage.interfaceImage = .validationOK
     }
 
     override func setText() {

--- a/Sources/Controllers/Notifications/NotificationCell.swift
+++ b/Sources/Controllers/Notifications/NotificationCell.swift
@@ -199,7 +199,7 @@ class NotificationCell: UICollectionViewCell, UIWebViewDelegate {
         titleTextView.textViewDelegate = self
 
         buyButtonImage.isHidden = true
-        buyButtonImage.image = InterfaceImage.buyButton.normalImage
+        buyButtonImage.interfaceImage = .buyButton
         buyButtonImage.frame.size = CGSize(width: Size.BuyButtonSize, height: Size.BuyButtonSize)
         buyButtonImage.backgroundColor = .greenD1()
         buyButtonImage.layer.cornerRadius = Size.BuyButtonSize / 2

--- a/Sources/Controllers/Onboarding/CreateProfileScreen.swift
+++ b/Sources/Controllers/Onboarding/CreateProfileScreen.swift
@@ -101,7 +101,7 @@ class CreateProfileScreen: Screen, CreateProfileScreenProtocol {
         avatarImageView.backgroundColor = .greyE5()
         avatarImageView.clipsToBounds = true
         avatarImageView.contentMode = .center
-        avatarImageView.image = InterfaceImage.elloGrayLineLogo.normalImage
+        avatarImageView.interfaceImage = .elloGrayLineLogo
         uploadAvatarPrompt.textAlignment = .center
         uploadAvatarPrompt.textColor = .greyA()
         uploadAvatarPrompt.font = UIFont.defaultFont(12)
@@ -344,7 +344,7 @@ extension CreateProfileScreen: UINavigationControllerDelegate, UIImagePickerCont
         }
         else if imageView == avatarImageView {
             imageView.contentMode = .center
-            imageView.image = InterfaceImage.elloGrayLineLogo.normalImage
+            imageView.interfaceImage = .elloGrayLineLogo
         }
         else if imageView == coverImageView {
             imageView.image = nil

--- a/Sources/Controllers/Stream/Cells/CategoryCardCell.swift
+++ b/Sources/Controllers/Stream/Cells/CategoryCardCell.swift
@@ -72,7 +72,7 @@ class CategoryCardCell: UICollectionViewCell {
         colorFillView.backgroundColor = .black
         colorFillView.alpha = 0.4
         selectedImageView.isHidden = true
-        selectedImageView.image = InterfaceImage.smallCheck.normalImage
+        selectedImageView.interfaceImage = .smallCheck
     }
 
     fileprivate func arrange() {

--- a/Sources/Controllers/Stream/Cells/StreamHeaderCell.swift
+++ b/Sources/Controllers/Stream/Cells/StreamHeaderCell.swift
@@ -176,7 +176,7 @@ class StreamHeaderCell: UICollectionViewCell {
         replyButton.setTitle("", for: .normal)
         replyButton.setImages(.reply)
 
-        repostIconView.image = InterfaceImage.repost.selectedImage
+        repostIconView.setInterfaceImage(.repost, style: .selected)
     }
 
     override func layoutSubviews() {

--- a/Sources/Controllers/Stream/Cells/StreamImageCell.swift
+++ b/Sources/Controllers/Stream/Cells/StreamImageCell.swift
@@ -68,7 +68,7 @@ class StreamImageCell: StreamRegionableCell {
     var isLargeImage: Bool {
         get { return !(largeImagePlayButton?.isHidden ?? true) }
         set {
-            largeImagePlayButton?.image = InterfaceImage.videoPlay.normalImage
+            largeImagePlayButton?.interfaceImage = .videoPlay
             largeImagePlayButton?.isHidden = !newValue
         }
     }
@@ -132,7 +132,7 @@ class StreamImageCell: StreamRegionableCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         if let playButton = largeImagePlayButton {
-            playButton.image = InterfaceImage.videoPlay.normalImage
+            playButton.interfaceImage = .videoPlay
         }
 
         if let buyButton = buyButton, let buyButtonGreen = buyButtonGreen {

--- a/Sources/Extensions/UIImageViewExtensions.swift
+++ b/Sources/Extensions/UIImageViewExtensions.swift
@@ -3,9 +3,13 @@
 //
 
 extension UIImageView {
+    var interfaceImage: InterfaceImage? {
+        get { return nil }
+        set { setInterfaceImage(newValue!, style: .normal) }
+    }
 
-    func setImage(_ interfaceImage: InterfaceImage, degree: Double) {
-        self.image = interfaceImage.normalImage
+    func setInterfaceImage(_ interfaceImage: InterfaceImage, style: InterfaceImage.Style, degree: Double = 0) {
+        self.image = interfaceImage.image(style)
         if degree != 0 {
             let radians = (degree * Double.pi) / 180.0
             self.transform = CGAffineTransform(rotationAngle: CGFloat(radians))

--- a/Sources/Views/NarrationView.swift
+++ b/Sources/Views/NarrationView.swift
@@ -34,7 +34,7 @@ class NarrationView: UIView {
     fileprivate let pointer: UIImageView = {
         let pointer = UIImageView()
         pointer.contentMode = .scaleAspectFit
-        pointer.image = InterfaceImage.narrationPointer.normalImage
+        pointer.interfaceImage = .narrationPointer
         return pointer
     }()
 


### PR DESCRIPTION
make assignment shorter, support `InterfaceImage.Style`

closer to how `UIButton` assigns images.

[Finishes #142860715](https://www.pivotaltracker.com/story/show/142860715)