### PR TITLE
Adds `More Posts` UI to Following

### DIFF
--- a/Ello.xcodeproj/project.pbxproj
+++ b/Ello.xcodeproj/project.pbxproj
@@ -796,6 +796,7 @@
 		1DF0B2D51E8D59DD001B9F97 /* ForgotPasswordResetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF0B2D11E8D59DD001B9F97 /* ForgotPasswordResetViewController.swift */; };
 		1DF0B2D91E8D679E001B9F97 /* ForgotPasswordEmailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF0B2D71E8D679E001B9F97 /* ForgotPasswordEmailScreen.swift */; };
 		1DF0B2DA1E8D679E001B9F97 /* ForgotPasswordResetScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF0B2D81E8D679E001B9F97 /* ForgotPasswordResetScreen.swift */; };
+		1DF0B2DE1E8EBACF001B9F97 /* NewPostsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF0B2DD1E8EBACE001B9F97 /* NewPostsButton.swift */; };
 		1DF233611A94FB060096DA65 /* CGRectExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF233601A94FB060096DA65 /* CGRectExtensions.swift */; };
 		1DF233641A9537590096DA65 /* CGRectSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF233631A9537590096DA65 /* CGRectSpec.swift */; };
 		1DF322421BD6F16C008203F3 /* DebugViewsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF322411BD6F16C008203F3 /* DebugViewsController.swift */; };
@@ -1777,6 +1778,7 @@
 		1DF0B2D11E8D59DD001B9F97 /* ForgotPasswordResetViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForgotPasswordResetViewController.swift; sourceTree = "<group>"; };
 		1DF0B2D71E8D679E001B9F97 /* ForgotPasswordEmailScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForgotPasswordEmailScreen.swift; sourceTree = "<group>"; };
 		1DF0B2D81E8D679E001B9F97 /* ForgotPasswordResetScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForgotPasswordResetScreen.swift; sourceTree = "<group>"; };
+		1DF0B2DD1E8EBACE001B9F97 /* NewPostsButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewPostsButton.swift; sourceTree = "<group>"; };
 		1DF2335B1A94005C0096DA65 /* Notification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
 		1DF233601A94FB060096DA65 /* CGRectExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGRectExtensions.swift; sourceTree = "<group>"; };
 		1DF233631A9537590096DA65 /* CGRectSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGRectSpec.swift; sourceTree = "<group>"; };
@@ -3144,6 +3146,7 @@
 				1289F3911AF1468B008A938C /* ImageLabelControl.swift */,
 				1D59EF841D5CFC480029C106 /* InterpolatedLoadingView.swift */,
 				1DF404091B150DB40073460B /* NarrationView.swift */,
+				1DF0B2DD1E8EBACE001B9F97 /* NewPostsButton.swift */,
 				F847BC231B0E1FE8006E5F3E /* NotificationBanner.swift */,
 				1DE3EC4B1D83245D00BDE16F /* OnePasswordButton.swift */,
 				12F717571A800D7C00A12A00 /* PulsingCircle.swift */,
@@ -5046,6 +5049,7 @@
 				1D066FF61B8BAF43002B303D /* OmnibarImageDownloadCell.swift in Sources */,
 				123375751DA6B8A80019CFAD /* ProfileHeaderCompactView.swift in Sources */,
 				1299D6A71ACEBE1000D47B35 /* UICollectionViewExtensions.swift in Sources */,
+				1DF0B2DE1E8EBACF001B9F97 /* NewPostsButton.swift in Sources */,
 				1D7152DA1D74C7FD005998FE /* OnboardingScreen.swift in Sources */,
 				124B48651DAEE3C60058D3F5 /* ProfileCategoriesProtocols.swift in Sources */,
 				1207C9911C73FEE000939ADB /* UserService.swift in Sources */,

--- a/Resources/GeneratedSVGs/arrow_normal.svg
+++ b/Resources/GeneratedSVGs/arrow_normal.svg
@@ -1,1 +1,5 @@
-<svg class="svg-arrow svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><g stroke-width="1.25" fill="none" stroke="#aaa"><polyline points="11,4 17,10 11,16"></polyline></g><g stroke-width="1.25" fill="none" stroke="#aaa"><line x1="17" x2="3" y1="10" y2="10"></line></g></svg>
+<svg class="svg-arrow svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+    <g stroke="#aaa" fill="none" stroke-width="1.25" transform="translate(10, 4.09)">
+        <polyline points="-4.75 4.75 0 0 4.75 4.75"></polyline>
+        <path d="M0,0 L0,11.81818181"></path></g>
+</svg>

