### PR TITLE
Fixes Invite from Drawer (add close button)

### DIFF
--- a/Sources/Controllers/App/AppViewController.swift
+++ b/Sources/Controllers/App/AppViewController.swift
@@ -40,32 +40,10 @@ class AppViewController: BaseElloViewController {
     fileprivate var receivedPushNotificationObserver: NotificationObserver?
     fileprivate var externalWebObserver: NotificationObserver?
     fileprivate var apiOutOfDateObserver: NotificationObserver?
-    fileprivate var statusBarShouldHideObserver: NotificationObserver?
 
     fileprivate var pushPayload: PushPayload?
 
     fileprivate var deepLinkPath: String?
-
-    var statusBarShouldHide = false
-
-    func hideStatusBar(_ hide: Bool) {
-        statusBarShouldHide = hide
-        animate {
-            self.setNeedsStatusBarAppearanceUpdate()
-        }
-    }
-
-    override var prefersStatusBarHidden: Bool {
-        return statusBarShouldHide
-    }
-
-    override var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
-    }
-
-    override var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
-        return .slide
-    }
 
     override func loadView() {
         self.view = AppScreen()
@@ -172,10 +150,6 @@ class AppViewController: BaseElloViewController {
             self?.apiOutOfDateObserver?.removeObserver()
             postNotification(AuthenticationNotifications.invalidToken, value: false)
         }
-
-        statusBarShouldHideObserver = NotificationObserver(notification: StatusBarNotifications.statusBarShouldHide) { [weak self] (hide) in
-            self?.hideStatusBar(hide)
-        }
     }
 
     fileprivate func removeNotificationObservers() {
@@ -183,7 +157,6 @@ class AppViewController: BaseElloViewController {
         receivedPushNotificationObserver?.removeObserver()
         externalWebObserver?.removeObserver()
         apiOutOfDateObserver?.removeObserver()
-        statusBarShouldHideObserver?.removeObserver()
     }
 }
 

--- a/Sources/Controllers/BaseElloViewController.swift
+++ b/Sources/Controllers/BaseElloViewController.swift
@@ -8,6 +8,28 @@ protocol ControllerThatMightHaveTheCurrentUser {
 }
 
 class BaseElloViewController: UIViewController, HasAppController, ControllerThatMightHaveTheCurrentUser {
+    var statusBarShouldHide = false
+    fileprivate var statusBarShouldHideObserver: NotificationObserver?
+
+    func hideStatusBar(_ hide: Bool) {
+        statusBarShouldHide = hide
+        animate {
+            self.setNeedsStatusBarAppearanceUpdate()
+        }
+    }
+
+    override var prefersStatusBarHidden: Bool {
+        return statusBarShouldHide
+    }
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+
+    override var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
+        return .slide
+    }
+
 
     var elloNavigationItem = UINavigationItem()
 
@@ -49,6 +71,17 @@ class BaseElloViewController: UIViewController, HasAppController, ControllerThat
         super.viewDidLoad()
         self.navigationItem.fixNavBarItemPadding()
         setupRelationshipController()
+        setupStatusBarObservers()
+    }
+
+    fileprivate func setupStatusBarObservers() {
+        statusBarShouldHideObserver = NotificationObserver(notification: StatusBarNotifications.statusBarShouldHide) { [weak self] (hide) in
+            self?.hideStatusBar(hide)
+        }
+    }
+
+    deinit {
+        statusBarShouldHideObserver?.removeObserver()
     }
 
     private func setupRelationshipController() {
@@ -82,9 +115,15 @@ class BaseElloViewController: UIViewController, HasAppController, ControllerThat
     @IBAction
     func backTapped() {
         guard
-            let navigationController = navigationController, navigationController.childViewControllers.count > 1 else { return }
+            let navigationController = navigationController, navigationController.childViewControllers.count > 1
+        else { return }
 
         _ = navigationController.popViewController(animated: true)
+    }
+
+    @IBAction
+    func closeTapped() {
+        dismiss(animated: true, completion: .none)
     }
 
     func showShareActivity(sender: UIView, url shareURL: URL) {

--- a/Sources/Controllers/Onboarding/InviteFriendsViewController.swift
+++ b/Sources/Controllers/Onboarding/InviteFriendsViewController.swift
@@ -81,6 +81,10 @@ extension InviteFriendsViewController {
             elloNavigationItem.leftBarButtonItems = [backItem]
             elloNavigationItem.fixNavBarItemPadding()
         }
+        else {
+            let closeItem = UIBarButtonItem.closeButton(target: self, action: #selector(closeTapped))
+            elloNavigationItem.leftBarButtonItems = [closeItem]
+        }
 
         screen.navigationItem = elloNavigationItem
     }


### PR DESCRIPTION
Two things:

1. add 'close' button to invite
2. fix status bar when presenting an ello controller

The status bar show/hide code was only in `AppViewController`, which made sense, except when you present a controller *it* becomes the controller in charge of the status bar.

[Finishes #143987763](https://www.pivotaltracker.com/story/show/143987763)