### PR TITLE
Use smaller images in more places

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -102,10 +102,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func setupCaches() {
         let manager = PINRemoteImageManager.shared()
-        let twoWeeks: TimeInterval = 1_209_600
-        let twoHundredFiftyMegaBytes: UInt = 250_000_000
-        manager.pinCache?.diskCache.ageLimit = twoWeeks
-        manager.pinCache?.diskCache.byteLimit = twoHundredFiftyMegaBytes
+        let diskAgeLimit: TimeInterval = 1_209_600
+        let diskByteLimit: UInt = 250_000_000
+        let memoryByteLimit: UInt = 10_000_000
+        manager.pinCache?.diskCache.ageLimit = diskAgeLimit
+        manager.pinCache?.diskCache.byteLimit = diskByteLimit
+        manager.pinCache?.memoryCache.costLimit = memoryByteLimit
         _ = CategoryService().loadCategories()
     }
 

--- a/Sources/Controllers/Stream/CellDequeing/StreamImageCellPresenter.swift
+++ b/Sources/Controllers/Stream/CellDequeing/StreamImageCellPresenter.swift
@@ -59,8 +59,7 @@ struct StreamImageCellPresenter {
                 imageToLoad = asset.optimized?.url as URL?
             }
             else {
-                attachmentToLoad = isGridView ?
-                    asset.gridLayoutPreviewAttachment : asset.oneColumnPreviewAttachment
+                attachmentToLoad = isGridView ? asset.gridLayoutAttachment : asset.oneColumnAttachment
                 cell.presentedImageUrl = asset.optimized?.url
                 cell.isLargeImage = true
             }

--- a/Sources/Controllers/Stream/Cells/CategoryHeaderCell.swift
+++ b/Sources/Controllers/Stream/Cells/CategoryHeaderCell.swift
@@ -285,7 +285,7 @@ private extension CategoryHeaderCell {
             return
         }
 