--- a/Resources/GeneratedSVGs/arrow_selected.svg
+++ b/Resources/GeneratedSVGs/arrow_selected.svg
@@ -1,1 +1,5 @@
-<svg class="svg-arrow svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><g stroke-width="1.25" fill="none" stroke="#000"><polyline points="11,4 17,10 11,16"></polyline></g><g stroke-width="1.25" fill="none" stroke="#000"><line x1="17" x2="3" y1="10" y2="10"></line></g></svg>
+<svg class="svg-arrow svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+    <g stroke="#000" fill="none" stroke-width="1.25" transform="translate(10, 4.09)">
+        <polyline points="-4.75 4.75 0 0 4.75 4.75"></polyline>
+        <path d="M0,0 L0,11.81818181"></path></g>
+</svg>

--- a/Resources/GeneratedSVGs/arrow_white.svg
+++ b/Resources/GeneratedSVGs/arrow_white.svg
@@ -1,1 +1,5 @@
-<svg class="svg-arrow svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><g stroke-width="1.25" fill="none" stroke="#fff"><polyline points="11,4 17,10 11,16"></polyline></g><g stroke-width="1.25" fill="none" stroke="#fff"><line x1="17" x2="3" y1="10" y2="10"></line></g></svg>
+<svg class="svg-arrow svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+    <g stroke="#fff" fill="none" stroke-width="1.25" transform="translate(10, 4.09)">
+        <polyline points="-4.75 4.75 0 0 4.75 4.75"></polyline>
+        <path d="M0,0 L0,11.81818181"></path></g>
+</svg>

--- a/Sources/Controllers/App/DebugController.swift
+++ b/Sources/Controllers/App/DebugController.swift
@@ -166,12 +166,12 @@ class DebugController: UIViewController, UITableViewDataSource, UITableViewDeleg
         }
 
         addAction(name: "Show Following Dot") {
-            postNotification(NewContentNotifications.newFollowingContent, value: nil)
+            postNotification(NewContentNotifications.newFollowingContent, value: ())
             appController.closeTodoController()
         }
 
         addAction(name: "Show Notification Dot") {
-            postNotification(NewContentNotifications.newNotifications, value: nil)
+            postNotification(NewContentNotifications.newNotifications, value: ())
             appController.closeTodoController()
         }
 

--- a/Sources/Controllers/App/DebugController.swift
+++ b/Sources/Controllers/App/DebugController.swift
@@ -166,7 +166,7 @@ class DebugController: UIViewController, UITableViewDataSource, UITableViewDeleg
         }
 
         addAction(name: "Show Following Dot") {
-            postNotification(NewContentNotifications.newStreamContent, value: nil)
+            postNotification(NewContentNotifications.newFollowingContent, value: nil)
             appController.closeTodoController()
         }
 

--- a/Sources/Controllers/ElloTabBarController.swift
+++ b/Sources/Controllers/ElloTabBarController.swift
@@ -283,11 +283,11 @@ extension ElloTabBarController {
             self?.newContentService.stopPolling()
         }
 
