### PR TITLE
Fix tracking on related posts

### DIFF
--- a/Sources/Controllers/Stream/Cells/StreamCreateCommentCell.swift
+++ b/Sources/Controllers/Stream/Cells/StreamCreateCommentCell.swift
@@ -180,17 +180,13 @@ class StreamCreateCommentCell: UICollectionViewCell {
     }
 
     func replyAllTapped() {
-        guard let indexPath = indexPath else { return }
-
         let responder = target(forAction: #selector(PostbarResponder.replyToAllButtonTapped(_:)), withSender: self) as? PostbarResponder
-        responder?.replyToAllButtonTapped(indexPath)
+        responder?.replyToAllButtonTapped(self)
     }
 
     func watchTapped() {
-        guard let indexPath = indexPath else { return }
-
-        let responder = target(forAction: #selector(PostbarResponder.watchPostTapped(_:cell:indexPath:)), withSender: self) as? PostbarResponder
-        responder?.watchPostTapped(!watching, cell: self, indexPath: indexPath)
+        let responder = target(forAction: #selector(PostbarResponder.watchPostTapped(_:cell:)), withSender: self) as? PostbarResponder
+        responder?.watchPostTapped(!watching, cell: self)
     }
 
 }

--- a/Sources/Controllers/Stream/Cells/StreamFooterCell.swift
+++ b/Sources/Controllers/Stream/Cells/StreamFooterCell.swift
@@ -176,10 +176,8 @@ class StreamFooterCell: UICollectionViewCell {
 // MARK: - IBActions
 
     @IBAction func viewsButtonTapped() {
-        guard let indexPath = indexPath else { return }
-
         let responder = target(forAction: #selector(PostbarResponder.viewsButtonTapped(_:)), withSender: self) as? PostbarResponder
-        responder?.viewsButtonTapped(indexPath)
+        responder?.viewsButtonTapped(self)
     }
 
     @IBAction func commentsButtonTapped() {
@@ -196,24 +194,18 @@ class StreamFooterCell: UICollectionViewCell {
     }
 
     @IBAction func lovesButtonTapped() {
-        guard let indexPath = indexPath else { return }
-
-        let responder = target(forAction: #selector(PostbarResponder.lovesButtonTapped(_:indexPath:)), withSender: self) as? PostbarResponder
-        responder?.lovesButtonTapped(self, indexPath: indexPath)
+        let responder = target(forAction: #selector(PostbarResponder.lovesButtonTapped(_:)), withSender: self) as? PostbarResponder
+        responder?.lovesButtonTapped(self)
     }
 
     @IBAction func repostButtonTapped() {
-        guard let indexPath = indexPath else { return }
-
         let responder = target(forAction: #selector(PostbarResponder.repostButtonTapped(_:)), withSender: self) as? PostbarResponder
-        responder?.repostButtonTapped(indexPath)
+        responder?.repostButtonTapped(self)
     }
 
     @IBAction func shareButtonTapped() {
-        guard let indexPath = indexPath else { return }
-
         let responder = target(forAction: #selector(PostbarResponder.shareButtonTapped(_:sourceView:)), withSender: self) as? PostbarResponder
-        responder?.shareButtonTapped(indexPath, sourceView: shareControl)
+        responder?.shareButtonTapped(self, sourceView: shareControl)
     }
 
     @IBAction func replyButtonTapped() {

--- a/Sources/Controllers/Stream/Cells/StreamHeaderCell.swift
+++ b/Sources/Controllers/Stream/Cells/StreamHeaderCell.swift
@@ -411,10 +411,8 @@ class StreamHeaderCell: UICollectionViewCell {
 // MARK: - IBActions
 
     func postTapped(_ recognizer: UITapGestureRecognizer) {
-        guard let indexPath = indexPath else { return }
-
         let responder = target(forAction: #selector(PostbarResponder.viewsButtonTapped(_:)), withSender: self) as? PostbarResponder
-        responder?.viewsButtonTapped(indexPath)
+        responder?.viewsButtonTapped(self)
     }
 
     @IBAction func userTapped(_ sender: AvatarButton) {
@@ -438,31 +436,23 @@ class StreamHeaderCell: UICollectionViewCell {
     }
 
     @IBAction func flagButtonTapped(_ sender: StreamFooterButton) {
-        guard let indexPath = indexPath else { return }
-
         let responder = target(forAction: #selector(PostbarResponder.flagCommentButtonTapped(_:)), withSender: self) as? PostbarResponder
-        responder?.flagCommentButtonTapped(indexPath)
+        responder?.flagCommentButtonTapped(self)
     }
 
     @IBAction func replyButtonTapped(_ sender: StreamFooterButton) {
-        guard let indexPath = indexPath else { return }
-
         let responder = target(forAction: #selector(PostbarResponder.replyToCommentButtonTapped(_:)), withSender: self) as? PostbarResponder
-        responder?.replyToCommentButtonTapped(indexPath)
+        responder?.replyToCommentButtonTapped(self)
     }
 
     @IBAction func deleteButtonTapped(_ sender: StreamFooterButton) {
-        guard let indexPath = indexPath else { return }
-
         let responder = target(forAction: #selector(PostbarResponder.deleteCommentButtonTapped(_:)), withSender: self) as? PostbarResponder
-        responder?.deleteCommentButtonTapped(indexPath)
+        responder?.deleteCommentButtonTapped(self)
     }
 
     @IBAction func editButtonTapped(_ sender: StreamFooterButton) {
-        guard let indexPath = indexPath else { return }
-
         let responder = target(forAction: #selector(PostbarResponder.editCommentButtonTapped(_:)), withSender: self) as? PostbarResponder
-        responder?.editCommentButtonTapped(indexPath)
+        responder?.editCommentButtonTapped(self)
     }
 
     @IBAction func chevronButtonTapped(_ sender: StreamFooterButton) {

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -22,6 +22,11 @@ protocol StreamImageCellResponder: class {
 }
 
 @objc
+protocol StreamPostTappedResponder: class {
+    func postTappedInStream(_ cell: UICollectionViewCell)
+}
+
+@objc
 protocol StreamEditingResponder: class {
     func cellDoubleTapped(cell: UICollectionViewCell, location: CGPoint)
     func cellLongPressed(cell: UICollectionViewCell)
@@ -907,9 +912,10 @@ extension StreamViewController: StreamEditingResponder {
             window.addSubview(imageView)
         }
 
-        if !post.loved {
+        if !post.loved,
             let footerCell = collectionView.cellForItem(at: footerPath) as? StreamFooterCell
-            postbarController?.lovesButtonTapped(footerCell, indexPath: footerPath)
+        {
+            postbarController?.lovesButtonTapped(footerCell)
         }
     }
 
@@ -961,7 +967,18 @@ extension StreamViewController: StreamImageCellResponder {
 }
 
 // MARK: StreamViewController: Open post
-extension StreamViewController {
+extension StreamViewController: StreamPostTappedResponder {
+
+    @objc
+    func postTappedInStream(_ cell: UICollectionViewCell) {
+        guard
+            let indexPath = collectionView.indexPath(for: cell),
+            let post = dataSource.postForIndexPath(indexPath),
+            let streamCellItem = dataSource.visibleStreamCellItem(at: indexPath)
+        else { return }
+
+        sendToPostTappedResponder(post: post, streamCellItem: streamCellItem)
+    }
 
     func sendToPostTappedResponder(post: Post, streamCellItem: StreamCellItem, scrollToComment: ElloComment? = nil) {
         if let placeholderType = streamCellItem.placeholderType,

--- a/Specs/Controllers/Stream/PostbarControllerSpec.swift
+++ b/Specs/Controllers/Stream/PostbarControllerSpec.swift
@@ -75,8 +75,6 @@ class PostbarControllerSpec: QuickSpec {
         describe("PostbarController") {
             describe("replyToAllButtonTapped(_:)") {
 
-                var indexPath: IndexPath!
-
                 beforeEach {
                     let post: Post = stub([
                         "id": "post1",
@@ -86,14 +84,13 @@ class PostbarControllerSpec: QuickSpec {
                     var postCellItems = parser.parse([post], streamKind: streamKind)
                     let newComment = ElloComment.newCommentForPost(post, currentUser: currentUser)
                     postCellItems += [StreamCellItem(jsonable: newComment, type: .createComment)]
-                    indexPath = IndexPath(item: postCellItems.count - 1, section: 0)
                     controller.dataSource.appendUnsizedCellItems(postCellItems, withWidth: 320.0) { cellCount in
                         controller.collectionView.reloadData()
                     }
                 }
                 context("tapping replyToAll") {
                     it("opens an OmnibarViewController with usernames set") {
-                        subject.replyToAllButtonTapped(indexPath)
+                        subject.replyToAllButtonTapped(UICollectionViewCell())
                         expect(responder.text) == "@user1 @user2 "
                     }
                 }
@@ -101,7 +98,6 @@ class PostbarControllerSpec: QuickSpec {
 
             describe("watchPostTapped(_:cell:)") {
                 var cell: StreamCreateCommentCell!
-                var indexPath: IndexPath!
 
                 beforeEach {
                     let post: Post = stub([
@@ -112,7 +108,6 @@ class PostbarControllerSpec: QuickSpec {
                     var postCellItems = parser.parse([post], streamKind: streamKind)
                     let newComment = ElloComment.newCommentForPost(post, currentUser: currentUser)
                     postCellItems += [StreamCellItem(jsonable: newComment, type: .createComment)]
-                    indexPath = IndexPath(item: postCellItems.count - 1, section: 0)
                     cell = StreamCreateCommentCell()
                     controller.dataSource.appendUnsizedCellItems(postCellItems, withWidth: 320.0) { cellCount in
                         controller.collectionView.reloadData()
@@ -122,30 +117,30 @@ class PostbarControllerSpec: QuickSpec {
                 it("should disable the cell during submission") {
                     ElloProvider.sharedProvider = ElloProvider.DelayedStubbingProvider()
                     cell.isUserInteractionEnabled = true
-                    subject.watchPostTapped(true, cell: cell, indexPath: indexPath)
+                    subject.watchPostTapped(true, cell: cell)
                     expect(cell.isUserInteractionEnabled) == false
                 }
                 it("should set the cell.watching property") {
                     ElloProvider.sharedProvider = ElloProvider.DelayedStubbingProvider()
                     cell.watching = false
-                    subject.watchPostTapped(true, cell: cell, indexPath: indexPath)
+                    subject.watchPostTapped(true, cell: cell)
                     expect(cell.watching) == true
                 }
                 it("should enable the cell after failure") {
                     ElloProvider.sharedProvider = ElloProvider.ErrorStubbingProvider()
                     cell.isUserInteractionEnabled = false
-                    subject.watchPostTapped(true, cell: cell, indexPath: indexPath)
+                    subject.watchPostTapped(true, cell: cell)
                     expect(cell.isUserInteractionEnabled) == true
                 }
                 it("should restore the cell.watching property after failure") {
                     ElloProvider.sharedProvider = ElloProvider.ErrorStubbingProvider()
                     cell.watching = false
-                    subject.watchPostTapped(true, cell: cell, indexPath: indexPath)
+                    subject.watchPostTapped(true, cell: cell)
                     expect(cell.watching) == false
                 }
                 it("should enable the cell after success") {
                     cell.isUserInteractionEnabled = false
-                    subject.watchPostTapped(true, cell: cell, indexPath: indexPath)
+                    subject.watchPostTapped(true, cell: cell)
                     expect(cell.isUserInteractionEnabled) == true
                 }
                 it("should post a notification after success") {
@@ -153,7 +148,7 @@ class PostbarControllerSpec: QuickSpec {
                     let observer = NotificationObserver(notification: PostChangedNotification) { (post, contentChange) in
                         postedNotification = true
                     }
-                    subject.watchPostTapped(true, cell: cell, indexPath: indexPath)
+                    subject.watchPostTapped(true, cell: cell)
                     expect(postedNotification) == true
                     observer.removeObserver()
                 }
@@ -178,7 +173,6 @@ class PostbarControllerSpec: QuickSpec {
                 context("post has not been loved") {
                     it("loves the post") {
                         stubCellItems(false)
-                        let indexPath = IndexPath(item: 2, section: 0)
                         let cell = StreamFooterCell.loadFromNib() as StreamFooterCell
 
                         var lovesCount = 0
@@ -187,7 +181,7 @@ class PostbarControllerSpec: QuickSpec {
                             lovesCount = post.lovesCount!
                             contentChange = change
                         }
-                        subject.lovesButtonTapped(cell, indexPath: indexPath)
+                        subject.lovesButtonTapped(cell)
                         observer.removeObserver()
 
                         expect(lovesCount) == 6
@@ -196,7 +190,6 @@ class PostbarControllerSpec: QuickSpec {
 
                     it("increases currentUser lovesCount") {
                         stubCellItems(false)
-                        let indexPath = IndexPath(item: 2, section: 0)
                         let cell = StreamFooterCell.loadFromNib() as StreamFooterCell
 
                         let prevLovesCount = currentUser.lovesCount!
@@ -204,7 +197,7 @@ class PostbarControllerSpec: QuickSpec {
                         let observer = NotificationObserver(notification: CurrentUserChangedNotification) { (user) in
                             lovesCount = user.lovesCount!
                         }
-                        subject.lovesButtonTapped(cell, indexPath: indexPath)
+                        subject.lovesButtonTapped(cell)
                         observer.removeObserver()
 
                         expect(lovesCount) == prevLovesCount + 1
@@ -214,7 +207,6 @@ class PostbarControllerSpec: QuickSpec {
                 context("post has already been loved") {
                     it("unloves the post") {
                         stubCellItems(true)
-                        let indexPath = IndexPath(item: 2, section: 0)
                         let cell = StreamFooterCell.loadFromNib() as StreamFooterCell
 
                         var lovesCount = 0
@@ -223,7 +215,7 @@ class PostbarControllerSpec: QuickSpec {
                             lovesCount = post.lovesCount!
                             contentChange = change
                         }
-                        subject.lovesButtonTapped(cell, indexPath: indexPath)
+                        subject.lovesButtonTapped(cell)
                         observer.removeObserver()
 
                         expect(lovesCount) == 4
@@ -232,7 +224,6 @@ class PostbarControllerSpec: QuickSpec {
 
                     it("decreases currentUser lovesCount") {
                         stubCellItems(true)
-                        let indexPath = IndexPath(item: 2, section: 0)
                         let cell = StreamFooterCell.loadFromNib() as StreamFooterCell
 
                         let prevLovesCount = currentUser.lovesCount!
@@ -240,7 +231,7 @@ class PostbarControllerSpec: QuickSpec {
                         let observer = NotificationObserver(notification: CurrentUserChangedNotification) { (user) in
                             lovesCount = user.lovesCount!
                         }
-                        subject.lovesButtonTapped(cell, indexPath: indexPath)
+                        subject.lovesButtonTapped(cell)
                         observer.removeObserver()
 
                         expect(lovesCount) == prevLovesCount - 1


### PR DESCRIPTION
In order to accomplish this I had to "re-insert" the `StreamViewController` into the responder.  Easily done by adding a `properTarget(forAction:,withSender:)` to `PostbarController`.  This method starts the responder chain search at `StreamViewController` instead of `PostbarController`.

The `PostbarController` had a bit of schizophrenia going on whether to use `cell` or `indexPath`, so I refactored the code to prefer `cell`.  This also simplified the `StreamHeader/FooterCell` code.

[Finishes #142723269](https://www.pivotaltracker.com/story/show/142723269)