-        self.imageView.pin_setImage(from: url) { [weak self] result in
+        imageView.pin_setImage(from: url) { [weak self] result in
             guard let `self` = self else { return }
 
             guard result.hasImage else {
@@ -313,7 +313,6 @@ private extension CategoryHeaderCell {
             }
 
             self.layoutIfNeeded()
-
         }
     }
 
@@ -377,7 +376,7 @@ extension CategoryHeaderCell.Config {
         callToActionURL = category.ctaURL as URL?
 
         if let promotional = category.randomPromotional {
-            imageURL = promotional.image?.xhdpi?.url as URL?
+            imageURL = promotional.image?.oneColumnAttachment?.url as URL?
             user = promotional.user
         }
     }

--- a/Sources/Model/Category.swift
+++ b/Sources/Model/Category.swift
@@ -146,7 +146,7 @@ final class Category: JSONAble, Groupable {
         let usesPagePromo = json["uses_page_promotionals"].bool ?? (level == .meta)
         let tileImage: Attachment?
         if let assetJson = json["tile_image"].object as? [String: AnyObject],
-            let attachmentJson = assetJson["large"] as? [String: AnyObject]
+            let attachmentJson = DeviceScreen.isRetina ? (assetJson["large"] as? [String: AnyObject]) : (assetJson["small"] as? [String: AnyObject])
         {
             tileImage = Attachment.fromJSON(attachmentJson) as? Attachment
         }

--- a/Sources/Model/PagePromotional.swift
+++ b/Sources/Model/PagePromotional.swift
@@ -15,7 +15,7 @@ final class PagePromotional: JSONAble {
     let ctaCaption: String
     let ctaURL: URL?
     let image: Asset?
-    var tileURL: URL? { return image?.xhdpi?.url as URL? }
+    var tileURL: URL? { return image?.oneColumnAttachment?.url as URL? }
 
     // links
     var user: User? { return getLinkObject("user") as? User }

--- a/Sources/Model/Regions/Asset.swift
+++ b/Sources/Model/Regions/Asset.swift
@@ -39,9 +39,11 @@ final class Asset: JSONAble {
         //
         // unfortunately that took 12.4 seconds to compile
         // this (much more verbose) code compiles very quickly
-        if let large = large { return large }
-        if let optimized = optimized { return optimized }
-        if let xhdpi = xhdpi { return xhdpi }
+        if DeviceScreen.isRetina {
+            if let large = large { return large }
+            if let optimized = optimized { return optimized }
+            if let xhdpi = xhdpi { return xhdpi }
+        }
         if let hdpi = hdpi { return hdpi }
         if let regular = regular { return regular }
         return nil

--- a/Sources/Model/Regions/Asset.swift
+++ b/Sources/Model/Regions/Asset.swift
@@ -84,18 +84,10 @@ final class Asset: JSONAble {
     }
 
     var oneColumnAttachment: Attachment? {
-        return Window.isWide(Window.width) && DeviceScreen.isRetina  ? xhdpi : hdpi
-    }
-
-    var oneColumnPreviewAttachment: Attachment? {
         return Window.isWide(Window.width) && DeviceScreen.isRetina ? xhdpi : hdpi
     }
 
     var gridLayoutAttachment: Attachment? {
-        return Window.isWide(Window.width) && DeviceScreen.isRetina ? hdpi : mdpi
-    }
-
-    var gridLayoutPreviewAttachment: Attachment? {
         return Window.isWide(Window.width) && DeviceScreen.isRetina ? hdpi : mdpi
     }
 

--- a/Sources/Model/User.swift
+++ b/Sources/Model/User.swift
@@ -381,7 +381,7 @@ extension User {
         if animated && (!postsAdultContent || viewsAdultContent == true) && coverImage?.original?.url.absoluteString.hasSuffix(".gif") == true {
             return coverImage?.original?.url as URL?
         }
-        return coverImage?.xhdpi?.url as URL?
+        return coverImage?.oneColumnAttachment?.url as URL?
     }
 
     func avatarURL(viewsAdultContent: Bool? = false, animated: Bool = false) -> URL? {

--- a/Sources/Networking/AuthState.swift
+++ b/Sources/Networking/AuthState.swift
@@ -22,10 +22,10 @@ enum AuthState {
 
     fileprivate var nextStates: [AuthState] {
         switch self {
-        case .initial: return [.noToken, .anonymous, .authenticated]
+        case .initial: return [.noToken, .shouldTryAnonymousCreds, .anonymous, .authenticated]
 
         case .noToken: return [.authenticated, .userCredsSent, .anonymousCredsSent, .shouldTryAnonymousCreds]
-        case .anonymous: return [.userCredsSent, .noToken]
+        case .anonymous: return [.userCredsSent, .authenticated, .noToken]
         case .authenticated: return [.refreshTokenSent, .noToken]
 
         case .refreshTokenSent: return [.authenticated, .shouldTryRefreshToken, .shouldTryUserCreds]

--- a/Sources/Networking/ElloProvider.swift
+++ b/Sources/Networking/ElloProvider.swift
@@ -305,7 +305,7 @@ extension ElloProvider {
         postNotification(AuthenticationNotifications.invalidToken, value: true)
     }
 
-    fileprivate func parseLinked(_ elloAPI: ElloAPI, dict: [String:AnyObject], responseConfig: ResponseConfig, success: @escaping ElloSuccessCompletion, failure: @escaping ElloFailureCompletion) {
+    fileprivate func parseLinked(_ elloAPI: ElloAPI, dict: [String: AnyObject], responseConfig: ResponseConfig, success: @escaping ElloSuccessCompletion, failure: @escaping ElloFailureCompletion) {
         let completion: ElloEmptyCompletion = {
             let node = dict[elloAPI.mappingType.rawValue]
             var newResponseConfig: ResponseConfig?

--- a/Sources/Networking/Mapper.swift
+++ b/Sources/Networking/Mapper.swift
@@ -22,23 +22,23 @@ struct Mapper {
         return (json, error)
     }
 
-    static func mapToObjectArray(_ dicts: [[String:AnyObject]], type: MappingType) -> [JSONAble] {
-        let fromJSON = type.fromJSON
+    static func mapToObjectArray(_ dicts: [[String: AnyObject]], type mappingType: MappingType) -> [JSONAble] {
+        let fromJSON = mappingType.fromJSON
         return dicts.map { data in
             let jsonable = fromJSON(data)
             if let id = (jsonable as? JSONSaveable)?.tableId {
-                ElloLinkedStore.sharedInstance.saveObject(jsonable, id: id, type: type)
+                ElloLinkedStore.sharedInstance.saveObject(jsonable, id: id, type: mappingType)
             }
             return jsonable
         }
     }
 
-    static func mapToObject(_ object: AnyObject?, type: MappingType) -> JSONAble? {
-        let fromJSON = type.fromJSON
-        return (object as? [String:AnyObject]).flatMap { data in
+    static func mapToObject(_ object: AnyObject?, type mappingType: MappingType) -> JSONAble? {
+        let fromJSON = mappingType.fromJSON
+        return (object as? [String: AnyObject]).flatMap { data in
             let jsonable = fromJSON(data)
             if let id = (jsonable as? JSONSaveable)?.tableId {
-                ElloLinkedStore.sharedInstance.saveObject(jsonable, id: id, type: type)
+                ElloLinkedStore.sharedInstance.saveObject(jsonable, id: id, type: mappingType)
             }
             return jsonable
         }

--- a/Sources/Utilities/Preloader.swift
+++ b/Sources/Utilities/Preloader.swift
@@ -124,7 +124,7 @@ struct Preloader {
     }
 
     fileprivate func preloadUrl(_ url: URL) {
-        if !url.hasGifExtension && !url.hasMP4Extension {
+        if !url.hasGifExtension && !url.hasMP4Extension && DeviceScreen.isRetina {
             manager.prefetchImage(with: url, options: PINRemoteImageManagerDownloadOptions())
         }
     }


### PR DESCRIPTION
Decrease the memory pressure by using smaller avatars and category images.

The other code refactors were due to just poking around, trying different memory changes.

[Finishes #141965649](https://www.pivotaltracker.com/story/show/141965649)
[Finishes #143336577](https://www.pivotaltracker.com/story/show/143336577)