-        newNotificationsObserver = NotificationObserver(notification: NewContentNotifications.newNotifications) { [weak self] _ in
+        newNotificationsObserver = NotificationObserver(notification: NewContentNotifications.newNotifications) { [weak self] in
             self?.newNotificationsAvailable = true
         }
 
-        newStreamContentObserver = NotificationObserver(notification: NewContentNotifications.newFollowingContent) { [weak self] _ in
+        newStreamContentObserver = NotificationObserver(notification: NewContentNotifications.newFollowingContent) { [weak self] in
             self?.followingDot?.isHidden = false
         }
 
@@ -338,10 +338,10 @@ extension ElloTabBarController: UITabBarDelegate {
                 }
 
                 if shouldReloadFollowingStream() {
-                    postNotification(NewContentNotifications.reloadFollowingContent, value: nil)
+                    postNotification(NewContentNotifications.reloadFollowingContent, value: ())
                 }
                 else if shouldReloadNotificationsStream() {
-                    postNotification(NewContentNotifications.reloadNotifications, value: nil)
+                    postNotification(NewContentNotifications.reloadNotifications, value: ())
                     self.newNotificationsAvailable = false
                 }
             }

--- a/Sources/Controllers/ElloTabBarController.swift
+++ b/Sources/Controllers/ElloTabBarController.swift
@@ -287,7 +287,7 @@ extension ElloTabBarController {
             self?.newNotificationsAvailable = true
         }
 
-        newStreamContentObserver = NotificationObserver(notification: NewContentNotifications.newStreamContent) { [weak self] _ in
+        newStreamContentObserver = NotificationObserver(notification: NewContentNotifications.newFollowingContent) { [weak self] _ in
             self?.followingDot?.isHidden = false
         }
 
@@ -338,7 +338,7 @@ extension ElloTabBarController: UITabBarDelegate {
                 }
 
                 if shouldReloadFollowingStream() {
-                    postNotification(NewContentNotifications.reloadStreamContent, value: nil)
+                    postNotification(NewContentNotifications.reloadFollowingContent, value: nil)
                 }
                 else if shouldReloadNotificationsStream() {
                     postNotification(NewContentNotifications.reloadNotifications, value: nil)

--- a/Sources/Controllers/Notifications/NotificationsViewController.swift
+++ b/Sources/Controllers/Notifications/NotificationsViewController.swift
@@ -204,8 +204,7 @@ private extension NotificationsViewController {
             self.respondToNotification(components)
         }
 
-        reloadNotificationsObserver = NotificationObserver(notification: NewContentNotifications.reloadNotifications) {
-            [weak self] _ in
+        reloadNotificationsObserver = NotificationObserver(notification: NewContentNotifications.reloadNotifications) { [weak self] in
             guard let `self` = self else { return }
             if self.navigationController?.childViewControllers.count == 1 {
                 self.reload(showSpinner: true)
@@ -215,8 +214,7 @@ private extension NotificationsViewController {
             }
         }
 
-        newAnnouncementsObserver = NotificationObserver(notification: NewContentNotifications.newAnnouncements) {
-            [weak self] _ in
+        newAnnouncementsObserver = NotificationObserver(notification: NewContentNotifications.newAnnouncements) { [weak self] in
             guard let `self` = self else { return }
             self.reloadAnnouncements()
         }

--- a/Sources/Controllers/Stream/FollowingViewController.swift
+++ b/Sources/Controllers/Stream/FollowingViewController.swift
@@ -34,6 +34,10 @@ class FollowingViewController: StreamableViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        removeNotificationObservers()
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
@@ -44,6 +48,8 @@ class FollowingViewController: StreamableViewController {
         streamViewController.streamKind = .following
         ElloHUD.showLoadingHudInView(streamViewController.view)
         streamViewController.loadInitialPage()
+
+        addNotificationObservers()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -58,7 +64,7 @@ class FollowingViewController: StreamableViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        removeNotificationObservers()
+        removeTemporaryNotificationObservers()
     }
 
     override func viewForStream() -> UIView {

--- a/Sources/Controllers/Stream/FollowingViewController.swift
+++ b/Sources/Controllers/Stream/FollowingViewController.swift
@@ -127,7 +127,7 @@ class FollowingViewController: StreamableViewController {
     func loadNewPosts() {
         let scrollView = streamViewController.collectionView
         scrollView.setContentOffset(CGPoint(x: 0, y: -scrollView.contentInset.top), animated: true)
-        postNotification(NewContentNotifications.reloadFollowingContent, value: nil)
+        postNotification(NewContentNotifications.reloadFollowingContent, value: ())
 
         animate {
             self.newPostsButton.alpha = 0
@@ -161,7 +161,7 @@ private extension FollowingViewController {
     }
 
     func addTemporaryNotificationObservers() {
-        reloadFollowingContentObserver = NotificationObserver(notification: NewContentNotifications.reloadFollowingContent) { [weak self] _ in
+        reloadFollowingContentObserver = NotificationObserver(notification: NewContentNotifications.reloadFollowingContent) { [weak self] in
             guard let `self` = self else { return }
 
             ElloHUD.showLoadingHudInView(self.streamViewController.view)
@@ -174,7 +174,7 @@ private extension FollowingViewController {
     }
 
     func addNotificationObservers() {
-        newFollowingContentObserver = NotificationObserver(notification: NewContentNotifications.newFollowingContent) { [weak self] _ in
+        newFollowingContentObserver = NotificationObserver(notification: NewContentNotifications.newFollowingContent) { [weak self] in
             guard let `self` = self else { return }
 
             animate {

--- a/Sources/Controllers/Stream/FollowingViewController.swift
+++ b/Sources/Controllers/Stream/FollowingViewController.swift
@@ -16,9 +16,10 @@ class FollowingViewController: StreamableViewController {
 
     var navigationBar: ElloNavigationBar!
     fileprivate var loggedPromptEventForThisSession = false
-    fileprivate var reloadStreamContentObserver: NotificationObserver?
+    fileprivate var reloadFollowingContentObserver: NotificationObserver?
     fileprivate var appBackgroundObserver: NotificationObserver?
     fileprivate var appForegroundObserver: NotificationObserver?
+    fileprivate var newFollowingContentObserver: NotificationObserver?
 
     override var tabBarItem: UITabBarItem? {
         get { return UITabBarItem.item(.following, insets: ElloTab.following.insets) }
@@ -130,7 +131,7 @@ private extension FollowingViewController {
     }
 
     func addTemporaryNotificationObservers() {
-        reloadStreamContentObserver = NotificationObserver(notification: NewContentNotifications.reloadStreamContent) { [weak self] _ in
+        reloadFollowingContentObserver = NotificationObserver(notification: NewContentNotifications.reloadFollowingContent) { [weak self] _ in
             guard let `self` = self else { return }
 
             ElloHUD.showLoadingHudInView(self.streamViewController.view)
@@ -139,16 +140,20 @@ private extension FollowingViewController {
     }
 
     func removeTemporaryNotificationObservers() {
-        reloadStreamContentObserver?.removeObserver()
+        reloadFollowingContentObserver?.removeObserver()
     }
 
     func addNotificationObservers() {
+        newFollowingContentObserver = NotificationObserver(notification: NewContentNotifications.newFollowingContent) { [weak self] _ in
+        }
+
         appBackgroundObserver = NotificationObserver(notification: Application.Notifications.DidEnterBackground) { [weak self] _ in
             self?.loggedPromptEventForThisSession = false
         }
     }
 
     func removeNotificationObservers() {
+        newFollowingContentObserver?.removeObserver()
         appBackgroundObserver?.removeObserver()
     }
 }

--- a/Sources/Controllers/Stream/StreamKind.swift
+++ b/Sources/Controllers/Stream/StreamKind.swift
@@ -56,8 +56,16 @@ enum StreamKind {
         }
     }
 
-    var lastViewedCreatedAtKey: String {
-        return self.cacheKey + "_createdAt"
+    var lastViewedCreatedAtKey: String? {
+        switch self {
+        case .announcements: return "Announcements_createdAt"
+        case let .discover(type): return "Discover_\(type)_createdAt"
+        case let .category(slug): return "Category_\(slug)_createdAt"
+        case .following: return "Following_createdAt"
+        case .notifications: return "Notifications_createdAt"
+        default:
+            return nil
+        }
     }
 
     var columnSpacing: CGFloat {

--- a/Sources/Networking/NewContentService.swift
+++ b/Sources/Networking/NewContentService.swift
@@ -8,8 +8,8 @@ import SwiftyUserDefaults
 struct NewContentNotifications {
     static let newAnnouncements = TypedNotification<Void?>(name: "NewAnnouncementsNotification")
     static let newNotifications = TypedNotification<Void?>(name: "NewNotificationsNotification")
-    static let newStreamContent = TypedNotification<Void?>(name: "NewStreamContentNotification")
-    static let reloadStreamContent = TypedNotification<Void?>(name: "ReloadStreamContentNotification")
+    static let newFollowingContent = TypedNotification<Void?>(name: "NewFollowingContentNotification")
+    static let reloadFollowingContent = TypedNotification<Void?>(name: "ReloadFollowingContentNotification")
     static let reloadNotifications = TypedNotification<Void?>(name: "ReloadNotificationsNotification")
 }
 
@@ -38,17 +38,18 @@ extension NewContentService {
         stopPolling()
         let (restart, done) = afterN(restartPolling)
         checkForNewNotifications(restart())
-        checkForNewStreamContent(restart())
+        checkForNewFollowingContent(restart())
         done()
     }
 
     func updateCreatedAt(_ jsonables: [JSONAble], streamKind: StreamKind) {
+        guard let storedKey = streamKind.lastViewedCreatedAtKey else { return }
+
         let old = Date(timeIntervalSince1970: 0)
         let new = newestDate(jsonables)
-        let storedKey = streamKind.lastViewedCreatedAtKey
         let storedDate = GroupDefaults[storedKey].date ?? old
         let mostRecent = new > storedDate ? new : storedDate
-        GroupDefaults[streamKind.lastViewedCreatedAtKey] = mostRecent
+        GroupDefaults[storedKey] = mostRecent
     }
 }
 
@@ -72,7 +73,7 @@ private extension NewContentService {
     }
 
     func checkForNewNotifications(_ done: @escaping BasicBlock = {}) {
-        let storedKey = StreamKind.notifications(category: nil).lastViewedCreatedAtKey
+        let storedKey = StreamKind.notifications(category: nil).lastViewedCreatedAtKey!
         let storedDate = GroupDefaults[storedKey].date
 
         ElloProvider.shared.elloRequest(
@@ -88,7 +89,7 @@ private extension NewContentService {
     }
 
     func checkForNewAnnouncements(_ done: @escaping BasicBlock = {}) {
-        let storedKey = StreamKind.announcements.lastViewedCreatedAtKey
+        let storedKey = StreamKind.announcements.lastViewedCreatedAtKey!
         let storedDate = GroupDefaults[storedKey].date
 
          ElloProvider.shared.elloRequest(
@@ -103,19 +104,19 @@ private extension NewContentService {
              failure: { _ in done() })
     }
 
-    func checkForNewStreamContent(_ done: @escaping BasicBlock = {}) {
-        let storedKey = StreamKind.following.lastViewedCreatedAtKey
+    func checkForNewFollowingContent(_ done: @escaping BasicBlock = {}) {
+        let storedKey = StreamKind.following.lastViewedCreatedAtKey!
         let storedDate = GroupDefaults[storedKey].date
 
         ElloProvider.shared.elloRequest(
             ElloAPI.followingNewContent(createdAt: storedDate),
             success: { (_, responseConfig) in
                 if let lastModified = responseConfig.lastModified {
-                    GroupDefaults[StreamKind.following.lastViewedCreatedAtKey] = lastModified.toDate(HTTPDateFormatter)
+                    GroupDefaults[storedKey] = lastModified.toDate(HTTPDateFormatter)
                 }
 
                 if let statusCode = responseConfig.statusCode, statusCode == 204 {
-                    postNotification(NewContentNotifications.newStreamContent, value: nil)
+                    postNotification(NewContentNotifications.newFollowingContent, value: nil)
                 }
 
                 done()

--- a/Sources/Networking/NewContentService.swift
+++ b/Sources/Networking/NewContentService.swift
@@ -6,11 +6,11 @@ import SwiftyUserDefaults
 
 
 struct NewContentNotifications {
-    static let newAnnouncements = TypedNotification<Void?>(name: "NewAnnouncementsNotification")
-    static let newNotifications = TypedNotification<Void?>(name: "NewNotificationsNotification")
-    static let newFollowingContent = TypedNotification<Void?>(name: "NewFollowingContentNotification")
-    static let reloadFollowingContent = TypedNotification<Void?>(name: "ReloadFollowingContentNotification")
-    static let reloadNotifications = TypedNotification<Void?>(name: "ReloadNotificationsNotification")
+    static let newAnnouncements = TypedNotification<()>(name: "NewAnnouncementsNotification")
+    static let newNotifications = TypedNotification<()>(name: "NewNotificationsNotification")
+    static let newFollowingContent = TypedNotification<()>(name: "NewFollowingContentNotification")
+    static let reloadFollowingContent = TypedNotification<()>(name: "ReloadFollowingContentNotification")
+    static let reloadNotifications = TypedNotification<()>(name: "ReloadNotificationsNotification")
 }
 
 class NewContentService {
@@ -80,7 +80,7 @@ private extension NewContentService {
             ElloAPI.notificationsNewContent(createdAt: storedDate),
             success: { (_, responseConfig) in
                 if let statusCode = responseConfig.statusCode, statusCode == 204 {
-                    postNotification(NewContentNotifications.newNotifications, value: nil)
+                    postNotification(NewContentNotifications.newNotifications, value: ())
                 }
 
                 done()
@@ -96,7 +96,7 @@ private extension NewContentService {
              ElloAPI.announcementsNewContent(createdAt: storedDate),
              success: { (_, responseConfig) in
                  if let statusCode = responseConfig.statusCode, statusCode == 204 {
-                     postNotification(NewContentNotifications.newAnnouncements, value: nil)
+                     postNotification(NewContentNotifications.newAnnouncements, value: ())
                  }
 
                  done()
@@ -116,7 +116,7 @@ private extension NewContentService {
                 }
 
                 if let statusCode = responseConfig.statusCode, statusCode == 204 {
-                    postNotification(NewContentNotifications.newFollowingContent, value: nil)
+                    postNotification(NewContentNotifications.newFollowingContent, value: ())
                 }
 
                 done()

--- a/Sources/Utilities/AppDefaults.swift
+++ b/Sources/Utilities/AppDefaults.swift
@@ -6,9 +6,9 @@ extension UserDefaults {
     func resetOnLogout() {
         let groupDefaultResetKeys = [
             "ElloImageUploadQuality",
-            StreamKind.notifications(category: nil).lastViewedCreatedAtKey,
-            StreamKind.announcements.lastViewedCreatedAtKey,
-            StreamKind.following.lastViewedCreatedAtKey,
+            StreamKind.notifications(category: nil).lastViewedCreatedAtKey!,
+            StreamKind.announcements.lastViewedCreatedAtKey!,
+            StreamKind.following.lastViewedCreatedAtKey!,
         ]
         for key in groupDefaultResetKeys {
             self[key] = nil

--- a/Sources/Utilities/InterfaceString.swift
+++ b/Sources/Utilities/InterfaceString.swift
@@ -33,6 +33,7 @@ struct InterfaceString {
 
     struct Following {
         static let Title: String = NSLocalizedString("Following", comment: "Following title")
+        static let NewPosts: String = NSLocalizedString("New Posts", comment: "New posts title")
         static let CurrentUserNoResultsTitle: String = NSLocalizedString("You aren't following anyone yet!", comment: "Current user no following results title")
         static let CurrentUserNoResultsBody: String = NSLocalizedString("Ello is way more rad when you're following lots of people.\n\nUse Discover to find people you're interested in, and to find or invite your contacts.\nYou can also use Search (upper right) to look for new and excellent people!", comment: "Current user No following results body.")
         static let NoResultsTitle: String = NSLocalizedString("This person isn't following anyone yet!", comment: "Non-current user followoing no results title")

--- a/Sources/Views/NewPostsButton.swift
+++ b/Sources/Views/NewPostsButton.swift
@@ -1,0 +1,83 @@
+////
+///  NewPostsButton.swift
+//
+
+import SnapKit
+
+
+class NewPostsButton: UIControl {
+    struct Size {
+        static let top: CGFloat = 45
+        static let sideMargin: CGFloat = 15
+        static let innerMargin: CGFloat = 7
+        static let height: CGFloat = 35
+    }
+
+    let bg = UIImageView()
+    let arrow = UIImageView()
+    let label = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setText()
+        style()
+        arrange()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setText() {
+        arrow.setInterfaceImage(.arrow, style: .white)
+        label.text = InterfaceString.Following.NewPosts
+    }
+
+    private func style() {
+        label.font = .defaultFont(16)
+        label.textColor = .white
+        bg.alpha = 0.8
+        bg.backgroundColor = .black
+        bg.clipsToBounds = true
+    }
+
+    private func arrange() {
+        addSubview(bg)
+        addSubview(arrow)
+        addSubview(label)
+
+        bg.snp.makeConstraints { make in
+            make.edges.equalTo(self)
+        }
+
+        arrow.snp.makeConstraints { make in
+            make.centerY.equalTo(self)
+            make.leading.equalTo(self.snp.leading).offset(Size.sideMargin)
+        }
+
+        label.snp.makeConstraints { make in
+            make.centerY.equalTo(self)
+            make.leading.equalTo(arrow.snp.trailing).offset(Size.innerMargin)
+        }
+    }
+
+    override var intrinsicContentSize: CGSize {
+        guard
+            arrow.intrinsicContentSize.width != UIViewNoIntrinsicMetric,
+            label.intrinsicContentSize.width != UIViewNoIntrinsicMetric
+        else { return super.intrinsicContentSize }
+
+        var width = 2 * Size.sideMargin + Size.innerMargin
+        width += arrow.intrinsicContentSize.width
+        width += label.intrinsicContentSize.width
+        return CGSize(width: width, height: Size.height)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        bg.layer.cornerRadius = Size.height / 2
+    }
+
+}

--- a/Specs/Controllers/ElloTabBarControllerSpec.swift
+++ b/Specs/Controllers/ElloTabBarControllerSpec.swift
@@ -146,8 +146,7 @@ class ElloTabBarControllerSpec: QuickSpec {
                             showController(subject)
                             var reloadPosted = false
                             subject.followingDot?.isHidden = false
-                            _ = NotificationObserver(notification: NewContentNotifications.reloadStreamContent) {
-                                _ in
+                            _ = NotificationObserver(notification: NewContentNotifications.reloadFollowingContent) {
                                 reloadPosted = true
                             }
                             let vc = child3.topViewController
@@ -170,7 +169,7 @@ class ElloTabBarControllerSpec: QuickSpec {
                 var notificationsItem: UITabBarItem!
 
                 beforeEach {
-                    responder = NotificationObserver(notification: NewContentNotifications.reloadNotifications) { _ in
+                    responder = NotificationObserver(notification: NewContentNotifications.reloadNotifications) {
                         responded = true
                     }
                     subject = ElloTabBarController()

--- a/Specs/Controllers/Notifications/NotificationsViewControllerSpec.swift
+++ b/Specs/Controllers/Notifications/NotificationsViewControllerSpec.swift
@@ -47,7 +47,7 @@ class NotificationsViewControllerSpec: QuickSpec {
                     let navigationController = UINavigationController(rootViewController: subject)
                     showController(navigationController)
                     subject.hasNewContent = true
-                    postNotification(NewContentNotifications.reloadNotifications, value: nil)
+                    postNotification(NewContentNotifications.reloadNotifications, value: ())
                     expect(subject.hasNewContent) == false
                 }
             }

--- a/Specs/Controllers/Stream/FollowingViewControllerSpec.swift
+++ b/Specs/Controllers/Stream/FollowingViewControllerSpec.swift
@@ -34,6 +34,20 @@ class FollowingViewControllerSpec: QuickSpec {
                 expect(item?.leftBarButtonItems?.count) == 1
                 expect(item?.rightBarButtonItems?.count) == 2
             }
+
+            it("shows the more posts button when new content is available") {
+                subject.newPostsButton.alpha = 0
+                postNotification(NewContentNotifications.newFollowingContent, value: ())
+                expect(subject.newPostsButton.alpha) == 1
+            }
+
+            it("hide the more posts button after scrolling") {
+                subject.newPostsButton.alpha = 1
+                let scrollView = subject.streamViewController.collectionView
+                scrollView.contentOffset = .zero
+                subject.streamViewDidScroll(scrollView: scrollView)
+                expect(subject.newPostsButton.alpha) == 0
+            }
         }
     }
 }

--- a/Specs/Controllers/Stream/StreamKindSpec.swift
+++ b/Specs/Controllers/Stream/StreamKindSpec.swift
@@ -49,16 +49,16 @@ class StreamKindSpec: QuickSpec {
             describe("lastViewedCreatedAtKey") {
 
                 it("is correct for all cases") {
-                    expect(StreamKind.discover(type: .featured).lastViewedCreatedAtKey) == "CategoryPosts_createdAt"
-                    expect(StreamKind.category(slug: "art").lastViewedCreatedAtKey) == "CategoryPosts_createdAt"
+                    expect(StreamKind.discover(type: .featured).lastViewedCreatedAtKey) == "Discover_featured_createdAt"
+                    expect(StreamKind.category(slug: "art").lastViewedCreatedAtKey) == "Category_art_createdAt"
                     expect(StreamKind.following.lastViewedCreatedAtKey) == "Following_createdAt"
                     expect(StreamKind.notifications(category: "").lastViewedCreatedAtKey) == "Notifications_createdAt"
-                    expect(StreamKind.postDetail(postParam: "param").lastViewedCreatedAtKey) == "PostDetail_createdAt"
-                    expect(StreamKind.currentUserStream.lastViewedCreatedAtKey) == "Profile_createdAt"
-                    expect(StreamKind.simpleStream(endpoint: ElloAPI.searchForPosts(terms: "meat"), title: "meat").lastViewedCreatedAtKey) == "SearchForPosts_createdAt"
-                    expect(StreamKind.simpleStream(endpoint: ElloAPI.searchForUsers(terms: "meat"), title: "meat").lastViewedCreatedAtKey) == "SimpleStream.meat_createdAt"
-                    expect(StreamKind.unknown.lastViewedCreatedAtKey) == "unknown_createdAt"
-                    expect(StreamKind.userStream(userParam: "NA").lastViewedCreatedAtKey) == "UserStream_createdAt"
+                    expect(StreamKind.postDetail(postParam: "param").lastViewedCreatedAtKey).to(beNil())
+                    expect(StreamKind.currentUserStream.lastViewedCreatedAtKey).to(beNil())
+                    expect(StreamKind.simpleStream(endpoint: ElloAPI.searchForPosts(terms: "meat"), title: "meat").lastViewedCreatedAtKey).to(beNil())
+                    expect(StreamKind.simpleStream(endpoint: ElloAPI.searchForUsers(terms: "meat"), title: "meat").lastViewedCreatedAtKey).to(beNil())
+                    expect(StreamKind.unknown.lastViewedCreatedAtKey).to(beNil())
+                    expect(StreamKind.userStream(userParam: "NA").lastViewedCreatedAtKey).to(beNil())
                 }
             }
 

--- a/Specs/Networking/NewContentServiceSpec.swift
+++ b/Specs/Networking/NewContentServiceSpec.swift
@@ -34,37 +34,36 @@ class NewContentServiceSpec: QuickSpec {
                 let jsonables = [post, post2, post3]
 
                 beforeEach {
-                    GroupDefaults[streamKind.lastViewedCreatedAtKey] = nil
+                    GroupDefaults[streamKind.lastViewedCreatedAtKey!] = nil
                 }
-
 
                 context("no existing date stored") {
 
                     it("stores the created_at of the most recent jsonable") {
-                        GroupDefaults[streamKind.lastViewedCreatedAtKey] = nil
+                        GroupDefaults[streamKind.lastViewedCreatedAtKey!] = nil
                         subject.updateCreatedAt(jsonables, streamKind: streamKind)
 
-                        expect(GroupDefaults[streamKind.lastViewedCreatedAtKey].date) == mar_01_2015
+                        expect(GroupDefaults[streamKind.lastViewedCreatedAtKey!].date) == mar_01_2015
                     }
                 }
 
                 context("older existing date stored") {
 
                     it("stores the created_at of the most recent jsonable") {
-                        GroupDefaults[streamKind.lastViewedCreatedAtKey] = sep_30_1978
+                        GroupDefaults[streamKind.lastViewedCreatedAtKey!] = sep_30_1978
                         subject.updateCreatedAt(jsonables, streamKind: streamKind)
 
-                        expect(GroupDefaults[streamKind.lastViewedCreatedAtKey].date) == mar_01_2015
+                        expect(GroupDefaults[streamKind.lastViewedCreatedAtKey!].date) == mar_01_2015
                     }
                 }
 
                 context("newer existing date stored") {
 
                     it("keeps the existing date") {
-                        GroupDefaults[streamKind.lastViewedCreatedAtKey] = apr_01_2015
+                        GroupDefaults[streamKind.lastViewedCreatedAtKey!] = apr_01_2015
                         subject.updateCreatedAt(jsonables, streamKind: streamKind)
 
-                        expect(GroupDefaults[streamKind.lastViewedCreatedAtKey].date) == apr_01_2015
+                        expect(GroupDefaults[streamKind.lastViewedCreatedAtKey!].date) == apr_01_2015
                     }
                 }
 
@@ -77,11 +76,11 @@ class NewContentServiceSpec: QuickSpec {
                         let jsonables = [user, user2, user3]
                         let old = Date(timeIntervalSince1970: 0)
 
-                        GroupDefaults[streamKind.lastViewedCreatedAtKey] = nil
+                        GroupDefaults[streamKind.lastViewedCreatedAtKey!] = nil
 
                         subject.updateCreatedAt(jsonables, streamKind: streamKind)
 
-                        expect(GroupDefaults[streamKind.lastViewedCreatedAtKey].date) == old
+                        expect(GroupDefaults[streamKind.lastViewedCreatedAtKey!].date) == old
                     }
                 }
             }

--- a/Specs/Utilities/GroupDefaultsSpec.swift
+++ b/Specs/Utilities/GroupDefaultsSpec.swift
@@ -13,18 +13,18 @@ class GroupDefaultsSpec: QuickSpec {
             context("resetOnLogout") {
                 beforeEach {
                     GroupDefaults["ElloImageUploadQuality"] = 0.25
-                    GroupDefaults[StreamKind.notifications(category: nil).lastViewedCreatedAtKey] = Date()
-                    GroupDefaults[StreamKind.announcements.lastViewedCreatedAtKey] = Date()
-                    GroupDefaults[StreamKind.following.lastViewedCreatedAtKey] = Date()
+                    GroupDefaults[StreamKind.notifications(category: nil).lastViewedCreatedAtKey!] = Date()
+                    GroupDefaults[StreamKind.announcements.lastViewedCreatedAtKey!] = Date()
+                    GroupDefaults[StreamKind.following.lastViewedCreatedAtKey!] = Date()
                     GroupDefaults[ElloTab.discover.narrationDefaultKey] = true
                     GroupDefaults.resetOnLogout()
                 }
 
                 let expectations: [(String, Bool)] = [
                     ("ElloImageUploadQuality", true),
-                    (StreamKind.notifications(category: nil).lastViewedCreatedAtKey, true),
-                    (StreamKind.announcements.lastViewedCreatedAtKey, true),
-                    (StreamKind.following.lastViewedCreatedAtKey, true),
+                    (StreamKind.notifications(category: nil).lastViewedCreatedAtKey!, true),
+                    (StreamKind.announcements.lastViewedCreatedAtKey!, true),
+                    (StreamKind.following.lastViewedCreatedAtKey!, true),
                     (ElloTab.discover.narrationDefaultKey, false),
                 ]
                 for (key, isNil) in expectations {


### PR DESCRIPTION
- added `NewPostsButton` class, updated `arrow.svg` to match comps (pulled in from Sketch, basically).
- shows on `newFollowingContent` notification
- hides on scroll-to-top
- tapping the button reloads `FollowingViewController`

Unrelated refactors:

- updated controllers and views to use `interfaceImage` setter (dunno why this wasn't in #386, I thought I had pulled these changes into that PR)
- `NewContentNotifications` use `()` instead of `Void?` as their value (removed `_ in` from listener blocks)
- fixed the notification listeners in `FollowingViewController`, they were not all being turned on and off.
- refactored `lastViewedCreatedAtKey` to be optional, and unique on a per-discover-endpoint basis (rather than based on `cacheKey`)

[Finishes #141638127](https://www.pivotaltracker.com/story/show/141638127)