### PR TITLE
Switch to PromiseKit

### DIFF
--- a/Ello.xcodeproj/project.pbxproj
+++ b/Ello.xcodeproj/project.pbxproj
@@ -557,6 +557,7 @@
 		1D472C261C1F349E00B61E55 /* breaklink_normal.svg in Resources */ = {isa = PBXBuildFile; fileRef = 1D472C251C1F349E00B61E55 /* breaklink_normal.svg */; };
 		1D472C281C1F42BA00B61E55 /* InterfaceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D472C271C1F42BA00B61E55 /* InterfaceSpec.swift */; };
 		1D513E061ED735910081BB2D /* EditorialsGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D513E051ED735910081BB2D /* EditorialsGenerator.swift */; };
+		1D513E081ED8DA660081BB2D /* PromiseKitExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D513E071ED8DA660081BB2D /* PromiseKitExtensions.swift */; };
 		1D59336C1D10ADA600EAF03D /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D59336A1D10ADA600EAF03D /* Category.swift */; };
 		1D59336D1D10ADA600EAF03D /* CategoryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D59336B1D10ADA600EAF03D /* CategoryList.swift */; };
 		1D59336F1D10ADB800EAF03D /* CategoryListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D59336E1D10ADB800EAF03D /* CategoryListCell.swift */; };
@@ -1601,6 +1602,7 @@
 		1D472C251C1F349E00B61E55 /* breaklink_normal.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = breaklink_normal.svg; sourceTree = "<group>"; };
 		1D472C271C1F42BA00B61E55 /* InterfaceSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceSpec.swift; sourceTree = "<group>"; };
 		1D513E051ED735910081BB2D /* EditorialsGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorialsGenerator.swift; sourceTree = "<group>"; };
+		1D513E071ED8DA660081BB2D /* PromiseKitExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseKitExtensions.swift; sourceTree = "<group>"; };
 		1D59336A1D10ADA600EAF03D /* Category.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		1D59336B1D10ADA600EAF03D /* CategoryList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CategoryList.swift; sourceTree = "<group>"; };
 		1D59336E1D10ADB800EAF03D /* CategoryListCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CategoryListCell.swift; sourceTree = "<group>"; };
@@ -2577,6 +2579,7 @@
 			isa = PBXGroup;
 			children = (
 				1267C7331BA232530000D809 /* Box */,
+				1D513E071ED8DA660081BB2D /* PromiseKitExtensions.swift */,
 				1D4042C91E0997DD00E4E74D /* SnapKitExtensions.swift */,
 			);
 			name = ThirdParty;
@@ -5190,6 +5193,7 @@
 				1D70DE5B1DF6106B008AF216 /* AnnouncementCell.swift in Sources */,
 				12F6ADFF1A43380C00493660 /* ProfileViewController.swift in Sources */,
 				1DCA942B1AA138AE0033C0EC /* ElloAttributedString.swift in Sources */,
+				1D513E081ED8DA660081BB2D /* PromiseKitExtensions.swift in Sources */,
 				1D06D6C11E3BADE6004FA878 /* LoggedOutViewController.swift in Sources */,
 				1DC91F751CF375F600336012 /* AutoCompleteResult.swift in Sources */,
 				1D2B50BD1D2C2FC000F6CE90 /* CategoryService.swift in Sources */,

--- a/Podfile
+++ b/Podfile
@@ -29,7 +29,6 @@ def ello_app_pods
   pod 'TimeAgoInWords', git: 'https://github.com/ello/TimeAgoInWords'
   pod 'WebLinking', git: 'https://github.com/kylef/WebLinking.swift'
   pod 'SnapKit', git: 'https://github.com/ello/SnapKit'
-  pod 'FutureKit', git: 'https://github.com/FutureKit/FutureKit', branch: 'v3'
   pod 'DeltaCalculator', git: 'https://github.com/ello/DeltaCalculator'
 end
 
@@ -44,6 +43,7 @@ def common_pods
     pod 'ElloOSSUIFonts', '~> 2.0'
     pod 'ElloOSSCerts', '~> 2.0'
   end
+  pod 'PromiseKit'
   pod 'MBProgressHUD', '~> 0.9.0'
   pod 'SVGKit', git: 'https://github.com/ello/SVGKit'
   pod 'FLAnimatedImage', '~> 1.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,6 @@ PODS:
   - FBSnapshotTestCase/SwiftSupport (2.1.4):
     - FBSnapshotTestCase/Core
   - FLAnimatedImage (1.0.12)
-  - FutureKit (2.0.0)
   - ImagePickerSheetController (0.9.3)
   - iRate (1.11.7)
   - JTSImageViewController (1.5)
@@ -66,6 +65,17 @@ PODS:
   - PINRemoteImage/PINCache (3.0.0-beta.8):
     - PINCache (= 3.0.1-beta.4)
     - PINRemoteImage/Core
+  - PromiseKit (4.1.7):
+    - PromiseKit/Foundation (= 4.1.7)
+    - PromiseKit/QuartzCore (= 4.1.7)
+    - PromiseKit/UIKit (= 4.1.7)
+  - PromiseKit/CorePromise (4.1.7)
+  - PromiseKit/Foundation (4.1.7):
+    - PromiseKit/CorePromise
+  - PromiseKit/QuartzCore (4.1.7):
+    - PromiseKit/CorePromise
+  - PromiseKit/UIKit (4.1.7):
+    - PromiseKit/CorePromise
   - Quick (1.1.0)
   - Result (3.2.1)
   - SnapKit (3.1.2)
@@ -133,7 +143,6 @@ DEPENDENCIES:
   - Fabric (~> 1.6)
   - FBSnapshotTestCase
   - FLAnimatedImage (~> 1.0)
-  - FutureKit (from `https://github.com/FutureKit/FutureKit`, branch `v3`)
   - ImagePickerSheetController (from `https://github.com/ello/ImagePickerSheetController`, branch `swift3`)
   - iRate (~> 1.11)
   - JTSImageViewController (from `https://github.com/ello/JTSImageViewController`)
@@ -147,6 +156,7 @@ DEPENDENCIES:
   - Nimble-Snapshots (~> 4.4)
   - PINCache (from `https://github.com/ello/PINCache`, commit `78c3461`)
   - PINRemoteImage (= 3.0.0-beta.8)
+  - PromiseKit
   - Quick (= 1.1.0)
   - SnapKit (from `https://github.com/ello/SnapKit`)
   - SSPullToRefresh (~> 1.2)
@@ -168,9 +178,6 @@ EXTERNAL SOURCES:
     :git: git@github.com:ello/Ello-iOS-Certs
   ElloUIFonts:
     :git: git@github.com:ello/ElloUIFonts
-  FutureKit:
-    :branch: v3
-    :git: https://github.com/FutureKit/FutureKit
   ImagePickerSheetController:
     :branch: swift3
     :git: https://github.com/ello/ImagePickerSheetController
@@ -208,9 +215,6 @@ CHECKOUT OPTIONS:
   ElloUIFonts:
     :commit: c0bcfe900cdcc97f7df534657d5ce3b1efeb6a67
     :git: git@github.com:ello/ElloUIFonts
-  FutureKit:
-    :commit: 43d4f55387e82e3a0892d346fc1a7018a7a5f15c
-    :git: https://github.com/FutureKit/FutureKit
   ImagePickerSheetController:
     :commit: 18e8d063a15c9d081d510f82ba25b46edfda7e28
     :git: https://github.com/ello/ImagePickerSheetController
@@ -249,7 +253,6 @@ SPEC CHECKSUMS:
   Fabric: 5911403591946b8228ab1c51d98f1d7137e863c6
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   FLAnimatedImage: 4a0b56255d9b05f18b6dd7ee06871be5d3b89e31
-  FutureKit: 409baf0c683f4cdd1784b90782f43386ca3749a5
   ImagePickerSheetController: 4789b06940e299431455c61be77fda440883c36c
   iRate: adae3f183d83c925ac42d7a2e86e89e838963f57
   JTSImageViewController: 89ae3c003060c65418fd3224ebbd67acc6046608
@@ -264,6 +267,7 @@ SPEC CHECKSUMS:
   PINCache: a89c8f609232afac77128557bd12c861844423d7
   PINOperation: ac23db44796d4a564ecf9b5ea7163510f579b71d
   PINRemoteImage: c4f9f16932840c597f32e69dd288e10e111a1929
+  PromiseKit: 779f2e41faf62d854e7593026ddbcb0bb5c5002d
   Quick: dafc587e21eed9f4cab3249b9f9015b0b7a7f71d
   Result: 2453a22e5c5b11c0c3a478736e82cd02f763b781
   SnapKit: 66bf0e9c5e02fdb6d2a549adb845ab4440d3ccfe
@@ -276,6 +280,6 @@ SPEC CHECKSUMS:
   WebLinking: 3f71787c14a225148e8be29fe6e7c98597cbc459
   YapDatabase: 861c720d5850a59f9e5c0bad0fd95334012b9dc9
 
-PODFILE CHECKSUM: f1fae533a9e0c5a6f272c2bbe8f8aa8c476d6ac6
+PODFILE CHECKSUM: 48c1c4bb07c0b0d5b81f46c5cd7a4793db01e621
 
 COCOAPODS: 1.1.1

--- a/Sources/Controllers/Categories/CategoryGenerator.swift
+++ b/Sources/Controllers/Categories/CategoryGenerator.swift
@@ -150,7 +150,7 @@ private extension CategoryGenerator {
         else { return }
 
         CategoryService().loadCategory(slug)
-            .onSuccess { [weak self] category in
+            .thenFinally { [weak self] category in
                 guard
                     let `self` = self,
                     self.loadingToken.isValidInitialPageLoadingToken(self.localToken)
@@ -161,7 +161,7 @@ private extension CategoryGenerator {
                 self.destination?.replacePlaceholder(type: .categoryHeader, items: self.headerItems()) {}
                 doneOperation.run()
             }
-            .onFail { [weak self] _ in
+            .catch { [weak self] _ in
                 guard let `self` = self else { return }
                 self.destination?.primaryJSONAbleNotFound()
                 self.queue.cancelAllOperations()
@@ -172,7 +172,7 @@ private extension CategoryGenerator {
         guard usesPagePromo() else { return }
 
         PagePromotionalService().loadPagePromotionals()
-            .onSuccess { [weak self] promotionals in
+            .thenFinally { [weak self] promotionals in
                 guard
                     let `self` = self,
                     self.loadingToken.isValidInitialPageLoadingToken(self.localToken)
@@ -188,7 +188,7 @@ private extension CategoryGenerator {
                 self.destination?.replacePlaceholder(type: .categoryHeader, items: self.headerItems()) {}
                 doneOperation.run()
             }
-            .onFail { [weak self] _ in
+            .catch { [weak self] _ in
                 guard let `self` = self else { return }
                 self.destination?.primaryJSONAbleNotFound()
                 self.queue.cancelAllOperations()
@@ -197,11 +197,12 @@ private extension CategoryGenerator {
 
     func loadCategories() {
         CategoryService().loadCategories()
-            .onSuccess { [weak self] categories in
+            .thenFinally { [weak self] categories in
                 guard let `self` = self else { return }
                 self.categories = categories
                 self.categoryStreamDestination?.set(categories: categories)
-            }.ignoreFailures()
+            }
+        .ignoreErrors()
     }
 
     func loadCategoryPosts(_ doneOperation: AsyncOperation, reload: Bool) {
@@ -233,7 +234,7 @@ private extension CategoryGenerator {
             endpoint: endpoint,
             streamKind: streamKind
             )
-            .onSuccess { [weak self] response in
+            .thenFinally { [weak self] response in
                 guard
                     let `self` = self,
                     self.loadingToken.isValidInitialPageLoadingToken(self.localToken)
@@ -267,7 +268,7 @@ private extension CategoryGenerator {
                     self.queue.cancelAllOperations()
                 }
             }
-            .onFail { [weak self] _ in
+            .catch { [weak self] _ in
                     guard let `self` = self else { return }
                     self.destination?.primaryJSONAbleNotFound()
                     self.queue.cancelAllOperations()

--- a/Sources/Controllers/Editorials/EditorialsGenerator.swift
+++ b/Sources/Controllers/Editorials/EditorialsGenerator.swift
@@ -48,7 +48,7 @@ private extension EditorialsGenerator {
 
         let receivedEditorials = afterAll()
         StreamService().loadStream(streamKind: streamKind)
-            .onSuccess { [weak self] response in
+            .thenFinally { [weak self] response in
                 guard
                     let `self` = self,
                     case let .jsonables(jsonables, responseConfig) = response,
@@ -62,7 +62,7 @@ private extension EditorialsGenerator {
                 self.loadPostStreamEditorials(postStreamEditorials, afterAll: afterAll)
                 receivedEditorials()
             }
-            .onFail { [weak self] _ in
+            .catch { [weak self] _ in
                 guard let `self` = self else { return }
                 self.destination?.primaryJSONAbleNotFound()
             }

--- a/Sources/Controllers/Editorials/EditorialsGenerator.swift
+++ b/Sources/Controllers/Editorials/EditorialsGenerator.swift
@@ -77,16 +77,14 @@ private extension EditorialsGenerator {
             else { continue }
 
             let next = afterAll()
-            ElloProvider.shared.elloRequest(
-                .custom(url: path, mimics: { return .following }),
-                success: { (data, responseConfig) in
+            ElloProvider.shared.request(.custom(url: path, mimics: { return .following }))
+                .thenFinally { data, responseConfig in
                     guard let posts = data as? [Post] else { next() ; return }
                     editorial.posts = posts
+                }
+                .always {
                     next()
-                },
-                failure: { (error, statusCode) in
-                    next()
-                })
+                }
         }
     }
 }

--- a/Sources/Controllers/Editorials/EditorialsViewController.swift
+++ b/Sources/Controllers/Editorials/EditorialsViewController.swift
@@ -78,9 +78,7 @@ extension EditorialsViewController: EditorialResponder {
 
         let emails: [String] = emailString.replacingOccurrences(of: "\n", with: ",").split(",").map { $0.trimmed() }
 
-        InviteService().invitations(emails)
-            .onSuccess { _ in }
-            .onFail { _ in }
+        InviteService().sendInvitations(emails).ignoreErrors()
     }
 
     func submitJoin(cell: UICollectionViewCell, email: String, username: String, password: String) {

--- a/Sources/Controllers/ForgotPassword/ForgotPasswordEmailViewController.swift
+++ b/Sources/Controllers/ForgotPassword/ForgotPasswordEmailViewController.swift
@@ -28,11 +28,11 @@ extension ForgotPasswordEmailViewController: ForgotPasswordEmailDelegate {
             Tracker.shared.requestPasswordValid()
 
             UserService().requestPasswordReset(email: email)
-                .onSuccess {
+                .thenFinally { _ in
                     self.screen.loadingHUD(visible: false)
                     self.screen.showSubmitMessage()
                 }
-                .onFail { error in
+                .catch { error in
                     self.screen.loadingHUD(visible: false)
                     let errorTitle = (error as NSError).elloErrorMessage ?? InterfaceString.UnknownError
                     self.screen.showEmailError(errorTitle)

--- a/Sources/Controllers/ForgotPassword/ForgotPasswordResetViewController.swift
+++ b/Sources/Controllers/ForgotPassword/ForgotPasswordResetViewController.swift
@@ -46,7 +46,7 @@ extension ForgotPasswordResetViewController: ForgotPasswordResetDelegate {
             Tracker.shared.resetPasswordValid()
 
             UserService().resetPassword(password: password, authToken: authToken)
-                .onSuccess { user in
+                .thenFinally { user in
                     CredentialsAuthService().authenticate(email: user.username,
                         password: password,
                         success: {
@@ -59,7 +59,7 @@ extension ForgotPasswordResetViewController: ForgotPasswordResetDelegate {
                         }
                     )
                 }
-                .onFail { error in
+                .catch { error in
                     Tracker.shared.resetPasswordFailed()
                     self.screen.loadingHUD(visible: false)
                     self.screen.showFailureMessage()

--- a/Sources/Controllers/Hire/HireViewController.swift
+++ b/Sources/Controllers/Hire/HireViewController.swift
@@ -2,7 +2,7 @@
 ///  HireViewController.swift
 //
 
-import FutureKit
+import PromiseKit
 
 
 class HireViewController: BaseElloViewController {
@@ -109,7 +109,7 @@ extension HireViewController: HireDelegate {
             hireSuccess()
         }
 
-        let endpoint: Future<Void>
+        let endpoint: Promise<Void>
         switch contactType {
         case .hire:
             endpoint = HireService().hire(user: user, body: body)
@@ -118,11 +118,11 @@ extension HireViewController: HireDelegate {
         }
 
         endpoint
-            .onSuccess { _ in
+            .thenFinally { _ in
                 Tracker.shared.hiredUser(self.user)
                 hireSuccess()
             }
-            .onFail { error in
+            .catch { error in
                 self.screen.hideSuccess()
                 let alertController = AlertViewController(error: InterfaceString.GenericError)
                 self.present(alertController, animated: true, completion: nil)

--- a/Sources/Controllers/Join/JoinViewController.swift
+++ b/Sources/Controllers/Join/JoinViewController.swift
@@ -94,7 +94,8 @@ extension JoinViewController: JoinDelegate {
                     username: username,
                     password: password,
                     invitationCode: self.invitationCode
-                    ).onSuccess { user in
+                    )
+                    .thenFinally { user in
                         let authService = CredentialsAuthService()
                         authService.authenticate(email: email,
                             password: password,
@@ -107,7 +108,7 @@ extension JoinViewController: JoinDelegate {
                                 self.showLoginScreen(email, password)
                             })
                     }
-                    .onFail { error in
+                    .catch { error in
                         let errorTitle = (error as NSError).elloErrorMessage ?? InterfaceString.UnknownError
                         self.screen.showError(errorTitle)
                         joinAborted()

--- a/Sources/Controllers/Notifications/NotificationsGenerator.swift
+++ b/Sources/Controllers/Notifications/NotificationsGenerator.swift
@@ -53,10 +53,10 @@ final class NotificationsGenerator: StreamGenerator {
 
     func markAnnouncementAsRead(_ announcement: Announcement) {
         NotificationService().markAnnouncementAsRead(announcement)
-            .onSuccess { [weak self] _ in
+            .thenFinally { [weak self] _ in
                 self?.announcements = []
             }
-            .onFail { _ in }
+            .catch { _ in }
     }
 
     func loadAnnouncements() {
@@ -66,7 +66,7 @@ final class NotificationsGenerator: StreamGenerator {
         }
 
         NotificationService().loadAnnouncements()
-            .onSuccess { [weak self] announcement in
+            .thenFinally { [weak self] announcement in
                 guard let `self` = self else { return }
                 guard self.loadingToken.isValidInitialPageLoadingToken(self.localToken) else { return }
 
@@ -77,7 +77,7 @@ final class NotificationsGenerator: StreamGenerator {
                     self.compareAndUpdateAnnouncements([])
                 }
             }
-            .onFail { [weak self] _ in
+            .catch { [weak self] _ in
                 self?.compareAndUpdateAnnouncements([])
             }
     }
@@ -98,7 +98,7 @@ final class NotificationsGenerator: StreamGenerator {
 
     func loadNotifications() {
         StreamService().loadStream(streamKind: streamKind)
-            .onSuccess { [weak self] response in
+            .thenFinally { [weak self] response in
                 guard
                     let `self` = self,
                     self.loadingToken.isValidInitialPageLoadingToken(self.localToken)
@@ -137,7 +137,7 @@ final class NotificationsGenerator: StreamGenerator {
                     }
                 }
             }
-            .onFail { [weak self] _ in
+            .catch { [weak self] _ in
                 self?.destination?.primaryJSONAbleNotFound()
             }
     }

--- a/Sources/Controllers/Omnibar/OmnibarViewController.swift
+++ b/Sources/Controllers/Omnibar/OmnibarViewController.swift
@@ -65,14 +65,14 @@ class OmnibarViewController: BaseElloViewController {
         self.init(nibName: nil, bundle: nil)
         editComment = comment
         PostService().loadComment(comment.postId, commentId: comment.id)
-            .onSuccess { [weak self] comment in
+            .thenFinally { [weak self] comment in
                 guard let `self` = self else { return }
                 self.rawEditBody = comment.body
                 if let body = comment.body, self.isViewLoaded {
                     self.prepareScreenForEditing(body, isComment: true)
                 }
             }
-            .onFail { error in
+            .catch { error in
                 print("could not edit comment: \(error)")
             }
     }
@@ -81,13 +81,13 @@ class OmnibarViewController: BaseElloViewController {
         self.init(nibName: nil, bundle: nil)
         editPost = post
         PostService().loadPost(post.id, needsComments: false)
-            .onSuccess { post in
+            .thenFinally { post in
                 self.rawEditBody = post.body
                 if let body = post.body, self.isViewLoaded {
                     self.prepareScreenForEditing(body, isComment: false)
                 }
             }
-            .ignoreFailures()
+            .ignoreErrors()
     }
 
     convenience init(parentPostId postId: String, defaultText: String?) {
@@ -456,12 +456,12 @@ extension OmnibarViewController {
 
             if let post = comment.parentPost {
                 PostService().loadPost(post.id, needsComments: false)
-                    .onSuccess { post in
+                    .thenFinally { post in
                         ElloLinkedStore.sharedInstance.setObject(post, forKey: post.id, type: .postsType)
                         postNotification(PostChangedNotification, value: (post, .watching))
                         self.stopSpinner()
                     }
-                    .onFail { _ in
+                    .catch { _ in
                         self.stopSpinner()
                     }
             }

--- a/Sources/Controllers/Onboarding/CategoriesSelectionViewController.swift
+++ b/Sources/Controllers/Onboarding/CategoriesSelectionViewController.swift
@@ -69,7 +69,7 @@ extension CategoriesSelectionViewController: OnboardingStepController {
         }
 
         UserService().setUser(categories: categories)
-            .onSuccess { [weak self] _ in
+            .thenFinally { [weak self] _ in
                 guard let `self` = self else { return }
 
                 // onboarding can be considered "done", even if they abort the app
@@ -78,7 +78,7 @@ extension CategoriesSelectionViewController: OnboardingStepController {
                 self.onboardingData.categories = categories
                 proceedClosure(.continue)
             }
-            .onFail { [weak self] _ in
+            .catch { [weak self] _ in
                 guard let `self` = self else { return }
 
                 let alertController = AlertViewController(error: InterfaceString.GenericError)

--- a/Sources/Controllers/Onboarding/InviteFriendsViewController.swift
+++ b/Sources/Controllers/Onboarding/InviteFriendsViewController.swift
@@ -92,12 +92,12 @@ extension InviteFriendsViewController {
     fileprivate func findFriendsFromContacts() {
         ElloHUD.showLoadingHudInView(view)
         InviteService().find(addressBook, currentUser: self.currentUser)
-            .onSuccess { mixedContacts in
+            .thenFinally { mixedContacts in
                 self.streamViewController.clearForInitialLoad()
                 self.setContacts(mixedContacts)
                 self.streamViewController.doneLoading()
             }
-            .onFail { _ in
+            .catch { _ in
                 let mixedContacts: [(LocalPerson, User?)] = self.addressBook.localPeople.map { ($0, .none) }
                 self.setContacts(mixedContacts)
                 self.streamViewController.doneLoading()

--- a/Sources/Controllers/Profile/Calculators/ProfileAvatarSizeCalculator.swift
+++ b/Sources/Controllers/Profile/Calculators/ProfileAvatarSizeCalculator.swift
@@ -12,8 +12,8 @@ struct ProfileAvatarSizeCalculator {
     }
 
     func calculate(_ item: StreamCellItem, maxWidth: CGFloat) -> Promise<CGFloat> {
-        return Promise { fulfill, _ in
-            fulfill(ProfileAvatarSizeCalculator.calculateHeight(maxWidth: maxWidth))
-        }
+        let (promise, fulfill, _) = Promise<CGFloat>.pending()
+        fulfill(ProfileAvatarSizeCalculator.calculateHeight(maxWidth: maxWidth))
+        return promise
     }
 }

--- a/Sources/Controllers/Profile/Calculators/ProfileAvatarSizeCalculator.swift
+++ b/Sources/Controllers/Profile/Calculators/ProfileAvatarSizeCalculator.swift
@@ -2,7 +2,7 @@
 ///  ProfileAvatarSizeCalculator.swift
 //
 
-import FutureKit
+import PromiseKit
 
 
 struct ProfileAvatarSizeCalculator {
@@ -11,9 +11,9 @@ struct ProfileAvatarSizeCalculator {
         return ceil(maxWidth / ProfileHeaderCellSizeCalculator.ratio) + ProfileAvatarView.Size.whiteBarHeight
     }
 
-    func calculate(_ item: StreamCellItem, maxWidth: CGFloat) -> Future<CGFloat> {
-        let promise = Promise<CGFloat>()
-        promise.completeWithSuccess(ProfileAvatarSizeCalculator.calculateHeight(maxWidth: maxWidth))
-        return promise.future
+    func calculate(_ item: StreamCellItem, maxWidth: CGFloat) -> Promise<CGFloat> {
+        return Promise { fulfill, _ in
+            fulfill(ProfileAvatarSizeCalculator.calculateHeight(maxWidth: maxWidth))
+        }
     }
 }

--- a/Sources/Controllers/Profile/Calculators/ProfileBadgesSizeCalculator.swift
+++ b/Sources/Controllers/Profile/Calculators/ProfileBadgesSizeCalculator.swift
@@ -8,16 +8,16 @@ import PromiseKit
 struct ProfileBadgesSizeCalculator {
 
     func calculate(_ item: StreamCellItem) -> Promise<CGFloat> {
-        return Promise { fulfill, reject in
-            guard
-                let user = item.jsonable as? User,
-                user.badges.count > 0
-            else {
-                fulfill(0)
-                return
-            }
-
-            fulfill(ProfileBadgesView.Size.height)
+        let (promise, fulfill, _) = Promise<CGFloat>.pending()
+        guard
+            let user = item.jsonable as? User,
+            user.badges.count > 0
+        else {
+            fulfill(0)
+            return promise
         }
+
+        fulfill(ProfileBadgesView.Size.height)
+        return promise
     }
 }

--- a/Sources/Controllers/Profile/Calculators/ProfileBadgesSizeCalculator.swift
+++ b/Sources/Controllers/Profile/Calculators/ProfileBadgesSizeCalculator.swift
@@ -2,22 +2,22 @@
 ///  ProfileBadgesSizeCalculator.swift
 //
 
-import FutureKit
+import PromiseKit
 
 
 struct ProfileBadgesSizeCalculator {
 
-    func calculate(_ item: StreamCellItem) -> Future<CGFloat> {
-        let promise = Promise<CGFloat>()
-        guard
-            let user = item.jsonable as? User,
-            user.badges.count > 0
-        else {
-            promise.completeWithSuccess(0)
-            return promise.future
-        }
+    func calculate(_ item: StreamCellItem) -> Promise<CGFloat> {
+        return Promise { fulfill, reject in
+            guard
+                let user = item.jsonable as? User,
+                user.badges.count > 0
+            else {
+                fulfill(0)
+                return
+            }
 
-        promise.completeWithSuccess(ProfileBadgesView.Size.height)
-        return promise.future
+            fulfill(ProfileBadgesView.Size.height)
+        }
     }
 }

--- a/Sources/Controllers/Profile/Calculators/ProfileBioSizeCalculator.swift
+++ b/Sources/Controllers/Profile/Calculators/ProfileBioSizeCalculator.swift
@@ -7,13 +7,14 @@ import PromiseKit
 
 class ProfileBioSizeCalculator: NSObject {
     let webView = UIWebView()
-    let (promise, fulfill, _) = Promise<CGFloat>.pending()
+    var fulfill: ((CGFloat) -> Void)?
 
     deinit {
         webView.delegate = nil
     }
 
     func calculate(_ item: StreamCellItem, maxWidth: CGFloat) -> Promise<CGFloat> {
+        let (promise, fulfill, _) = Promise<CGFloat>.pending()
         guard
             let user = item.jsonable as? User,
             let formattedShortBio = user.formattedShortBio, !formattedShortBio.isEmpty
@@ -22,9 +23,15 @@ class ProfileBioSizeCalculator: NSObject {
             return promise
         }
 
+        guard !AppSetup.sharedState.isTesting else {
+            fulfill(ProfileBioSizeCalculator.calculateHeight(webViewHeight: 30))
+            return promise
+        }
+
         webView.frame.size.width = maxWidth
         webView.delegate = self
         webView.loadHTMLString(StreamTextCellHTML.postHTML(formattedShortBio), baseURL: URL(string: "/"))
+        self.fulfill = fulfill
         return promise
     }
 
@@ -42,11 +49,11 @@ extension ProfileBioSizeCalculator: UIWebViewDelegate {
     func webViewDidFinishLoad(_ webView: UIWebView) {
         let webViewHeight = webView.windowContentSize()?.height ?? 0
         let totalHeight = ProfileBioSizeCalculator.calculateHeight(webViewHeight: webViewHeight)
-        fulfill(totalHeight)
+        fulfill?(totalHeight)
     }
 
     func webView(_ webView: UIWebView, didFailLoadWithError error: Error) {
-        fulfill(0)
+        fulfill?(0)
     }
 
 }

--- a/Sources/Controllers/Profile/Calculators/ProfileHeaderCellSizeCalculator.swift
+++ b/Sources/Controllers/Profile/Calculators/ProfileHeaderCellSizeCalculator.swift
@@ -14,15 +14,6 @@ class ProfileHeaderCellSizeCalculator {
     fileprivate var cellItems: [StreamCellItem] = []
     fileprivate var completion: ElloEmptyCompletion = {}
 
-    let avatarSizeCalculator = ProfileAvatarSizeCalculator()
-    let namesSizeCalculator = ProfileNamesSizeCalculator()
-    let totalCountSizeCalculator = ProfileTotalCountSizeCalculator()
-    let badgesSizeCalculator = ProfileBadgesSizeCalculator()
-    let statsSizeCalculator = ProfileStatsSizeCalculator()
-    let bioSizeCalculator = ProfileBioSizeCalculator()
-    let locationSizeCalculator = ProfileLocationSizeCalculator()
-    let linksSizeCalculator = ProfileLinksSizeCalculator()
-
 // MARK: Public
     init() {}
 
@@ -100,6 +91,15 @@ private extension ProfileHeaderCellSizeCalculator {
     }
 
     func calculateAggregateHeights(_ item: StreamCellItem) {
+        let avatarSizeCalculator = ProfileAvatarSizeCalculator()
+        let namesSizeCalculator = ProfileNamesSizeCalculator()
+        let totalCountSizeCalculator = ProfileTotalCountSizeCalculator()
+        let badgesSizeCalculator = ProfileBadgesSizeCalculator()
+        let statsSizeCalculator = ProfileStatsSizeCalculator()
+        let bioSizeCalculator = ProfileBioSizeCalculator()
+        let locationSizeCalculator = ProfileLocationSizeCalculator()
+        let linksSizeCalculator = ProfileLinksSizeCalculator()
+
         let promises: [(CalculatedCellHeights.Prop, Promise<CGFloat>)] = [
             (.profileAvatar, avatarSizeCalculator.calculate(item, maxWidth: maxWidth)),
             (.profileNames, namesSizeCalculator.calculate(item, maxWidth: maxWidth)),

--- a/Sources/Controllers/Profile/Calculators/ProfileLinksSizeCalculator.swift
+++ b/Sources/Controllers/Profile/Calculators/ProfileLinksSizeCalculator.swift
@@ -8,17 +8,17 @@ import PromiseKit
 struct ProfileLinksSizeCalculator {
 
     func calculate(_ item: StreamCellItem, maxWidth: CGFloat) -> Promise<CGFloat> {
-        return Promise { fulfill, reject in
-            guard
-                let user = item.jsonable as? User,
-                let externalLinks = user.externalLinksList, externalLinks.count > 0
-            else {
-                fulfill(0)
-                return
-            }
-
-            fulfill(ProfileLinksSizeCalculator.calculateHeight(externalLinks, maxWidth: maxWidth))
+        let (promise, fulfill, _) = Promise<CGFloat>.pending()
+        guard
+            let user = item.jsonable as? User,
+            let externalLinks = user.externalLinksList, externalLinks.count > 0
+        else {
+            fulfill(0)
+            return promise
         }
+
+        fulfill(ProfileLinksSizeCalculator.calculateHeight(externalLinks, maxWidth: maxWidth))
+        return promise
     }
 
     static func calculateHeight(_ externalLinks: [ExternalLink], maxWidth: CGFloat) -> CGFloat {

--- a/Sources/Controllers/Profile/Calculators/ProfileLinksSizeCalculator.swift
+++ b/Sources/Controllers/Profile/Calculators/ProfileLinksSizeCalculator.swift
@@ -2,23 +2,23 @@
 ///  ProfileLinksSizeCalculator.swift
 //
 
-import FutureKit
+import PromiseKit
 
 
 struct ProfileLinksSizeCalculator {
 
-    func calculate(_ item: StreamCellItem, maxWidth: CGFloat) -> Future<CGFloat> {
-        let promise = Promise<CGFloat>()
-        guard
-            let user = item.jsonable as? User,
-            let externalLinks = user.externalLinksList, externalLinks.count > 0
-        else {
-            promise.completeWithSuccess(0)
-            return promise.future
-        }
+    func calculate(_ item: StreamCellItem, maxWidth: CGFloat) -> Promise<CGFloat> {
+        return Promise { fulfill, reject in
+            guard
+                let user = item.jsonable as? User,
+                let externalLinks = user.externalLinksList, externalLinks.count > 0
+            else {
+                fulfill(0)
+                return
+            }
 
-        promise.completeWithSuccess(ProfileLinksSizeCalculator.calculateHeight(externalLinks, maxWidth: maxWidth))
-        return promise.future
+            fulfill(ProfileLinksSizeCalculator.calculateHeight(externalLinks, maxWidth: maxWidth))
+        }
     }
 
     static func calculateHeight(_ externalLinks: [ExternalLink], maxWidth: CGFloat) -> CGFloat {

--- a/Sources/Controllers/Profile/Calculators/ProfileLocationSizeCalculator.swift
+++ b/Sources/Controllers/Profile/Calculators/ProfileLocationSizeCalculator.swift
@@ -8,16 +8,16 @@ import PromiseKit
 struct ProfileLocationSizeCalculator {
 
     func calculate(_ item: StreamCellItem, maxWidth: CGFloat) -> Promise<CGFloat> {
-        return Promise { fulfill, reject in
-            guard
-                let user = item.jsonable as? User,
-                let location = user.location, !location.isEmpty
-            else {
-                fulfill(0)
-                return
-            }
-
-            fulfill(ProfileLocationView.Size.height)
+        let (promise, fulfill, _) = Promise<CGFloat>.pending()
+        guard
+            let user = item.jsonable as? User,
+            let location = user.location, !location.isEmpty
+        else {
+            fulfill(0)
+            return promise
         }
+
+        fulfill(ProfileLocationView.Size.height)
+        return promise
     }
 }

--- a/Sources/Controllers/Profile/Calculators/ProfileLocationSizeCalculator.swift
+++ b/Sources/Controllers/Profile/Calculators/ProfileLocationSizeCalculator.swift
@@ -2,22 +2,22 @@
 ///  ProfileLocationSizeCalculator.swift
 //
 
-import FutureKit
+import PromiseKit
 
 
 struct ProfileLocationSizeCalculator {
 
-    func calculate(_ item: StreamCellItem, maxWidth: CGFloat) -> Future<CGFloat> {
-        let promise = Promise<CGFloat>()
-        guard
-            let user = item.jsonable as? User,
-            let location = user.location, !location.isEmpty
-        else {
-            promise.completeWithSuccess(0)
-            return promise.future
-        }
+    func calculate(_ item: StreamCellItem, maxWidth: CGFloat) -> Promise<CGFloat> {
+        return Promise { fulfill, reject in
+            guard
+                let user = item.jsonable as? User,
+                let location = user.location, !location.isEmpty
+            else {
+                fulfill(0)
+                return
+            }
 
-        promise.completeWithSuccess(ProfileLocationView.Size.height)
-        return promise.future
+            fulfill(ProfileLocationView.Size.height)
+        }
     }
 }

--- a/Sources/Controllers/Profile/Calculators/ProfileNamesSizeCalculator.swift
+++ b/Sources/Controllers/Profile/Calculators/ProfileNamesSizeCalculator.swift
@@ -8,41 +8,41 @@ import PromiseKit
 struct ProfileNamesSizeCalculator {
 
     func calculate(_ item: StreamCellItem, maxWidth: CGFloat) -> Promise<CGFloat> {
-        return Promise { fulfill, _ in
-            guard
-                let user = item.jsonable as? User
-            else {
-                fulfill(0)
-                return
-            }
+        let (promise, fulfill, _) = Promise<CGFloat>.pending()
+        guard
+            let user = item.jsonable as? User
+        else {
+            fulfill(0)
+            return promise
+        }
 
-            let nameFont = ProfileNamesView.nameFont
-            let usernameFont = ProfileNamesView.usernameFont
+        let nameFont = ProfileNamesView.nameFont
+        let usernameFont = ProfileNamesView.usernameFont
 
-            let viewWidth = maxWidth - ProfileNamesView.Size.outerMargins.left - ProfileNamesView.Size.outerMargins.right
-            let maxSize = CGSize(width: viewWidth, height: CGFloat.greatestFiniteMagnitude)
+        let viewWidth = maxWidth - ProfileNamesView.Size.outerMargins.left - ProfileNamesView.Size.outerMargins.right
+        let maxSize = CGSize(width: viewWidth, height: CGFloat.greatestFiniteMagnitude)
 
-            let nameSize: CGSize
-            if user.name.isEmpty {
-                nameSize = .zero
-            }
-            else {
-                nameSize = user.name.boundingRect(
-                    with: maxSize, options: [],
-                    attributes: [
-                        NSFontAttributeName: nameFont,
-                    ], context: nil).size.integral
-            }
-
-            let usernameSize = user.atName.boundingRect(
+        let nameSize: CGSize
+        if user.name.isEmpty {
+            nameSize = .zero
+        }
+        else {
+            nameSize = user.name.boundingRect(
                 with: maxSize, options: [],
                 attributes: [
-                    NSFontAttributeName: usernameFont,
+                    NSFontAttributeName: nameFont,
                 ], context: nil).size.integral
-
-            let (height, _) = ProfileNamesView.preferredHeight(nameSize: nameSize, usernameSize: usernameSize, maxWidth: maxWidth)
-            let totalHeight = height + ProfileNamesView.Size.outerMargins.top + ProfileNamesView.Size.outerMargins.bottom
-            fulfill(totalHeight)
         }
+
+        let usernameSize = user.atName.boundingRect(
+            with: maxSize, options: [],
+            attributes: [
+                NSFontAttributeName: usernameFont,
+            ], context: nil).size.integral
+
+        let (height, _) = ProfileNamesView.preferredHeight(nameSize: nameSize, usernameSize: usernameSize, maxWidth: maxWidth)
+        let totalHeight = height + ProfileNamesView.Size.outerMargins.top + ProfileNamesView.Size.outerMargins.bottom
+        fulfill(totalHeight)
+        return promise
     }
 }

--- a/Sources/Controllers/Profile/Calculators/ProfileNamesSizeCalculator.swift
+++ b/Sources/Controllers/Profile/Calculators/ProfileNamesSizeCalculator.swift
@@ -2,48 +2,47 @@
 ///  ProfileNamesSizeCalculator.swift
 //
 
-import FutureKit
+import PromiseKit
 
 
 struct ProfileNamesSizeCalculator {
 
-    func calculate(_ item: StreamCellItem, maxWidth: CGFloat) -> Future<CGFloat> {
-        let promise = Promise<CGFloat>()
-        guard
-            let user = item.jsonable as? User
-        else {
-            promise.completeWithSuccess(0)
-            return promise.future
-        }
+    func calculate(_ item: StreamCellItem, maxWidth: CGFloat) -> Promise<CGFloat> {
+        return Promise { fulfill, _ in
+            guard
+                let user = item.jsonable as? User
+            else {
+                fulfill(0)
+                return
+            }
 
-        let nameFont = ProfileNamesView.nameFont
-        let usernameFont = ProfileNamesView.usernameFont
+            let nameFont = ProfileNamesView.nameFont
+            let usernameFont = ProfileNamesView.usernameFont
 
-        let viewWidth = maxWidth - ProfileNamesView.Size.outerMargins.left - ProfileNamesView.Size.outerMargins.right
-        let maxSize = CGSize(width: viewWidth, height: CGFloat.greatestFiniteMagnitude)
+            let viewWidth = maxWidth - ProfileNamesView.Size.outerMargins.left - ProfileNamesView.Size.outerMargins.right
+            let maxSize = CGSize(width: viewWidth, height: CGFloat.greatestFiniteMagnitude)
 
-        let nameSize: CGSize
-        if user.name.isEmpty {
-            nameSize = .zero
-        }
-        else {
-            nameSize = user.name.boundingRect(
+            let nameSize: CGSize
+            if user.name.isEmpty {
+                nameSize = .zero
+            }
+            else {
+                nameSize = user.name.boundingRect(
+                    with: maxSize, options: [],
+                    attributes: [
+                        NSFontAttributeName: nameFont,
+                    ], context: nil).size.integral
+            }
+
+            let usernameSize = user.atName.boundingRect(
                 with: maxSize, options: [],
                 attributes: [
-                    NSFontAttributeName: nameFont,
+                    NSFontAttributeName: usernameFont,
                 ], context: nil).size.integral
+
+            let (height, _) = ProfileNamesView.preferredHeight(nameSize: nameSize, usernameSize: usernameSize, maxWidth: maxWidth)
+            let totalHeight = height + ProfileNamesView.Size.outerMargins.top + ProfileNamesView.Size.outerMargins.bottom
+            fulfill(totalHeight)
         }
-
-        let usernameSize = user.atName.boundingRect(
-            with: maxSize, options: [],
-            attributes: [
-                NSFontAttributeName: usernameFont,
-            ], context: nil).size.integral
-
-        let (height, _) = ProfileNamesView.preferredHeight(nameSize: nameSize, usernameSize: usernameSize, maxWidth: maxWidth)
-        let totalHeight = height + ProfileNamesView.Size.outerMargins.top + ProfileNamesView.Size.outerMargins.bottom
-        promise.completeWithSuccess(totalHeight)
-
-        return promise.future
     }
 }

--- a/Sources/Controllers/Profile/Calculators/ProfileStatsSizeCalculator.swift
+++ b/Sources/Controllers/Profile/Calculators/ProfileStatsSizeCalculator.swift
@@ -2,14 +2,14 @@
 ///  ProfileStatsSizeCalculator.swift
 //
 
-import FutureKit
+import PromiseKit
 
 
 struct ProfileStatsSizeCalculator {
 
-    func calculate(_ item: StreamCellItem) -> Future<CGFloat> {
-        let promise = Promise<CGFloat>()
-        promise.completeWithSuccess(ProfileStatsView.Size.height)
-        return promise.future
+    func calculate(_ item: StreamCellItem) -> Promise<CGFloat> {
+        return Promise { fulfill, _ in
+            fulfill(ProfileStatsView.Size.height)
+        }
     }
 }

--- a/Sources/Controllers/Profile/Calculators/ProfileStatsSizeCalculator.swift
+++ b/Sources/Controllers/Profile/Calculators/ProfileStatsSizeCalculator.swift
@@ -8,8 +8,8 @@ import PromiseKit
 struct ProfileStatsSizeCalculator {
 
     func calculate(_ item: StreamCellItem) -> Promise<CGFloat> {
-        return Promise { fulfill, _ in
-            fulfill(ProfileStatsView.Size.height)
-        }
+        let (promise, fulfill, _) = Promise<CGFloat>.pending()
+        fulfill(ProfileStatsView.Size.height)
+        return promise
     }
 }

--- a/Sources/Controllers/Profile/Calculators/ProfileTotalCountSizeCalculator.swift
+++ b/Sources/Controllers/Profile/Calculators/ProfileTotalCountSizeCalculator.swift
@@ -2,23 +2,23 @@
 ///  ProfileTotalCountSizeCalculator.swift
 //
 
-import FutureKit
+import PromiseKit
 
 
 struct ProfileTotalCountSizeCalculator {
 
-    func calculate(_ item: StreamCellItem) -> Future<CGFloat> {
-        let promise = Promise<CGFloat>()
-        guard
-            let user = item.jsonable as? User,
-            let count = user.totalViewsCount,
-            count > 0
-        else {
-            promise.completeWithSuccess(0)
-            return promise.future
-        }
+    func calculate(_ item: StreamCellItem) -> Promise<CGFloat> {
+        return Promise { fulfill, reject in
+            guard
+                let user = item.jsonable as? User,
+                let count = user.totalViewsCount,
+                count > 0
+            else {
+                fulfill(0)
+                return
+            }
 
-        promise.completeWithSuccess(ProfileTotalCountView.Size.height)
-        return promise.future
+            fulfill(ProfileTotalCountView.Size.height)
+        }
     }
 }

--- a/Sources/Controllers/Profile/Calculators/ProfileTotalCountSizeCalculator.swift
+++ b/Sources/Controllers/Profile/Calculators/ProfileTotalCountSizeCalculator.swift
@@ -8,17 +8,17 @@ import PromiseKit
 struct ProfileTotalCountSizeCalculator {
 
     func calculate(_ item: StreamCellItem) -> Promise<CGFloat> {
-        return Promise { fulfill, reject in
-            guard
-                let user = item.jsonable as? User,
-                let count = user.totalViewsCount,
-                count > 0
-            else {
-                fulfill(0)
-                return
-            }
-
-            fulfill(ProfileTotalCountView.Size.height)
+        let (promise, fulfill, _) = Promise<CGFloat>.pending()
+        guard
+            let user = item.jsonable as? User,
+            let count = user.totalViewsCount,
+            count > 0
+        else {
+            fulfill(0)
+            return promise
         }
+
+        fulfill(ProfileTotalCountView.Size.height)
+        return promise
     }
 }

--- a/Sources/Controllers/Profile/ProfileGenerator.swift
+++ b/Sources/Controllers/Profile/ProfileGenerator.swift
@@ -99,7 +99,7 @@ private extension ProfileGenerator {
 
         // load the user with no posts
         StreamService().loadUser(streamKind.endpoint)
-            .onSuccess { [weak self] user in
+            .thenFinally { [weak self] user in
                 guard let `self` = self else { return }
                 guard self.loadingToken.isValidInitialPageLoadingToken(self.localToken) else { return }
 
@@ -108,7 +108,7 @@ private extension ProfileGenerator {
                 self.destination?.replacePlaceholder(type: .profileHeader, items: self.headerItems()) {}
                 doneOperation.run()
             }
-            .onFail { [weak self] _ in
+            .catch { [weak self] _ in
                 guard let `self` = self else { return }
                 self.destination?.primaryJSONAbleNotFound()
                 self.queue.cancelAllOperations()
@@ -121,7 +121,7 @@ private extension ProfileGenerator {
         queue.addOperation(displayPostsOperation)
 
         StreamService().loadUserPosts(userParam)
-            .onSuccess { [weak self] (posts, responseConfig) in
+            .thenFinally { [weak self] (posts, responseConfig) in
                 guard let `self` = self else { return }
                 guard self.loadingToken.isValidInitialPageLoadingToken(self.localToken) else { return }
 
@@ -152,7 +152,7 @@ private extension ProfileGenerator {
                     }
                 }
             }
-            .onFail { [weak self] _ in
+            .catch { [weak self] _ in
                 guard let `self` = self else { return }
                 self.destination?.primaryJSONAbleNotFound()
                 self.queue.cancelAllOperations()

--- a/Sources/Controllers/Settings/DynamicSettingsViewController.swift
+++ b/Sources/Controllers/Settings/DynamicSettingsViewController.swift
@@ -71,7 +71,7 @@ class DynamicSettingsViewController: UITableViewController {
         tableView.rowHeight = DynamicSettingsCellHeight
 
         StreamService().loadStream(endpoint: .profileToggles)
-            .onSuccess { [weak self] response in
+            .thenFinally { [weak self] response in
                 guard let `self` = self else { return }
 
                 self.hideLoadingHud()
@@ -97,7 +97,7 @@ class DynamicSettingsViewController: UITableViewController {
                 case .empty: break
                 }
             }
-            .onFail { [weak self] _ in
+            .catch { [weak self] _ in
                 self?.hideLoadingHud()
             }
     }

--- a/Sources/Controllers/Stream/Calculators/CategoryHeaderCellSizeCalculator.swift
+++ b/Sources/Controllers/Stream/Calculators/CategoryHeaderCellSizeCalculator.swift
@@ -2,8 +2,6 @@
 ///  CategoryHeaderCellSizeCalculator.swift
 //
 
-import FutureKit
-
 
 class CategoryHeaderCellSizeCalculator {
     static let ratio: CGFloat = 320 / 192

--- a/Sources/Controllers/Stream/Detail/PostDetailGenerator.swift
+++ b/Sources/Controllers/Stream/Detail/PostDetailGenerator.swift
@@ -68,7 +68,7 @@ final class PostDetailGenerator: StreamGenerator {
 
         let scrollAPI = ElloAPI.infiniteScroll(queryItems: nextQueryItems) { return ElloAPI.postComments(postId: postId) }
         StreamService().loadStream(endpoint: scrollAPI, streamKind: .postDetail(postParam: postId))
-            .onSuccess { [weak self] response in
+            .thenFinally { [weak self] response in
                 guard let `self` = self else { return }
 
                 switch response {
@@ -84,7 +84,7 @@ final class PostDetailGenerator: StreamGenerator {
                     self.destination?.replacePlaceholder(type: .postLoadingComments, items: []) {}
                 }
             }
-            .onFail { _ in
+            .catch { _ in
                 self.destination?.replacePlaceholder(type: .postLoadingComments, items: []) {}
             }
     }
@@ -142,7 +142,7 @@ private extension PostDetailGenerator {
 
         // load the post with no comments
         PostService().loadPost(postParam, needsComments: false)
-            .onSuccess { [weak self] post in
+            .thenFinally { [weak self] post in
                 guard let `self` = self else { return }
                 guard self.loadingToken.isValidInitialPageLoadingToken(self.localToken) else { return }
                 self.post = post
@@ -151,7 +151,7 @@ private extension PostDetailGenerator {
                 self.destination?.replacePlaceholder(type: .postHeader, items: postItems) {}
                 doneOperation.run()
             }
-            .onFail { [weak self] _ in
+            .catch { [weak self] _ in
                 guard let `self` = self else { return }
                 self.destination?.primaryJSONAbleNotFound()
                 self.queue.cancelAllOperations()
@@ -201,7 +201,7 @@ private extension PostDetailGenerator {
         queue.addOperation(displayCommentsOperation)
 
         PostService().loadPostComments(postParam)
-            .onSuccess { [weak self] (comments, responseConfig) in
+            .thenFinally { [weak self] (comments, responseConfig) in
                 guard let `self` = self else { return }
                 guard self.loadingToken.isValidInitialPageLoadingToken(self.localToken) else { return }
 
@@ -217,7 +217,7 @@ private extension PostDetailGenerator {
                     }
                 }
             }
-            .onFail { _ in
+            .catch { _ in
                 print("failed load post comments")
             }
     }
@@ -230,7 +230,7 @@ private extension PostDetailGenerator {
         queue.addOperation(displayLoversOperation)
 
         PostService().loadPostLovers(postParam)
-            .onSuccess { [weak self] users in
+            .thenFinally { [weak self] users in
                 guard let `self` = self else { return }
                 guard self.loadingToken.isValidInitialPageLoadingToken(self.localToken) else { return }
                 guard users.count > 0 else { return }
@@ -247,7 +247,7 @@ private extension PostDetailGenerator {
                     }
                 }
             }
-            .onFail { _ in
+            .catch { _ in
                 print("failed load post lovers")
             }
     }
@@ -260,7 +260,7 @@ private extension PostDetailGenerator {
         queue.addOperation(displayRepostersOperation)
 
         PostService().loadPostReposters(postParam)
-            .onSuccess { [weak self] users in
+            .thenFinally { [weak self] users in
                 guard let `self` = self else { return }
                 guard self.loadingToken.isValidInitialPageLoadingToken(self.localToken) else { return }
                 guard users.count > 0 else { return }
@@ -277,7 +277,7 @@ private extension PostDetailGenerator {
                     }
                 }
             }
-            .onFail { _ in
+            .catch { _ in
                 print("failed load post reposters")
             }
     }
@@ -290,7 +290,7 @@ private extension PostDetailGenerator {
         queue.addOperation(displayRelatedPostsOperation)
 
         PostService().loadRelatedPosts(postParam)
-            .onSuccess { [weak self] relatedPosts in
+            .thenFinally { [weak self] relatedPosts in
                 guard let `self` = self else { return }
                 guard self.loadingToken.isValidInitialPageLoadingToken(self.localToken) else { return }
                 guard relatedPosts.count > 0 else { return }
@@ -306,7 +306,7 @@ private extension PostDetailGenerator {
                     }
                 }
             }
-            .onFail { _ in
+            .catch { _ in
                 print("failed load post reposters")
             }
     }

--- a/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
+++ b/Sources/Controllers/Stream/Detail/PostDetailViewController.swift
@@ -198,10 +198,10 @@ final class PostDetailViewController: StreamableViewController {
 
             postNotification(PostChangedNotification, value: (post, .delete))
             PostService().deletePost(post.id)
-                .onSuccess {
+                .then {
                     Tracker.shared.postDeleted(post)
                 }
-                .onFail { error in
+                .catch { error in
                     // TODO: add error handling
                     print("failed to delete post, error: \(error)")
                 }

--- a/Sources/Controllers/Stream/StreamViewController.swift
+++ b/Sources/Controllers/Stream/StreamViewController.swift
@@ -415,7 +415,7 @@ final class StreamViewController: BaseElloViewController {
             let localToken = loadingToken.resetInitialPageLoadingToken()
 
             streamService.loadStream(streamKind: streamKind)
-                .onSuccess { response in
+                .thenFinally { response in
                     guard self.loadingToken.isValidInitialPageLoadingToken(localToken) else { return }
 
                     switch response {
@@ -426,7 +426,7 @@ final class StreamViewController: BaseElloViewController {
                         self.showInitialJSONAbles([])
                     }
                 }
-                .onFail { error in
+                .catch { error in
                     print("failed to load \(self.streamKind.cacheKey) stream (reason: \(error))")
                     self.initialLoadFailure()
                 }
@@ -1256,7 +1256,7 @@ extension StreamViewController: UIScrollViewDelegate {
 
         let scrollAPI = ElloAPI.infiniteScroll(queryItems: nextQueryItems) { return self.streamKind.endpoint }
         streamService.loadStream(endpoint: scrollAPI, streamKind: streamKind)
-            .onSuccess { response in
+            .thenFinally { response in
                 switch response {
                 case let .jsonables(jsonables, responseConfig):
                     self.scrollLoaded(jsonables: jsonables, placeholderType: placeholderType)
@@ -1266,7 +1266,7 @@ extension StreamViewController: UIScrollViewDelegate {
                     self.scrollLoaded()
                 }
             }
-            .onFail { error in
+            .catch { error in
                 print("failed to load stream (reason: \(error))")
                 self.scrollLoaded()
             }

--- a/Sources/Controllers/Stream/StreamableViewController.swift
+++ b/Sources/Controllers/Stream/StreamableViewController.swift
@@ -352,7 +352,7 @@ extension StreamableViewController: InviteResponder {
         }
         ElloHUD.showLoadingHudInView(view)
         InviteService().invite(email)
-            .onComplete { [weak self] _ in
+            .always { [weak self] _ in
                 guard let `self` = self else { return }
                 ElloHUD.hideLoadingHudInView(self.view)
                 completion()

--- a/Sources/Networking/CategoryService.swift
+++ b/Sources/Networking/CategoryService.swift
@@ -3,43 +3,43 @@
 //
 
 import PINRemoteImage
-import FutureKit
+import PromiseKit
 
 typealias CategoriesCompletion = (_ categories: [Category]) -> Void
 
 class CategoryService {
 
-    func loadCategories() -> Future<[Category]> {
-        let promise = Promise<[Category]>()
-        ElloProvider.shared.elloRequest(.categories, success: { (data, responseConfig) in
-            if let categories = data as? [Category] {
-                Preloader().preloadImages(categories)
-                promise.completeWithSuccess(categories)
-            }
-            else {
-                promise.completeWithFail(NSError.uncastableJSONAble())
-            }
-        }, failure: { (error, _) in
-            promise.completeWithFail(error)
-        })
-        return promise.future
-    }
-
-    func loadCategory(_ categorySlug: String) -> Future<Category> {
-        let promise = Promise<Category>()
-        ElloProvider.shared.elloRequest(
-            ElloAPI.category(slug: categorySlug),
-            success: { (data, responseConfig) in
-                if let category = data as? Category {
-                    Preloader().preloadImages([category])
-                    promise.completeWithSuccess(category)
+    func loadCategories() -> Promise<[Category]> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(.categories, success: { (data, responseConfig) in
+                if let categories = data as? [Category] {
+                    Preloader().preloadImages(categories)
+                    fulfill(categories)
                 }
                 else {
-                    promise.completeWithFail(NSError.uncastableJSONAble())
+                    reject(NSError.uncastableJSONAble())
                 }
-            }, failure: { (error, statusCode) in
-                promise.completeWithFail(error)
+            }, failure: { (error, _) in
+                reject(error)
             })
-        return promise.future
+        }
+    }
+
+    func loadCategory(_ categorySlug: String) -> Promise<Category> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(
+                ElloAPI.category(slug: categorySlug),
+                success: { (data, responseConfig) in
+                    if let category = data as? Category {
+                        Preloader().preloadImages([category])
+                        fulfill(category)
+                    }
+                    else {
+                        reject(NSError.uncastableJSONAble())
+                    }
+                }, failure: { (error, statusCode) in
+                    reject(error)
+                })
+        }
     }
 }

--- a/Sources/Networking/CategoryService.swift
+++ b/Sources/Networking/CategoryService.swift
@@ -10,36 +10,25 @@ typealias CategoriesCompletion = (_ categories: [Category]) -> Void
 class CategoryService {
 
     func loadCategories() -> Promise<[Category]> {
-        return Promise { fulfill, reject in
-            ElloProvider.shared.elloRequest(.categories, success: { (data, responseConfig) in
-                if let categories = data as? [Category] {
-                    Preloader().preloadImages(categories)
-                    fulfill(categories)
+        return ElloProvider.shared.request(.categories)
+            .then { data, _ -> [Category] in
+                guard let categories = data as? [Category] else {
+                    throw NSError.uncastableJSONAble()
                 }
-                else {
-                    reject(NSError.uncastableJSONAble())
-                }
-            }, failure: { (error, _) in
-                reject(error)
-            })
-        }
+                Preloader().preloadImages(categories)
+                return categories
+            }
     }
 
     func loadCategory(_ categorySlug: String) -> Promise<Category> {
-        return Promise { fulfill, reject in
-            ElloProvider.shared.elloRequest(
-                ElloAPI.category(slug: categorySlug),
-                success: { (data, responseConfig) in
-                    if let category = data as? Category {
-                        Preloader().preloadImages([category])
-                        fulfill(category)
-                    }
-                    else {
-                        reject(NSError.uncastableJSONAble())
-                    }
-                }, failure: { (error, statusCode) in
-                    reject(error)
-                })
-        }
+        return ElloProvider.shared.request(.category(slug: categorySlug))
+            .then { data, _ -> Category in
+                guard let category = data as? Category else {
+                    throw NSError.uncastableJSONAble()
+                }
+                Preloader().preloadImages([category])
+                return category
+            }
     }
+
 }

--- a/Sources/Networking/ElloProvider.swift
+++ b/Sources/Networking/ElloProvider.swift
@@ -5,14 +5,15 @@
 import Moya
 import Result
 import Alamofire
+import PromiseKit
 
 
 typealias ElloRequestClosure = (target: ElloAPI, success: ElloSuccessCompletion, failure: ElloFailureCompletion)
 typealias ElloSuccessCompletion = (Any, ResponseConfig) -> Void
-typealias ElloFailure = (error: NSError, Int?)
 typealias ElloFailureCompletion = (NSError, Int?) -> Void
 typealias ElloErrorCompletion = (NSError) -> Void
 typealias ElloEmptyCompletion = () -> Void
+typealias ElloAPIResponse = (Any, ResponseConfig)
 
 class ElloProvider {
     static var shared: ElloProvider = ElloProvider()
@@ -57,6 +58,18 @@ class ElloProvider {
     }
 
     // MARK: - Public
+
+    func request(_ target: ElloAPI) -> Promise<ElloAPIResponse> {
+        return Promise { fulfill, reject in
+            elloRequest((target,
+                success: { jsonables, responseConfig in
+                    fulfill((jsonables, responseConfig))
+                },
+                failure: { error, _ in
+                    reject(error)
+                }))
+        }
+    }
 
     func elloRequest(_ target: ElloAPI, success: @escaping ElloSuccessCompletion) {
         elloRequest((target: target, success: success, failure: { _ in }))

--- a/Sources/Networking/ElloProvider.swift
+++ b/Sources/Networking/ElloProvider.swift
@@ -60,15 +60,15 @@ class ElloProvider {
     // MARK: - Public
 
     func request(_ target: ElloAPI) -> Promise<ElloAPIResponse> {
-        return Promise { fulfill, reject in
-            elloRequest((target,
-                success: { jsonables, responseConfig in
-                    fulfill((jsonables, responseConfig))
-                },
-                failure: { error, _ in
-                    reject(error)
-                }))
-        }
+        let (promise, fulfill, reject) = Promise<CGFloat>.pending()
+        elloRequest((target,
+            success: { jsonables, responseConfig in
+                fulfill((jsonables, responseConfig))
+            },
+            failure: { error, _ in
+                reject(error)
+            }))
+        return promise
     }
 
     func elloRequest(_ target: ElloAPI, success: @escaping ElloSuccessCompletion) {

--- a/Sources/Networking/ElloProvider.swift
+++ b/Sources/Networking/ElloProvider.swift
@@ -60,7 +60,7 @@ class ElloProvider {
     // MARK: - Public
 
     func request(_ target: ElloAPI) -> Promise<ElloAPIResponse> {
-        let (promise, fulfill, reject) = Promise<CGFloat>.pending()
+        let (promise, fulfill, reject) = Promise<ElloAPIResponse>.pending()
         elloRequest((target,
             success: { jsonables, responseConfig in
                 fulfill((jsonables, responseConfig))

--- a/Sources/Networking/HireService.swift
+++ b/Sources/Networking/HireService.swift
@@ -7,32 +7,14 @@ import PromiseKit
 
 class HireService {
 
-    init() {}
-
-    func hire(user: User, body: String) -> Promise<Void> {
-        return Promise { fulfill, reject in
-            ElloProvider.shared.elloRequest(.hire(userId: user.id, body: body),
-                success: { _ in
-                    fulfill(Void())
-                },
-                failure: { error, _ in
-                    reject(error)
-                }
-            )
-        }
+    func hire(user: User, body: String) -> Promise<()> {
+        return ElloProvider.shared.request(.hire(userId: user.id, body: body))
+            .thenFinally { _ in }
     }
 
-    func collaborate(user: User, body: String) -> Promise<Void> {
-        return Promise { fulfill, reject in
-            ElloProvider.shared.elloRequest(.collaborate(userId: user.id, body: body),
-                success: { _ in
-                    fulfill(Void())
-                },
-                failure: { error, _ in
-                    reject(error)
-                }
-            )
-        }
+    func collaborate(user: User, body: String) -> Promise<()> {
+        return ElloProvider.shared.request(.collaborate(userId: user.id, body: body))
+            .thenFinally { _ in }
     }
 
 }

--- a/Sources/Networking/HireService.swift
+++ b/Sources/Networking/HireService.swift
@@ -2,37 +2,37 @@
 ///  HireService.swift
 //
 
-import FutureKit
+import PromiseKit
 
 
 class HireService {
 
     init() {}
 
-    func hire(user: User, body: String) -> Future<Void> {
-        let promise = Promise<Void>()
-        ElloProvider.shared.elloRequest(.hire(userId: user.id, body: body),
-            success: { _ in
-                promise.completeWithSuccess(Void())
-            },
-            failure: { error, _ in
-                promise.completeWithFail(error)
-            }
-        )
-        return promise.future
+    func hire(user: User, body: String) -> Promise<Void> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(.hire(userId: user.id, body: body),
+                success: { _ in
+                    fulfill(Void())
+                },
+                failure: { error, _ in
+                    reject(error)
+                }
+            )
+        }
     }
 
-    func collaborate(user: User, body: String) -> Future<Void> {
-        let promise = Promise<Void>()
-        ElloProvider.shared.elloRequest(.collaborate(userId: user.id, body: body),
-            success: { _ in
-                promise.completeWithSuccess(Void())
-            },
-            failure: { error, _ in
-                promise.completeWithFail(error)
-            }
-        )
-        return promise.future
+    func collaborate(user: User, body: String) -> Promise<Void> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(.collaborate(userId: user.id, body: body),
+                success: { _ in
+                    fulfill(Void())
+                },
+                failure: { error, _ in
+                    reject(error)
+                }
+            )
+        }
     }
 
 }

--- a/Sources/Networking/HireService.swift
+++ b/Sources/Networking/HireService.swift
@@ -9,12 +9,12 @@ class HireService {
 
     func hire(user: User, body: String) -> Promise<()> {
         return ElloProvider.shared.request(.hire(userId: user.id, body: body))
-            .thenFinally { _ in }
+            .asVoid()
     }
 
     func collaborate(user: User, body: String) -> Promise<()> {
         return ElloProvider.shared.request(.collaborate(userId: user.id, body: body))
-            .thenFinally { _ in }
+            .asVoid()
     }
 
 }

--- a/Sources/Networking/InviteService.swift
+++ b/Sources/Networking/InviteService.swift
@@ -12,12 +12,12 @@ struct InviteService {
 
     func sendInvitations(_ emails: [String]) -> Promise<()> {
         return ElloProvider.shared.request(.invitations(emails: emails))
-            .thenFinally { _ in }
+            .asVoid()
     }
 
     func invite(_ email: String) -> Promise<()> {
         return ElloProvider.shared.request(.inviteFriends(email: email))
-            .thenFinally { _ in }
+            .asVoid()
     }
 
     func find(_ addressBook: AddressBookProtocol, currentUser: User?) -> Promise<FindSuccess> {

--- a/Sources/Networking/NotificationService.swift
+++ b/Sources/Networking/NotificationService.swift
@@ -7,42 +7,26 @@ import PromiseKit
 
 class NotificationService {
 
-    init() {}
-
     func loadAnnouncements() -> Promise<Announcement?> {
-        return Promise { fulfill, reject in
-            ElloProvider.shared.elloRequest(
-                .announcements,
-                success: { (data, responseConfig) in
-                    if let results = data as? Announcement {
-                        fulfill(results)
-                    }
-                    else if data as? String == "" {
-                        fulfill(nil)
-                    }
-                    else {
-                        let error = NSError.uncastableJSONAble()
-                        reject(error)
-                    }
-                },
-                failure: { error, _ in
-                    reject(error)
+        return ElloProvider.shared.request(.announcements)
+            .then { data, _ -> Announcement? in
+                if let results = data as? Announcement {
+                    return results
                 }
-            )
-        }
+                else if data as? String == "" {
+                    return nil
+                }
+                else {
+                    throw NSError.uncastableJSONAble()
+                }
+            }
     }
 
     func markAnnouncementAsRead(_ announcement: Announcement) -> Promise<Announcement> {
-        return Promise { fulfill, reject in
-            ElloProvider.shared.elloRequest(.markAnnouncementAsRead,
-                success: { _ in
-                    fulfill(announcement)
-                },
-                failure: { error, _ in
-                    reject(error)
-                }
-            )
-        }
+        return ElloProvider.shared.request(.markAnnouncementAsRead)
+            .then { _ -> Announcement in
+                return announcement
+            }
     }
 
 }

--- a/Sources/Networking/NotificationService.swift
+++ b/Sources/Networking/NotificationService.swift
@@ -2,47 +2,47 @@
 ///  NotificationService.swift
 //
 
-import FutureKit
+import PromiseKit
 
 
 class NotificationService {
 
     init() {}
 
-    func loadAnnouncements() -> Future<Announcement?> {
-        let promise = Promise<Announcement?>()
-        ElloProvider.shared.elloRequest(
-            .announcements,
-            success: { (data, responseConfig) in
-                if let results = data as? Announcement {
-                    promise.completeWithSuccess(results)
+    func loadAnnouncements() -> Promise<Announcement?> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(
+                .announcements,
+                success: { (data, responseConfig) in
+                    if let results = data as? Announcement {
+                        fulfill(results)
+                    }
+                    else if data as? String == "" {
+                        fulfill(nil)
+                    }
+                    else {
+                        let error = NSError.uncastableJSONAble()
+                        reject(error)
+                    }
+                },
+                failure: { error, _ in
+                    reject(error)
                 }
-                else if data as? String == "" {
-                    promise.completeWithSuccess(nil)
-                }
-                else {
-                    let error = NSError.uncastableJSONAble()
-                    promise.completeWithFail(error)
-                }
-            },
-            failure: { error, _ in
-                promise.completeWithFail(error)
-            }
-        )
-        return promise.future
+            )
+        }
     }
 
-    func markAnnouncementAsRead(_ announcement: Announcement) -> Future<Announcement> {
-        let promise = Promise<Announcement>()
-        ElloProvider.shared.elloRequest(.markAnnouncementAsRead,
-            success: { _ in
-                promise.completeWithSuccess(announcement)
-            },
-            failure: { error, _ in
-                promise.completeWithFail(error)
-            }
-        )
-        return promise.future
+    func markAnnouncementAsRead(_ announcement: Announcement) -> Promise<Announcement> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(.markAnnouncementAsRead,
+                success: { _ in
+                    fulfill(announcement)
+                },
+                failure: { error, _ in
+                    reject(error)
+                }
+            )
+        }
     }
 
 }

--- a/Sources/Networking/PagePromotionalService.swift
+++ b/Sources/Networking/PagePromotionalService.swift
@@ -3,28 +3,28 @@
 //
 
 import PINRemoteImage
-import FutureKit
+import PromiseKit
 
 
 class PagePromotionalService {
 
-    func loadPagePromotionals() -> Future<[PagePromotional]?> {
-        let promise = Promise<[PagePromotional]?>()
-        ElloProvider.shared.elloRequest(.pagePromotionals,
-            success: { (data, responseConfig) in
-                if responseConfig.statusCode == 204 {
-                    promise.completeWithSuccess(.none)
-                }
-                else if let pagePromotionals = data as? [PagePromotional] {
-                    Preloader().preloadImages(pagePromotionals)
-                    promise.completeWithSuccess(pagePromotionals)
-                }
-                else {
-                    promise.completeWithFail(NSError.uncastableJSONAble())
-                }
-            }, failure: { (error, statusCode) in
-                promise.completeWithFail(error)
-            })
-        return promise.future
+    func loadPagePromotionals() -> Promise<[PagePromotional]?> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(.pagePromotionals,
+                success: { (data, responseConfig) in
+                    if responseConfig.statusCode == 204 {
+                        fulfill(.none)
+                    }
+                    else if let pagePromotionals = data as? [PagePromotional] {
+                        Preloader().preloadImages(pagePromotionals)
+                        fulfill(pagePromotionals)
+                    }
+                    else {
+                        reject(NSError.uncastableJSONAble())
+                    }
+                }, failure: { (error, statusCode) in
+                    reject(error)
+                })
+        }
     }
 }

--- a/Sources/Networking/PagePromotionalService.swift
+++ b/Sources/Networking/PagePromotionalService.swift
@@ -9,22 +9,18 @@ import PromiseKit
 class PagePromotionalService {
 
     func loadPagePromotionals() -> Promise<[PagePromotional]?> {
-        return Promise { fulfill, reject in
-            ElloProvider.shared.elloRequest(.pagePromotionals,
-                success: { (data, responseConfig) in
-                    if responseConfig.statusCode == 204 {
-                        fulfill(.none)
-                    }
-                    else if let pagePromotionals = data as? [PagePromotional] {
-                        Preloader().preloadImages(pagePromotionals)
-                        fulfill(pagePromotionals)
-                    }
-                    else {
-                        reject(NSError.uncastableJSONAble())
-                    }
-                }, failure: { (error, statusCode) in
-                    reject(error)
-                })
-        }
+        return ElloProvider.shared.request(.pagePromotionals)
+            .then { data, responseConfig -> [PagePromotional]? in
+                if responseConfig.statusCode == 204 {
+                    return .none
+                }
+                else if let pagePromotionals = data as? [PagePromotional] {
+                    Preloader().preloadImages(pagePromotionals)
+                    return pagePromotionals
+                }
+                else {
+                    throw NSError.uncastableJSONAble()
+                }
+            }
     }
 }

--- a/Sources/Networking/PagePromotionalService.swift
+++ b/Sources/Networking/PagePromotionalService.swift
@@ -12,7 +12,7 @@ class PagePromotionalService {
         return ElloProvider.shared.request(.pagePromotionals)
             .then { data, responseConfig -> [PagePromotional]? in
                 if responseConfig.statusCode == 204 {
-                    return .none
+                    return nil
                 }
                 else if let pagePromotionals = data as? [PagePromotional] {
                     Preloader().preloadImages(pagePromotionals)

--- a/Sources/Networking/PostService.swift
+++ b/Sources/Networking/PostService.swift
@@ -2,33 +2,33 @@
 ///  PostService.swift
 //
 
-import FutureKit
+import PromiseKit
 
 
 struct PostService {
 
     func loadPost(
         _ postParam: String,
-        needsComments: Bool) -> Future<Post>
+        needsComments: Bool) -> Promise<Post>
     {
         let commentCount = needsComments ? 10 : 0
-        let promise = Promise<Post>()
-        ElloProvider.shared.elloRequest(
-            ElloAPI.postDetail(postParam: postParam, commentCount: commentCount),
-            success: { (data, responseConfig) in
-                if let post = data as? Post {
-                    Preloader().preloadImages([post])
-                    promise.completeWithSuccess(post)
-                }
-                else {
-                    let error = NSError.uncastableJSONAble()
-                    promise.completeWithFail(error)
-                }
-            },
-            failure: { (error, _) in
-                promise.completeWithFail(error)
-            })
-        return promise.future
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(
+                ElloAPI.postDetail(postParam: postParam, commentCount: commentCount),
+                success: { (data, responseConfig) in
+                    if let post = data as? Post {
+                        Preloader().preloadImages([post])
+                        fulfill(post)
+                    }
+                    else {
+                        let error = NSError.uncastableJSONAble()
+                        reject(error)
+                    }
+                },
+                failure: { (error, _) in
+                    reject(error)
+                })
+        }
     }
 
     func sendPostViews(
@@ -46,168 +46,168 @@ struct PostService {
             success: { _ in })
     }
 
-    func loadPostComments(_ postId: String) -> Future<([ElloComment], ResponseConfig)> {
-        let promise = Promise<([ElloComment], ResponseConfig)>()
-        ElloProvider.shared.elloRequest(
-            ElloAPI.postComments(postId: postId),
-            success: { (data, responseConfig) in
-                if let comments = data as? [ElloComment] {
-                    Preloader().preloadImages(comments)
-                    for comment in comments {
-                        comment.loadedFromPostId = postId
+    func loadPostComments(_ postId: String) -> Promise<([ElloComment], ResponseConfig)> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(
+                ElloAPI.postComments(postId: postId),
+                success: { (data, responseConfig) in
+                    if let comments = data as? [ElloComment] {
+                        Preloader().preloadImages(comments)
+                        for comment in comments {
+                            comment.loadedFromPostId = postId
+                        }
+                        fulfill((comments, responseConfig))
                     }
-                    promise.completeWithSuccess((comments, responseConfig))
-                }
-                else if data as? String == "" {
-                    promise.completeWithSuccess(([], responseConfig))
-                }
-                else {
-                    let error = NSError.uncastableJSONAble()
-                    promise.completeWithFail(error)
-                }
-            },
-            failure: { (error, statusCode) in
-                promise.completeWithFail(error)
-            })
-        return promise.future
+                    else if data as? String == "" {
+                        fulfill(([], responseConfig))
+                    }
+                    else {
+                        let error = NSError.uncastableJSONAble()
+                        reject(error)
+                    }
+                },
+                failure: { (error, statusCode) in
+                    reject(error)
+                })
+        }
     }
 
-    func loadPostLovers(_ postId: String) -> Future<[User]> {
-        let promise = Promise<[User]>()
-        ElloProvider.shared.elloRequest(
-            ElloAPI.postLovers(postId: postId),
-            success: { (data, responseConfig) in
-                if let users = data as? [User] {
-                    Preloader().preloadImages(users)
-                    promise.completeWithSuccess(users)
-                }
-                else if data as? String == "" {
-                    promise.completeWithSuccess([])
-                }
-                else {
-                    let error = NSError.uncastableJSONAble()
-                    promise.completeWithFail(error)
-                }
-            },
-            failure: { (error, statusCode) in
-                promise.completeWithFail(error)
-            })
-        return promise.future
+    func loadPostLovers(_ postId: String) -> Promise<[User]> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(
+                ElloAPI.postLovers(postId: postId),
+                success: { (data, responseConfig) in
+                    if let users = data as? [User] {
+                        Preloader().preloadImages(users)
+                        fulfill(users)
+                    }
+                    else if data as? String == "" {
+                        fulfill([])
+                    }
+                    else {
+                        let error = NSError.uncastableJSONAble()
+                        reject(error)
+                    }
+                },
+                failure: { (error, statusCode) in
+                    reject(error)
+                })
+        }
     }
 
-    func loadPostReposters(_ postId: String) -> Future<[User]> {
-        let promise = Promise<[User]>()
-        ElloProvider.shared.elloRequest(
-            ElloAPI.postReposters(postId: postId),
-            success: { (data, responseConfig) in
-                if let users = data as? [User] {
-                    Preloader().preloadImages(users)
-                    promise.completeWithSuccess(users)
-                }
-                else if data as? String == "" {
-                    promise.completeWithSuccess([])
-                }
-                else {
-                    let error = NSError.uncastableJSONAble()
-                    promise.completeWithFail(error)
-                }
-            },
-            failure: { (error, statusCode) in
-                promise.completeWithFail(error)
-            })
-        return promise.future
+    func loadPostReposters(_ postId: String) -> Promise<[User]> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(
+                ElloAPI.postReposters(postId: postId),
+                success: { (data, responseConfig) in
+                    if let users = data as? [User] {
+                        Preloader().preloadImages(users)
+                        fulfill(users)
+                    }
+                    else if data as? String == "" {
+                        fulfill([])
+                    }
+                    else {
+                        let error = NSError.uncastableJSONAble()
+                        reject(error)
+                    }
+                },
+                failure: { (error, statusCode) in
+                    reject(error)
+                })
+        }
     }
 
-    func loadRelatedPosts(_ postId: String)  -> Future<[Post]> {
-        let promise = Promise<[Post]>()
-       ElloProvider.shared.elloRequest(
-           ElloAPI.postRelatedPosts(postId: postId),
-           success: { (data, _) in
-               if let posts = data as? [Post] {
-                   Preloader().preloadImages(posts)
-                   promise.completeWithSuccess(posts)
-               }
-                else if data as? String == "" {
-                    promise.completeWithSuccess([])
-                }
-               else {
-                   let error = NSError.uncastableJSONAble()
-                   promise.completeWithFail(error)
-               }
-           },
-           failure: { (error, statusCode) in
-               promise.completeWithFail(error)
-           })
-        return promise.future
+    func loadRelatedPosts(_ postId: String)  -> Promise<[Post]> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(
+                ElloAPI.postRelatedPosts(postId: postId),
+                success: { (data, _) in
+                    if let posts = data as? [Post] {
+                        Preloader().preloadImages(posts)
+                        fulfill(posts)
+                    }
+                     else if data as? String == "" {
+                         fulfill([])
+                     }
+                    else {
+                        let error = NSError.uncastableJSONAble()
+                        reject(error)
+                    }
+                },
+                failure: { (error, statusCode) in
+                    reject(error)
+                })
+        }
     }
 
-    func loadComment(_ postId: String, commentId: String) -> Future<ElloComment> {
-        let promise = Promise<ElloComment>()
-        ElloProvider.shared.elloRequest(
-            ElloAPI.commentDetail(postId: postId, commentId: commentId),
-            success: { (data, responseConfig) in
-                if let comment = data as? ElloComment {
-                    comment.loadedFromPostId = postId
-                    promise.completeWithSuccess(comment)
-                }
-                else {
-                    let error = NSError.uncastableJSONAble()
-                    promise.completeWithFail(error)
-                }
-            },
-            failure: { (error, statusCode) in
-                promise.completeWithFail(error)
-            })
-        return promise.future
+    func loadComment(_ postId: String, commentId: String) -> Promise<ElloComment> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(
+                ElloAPI.commentDetail(postId: postId, commentId: commentId),
+                success: { (data, responseConfig) in
+                    if let comment = data as? ElloComment {
+                        comment.loadedFromPostId = postId
+                        fulfill(comment)
+                    }
+                    else {
+                        let error = NSError.uncastableJSONAble()
+                        reject(error)
+                    }
+                },
+                failure: { (error, statusCode) in
+                    reject(error)
+                })
+        }
     }
 
-    func loadReplyAll(_ postId: String) -> Future<[String]> {
-        let promise = Promise<[String]>()
-        ElloProvider.shared.elloRequest(
-            ElloAPI.postReplyAll(postId: postId),
-            success: { (usernames, _) in
-                if let usernames = usernames as? [Username] {
-                    let strings = usernames
-                        .map { $0.username }
-                    let uniq = strings.unique()
-                    promise.completeWithSuccess(uniq)
+    func loadReplyAll(_ postId: String) -> Promise<[String]> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(
+                ElloAPI.postReplyAll(postId: postId),
+                success: { (usernames, _) in
+                    if let usernames = usernames as? [Username] {
+                        let strings = usernames
+                            .map { $0.username }
+                        let uniq = strings.unique()
+                        fulfill(uniq)
+                    }
+                    else {
+                        let error = NSError.uncastableJSONAble()
+                        reject(error)
+                    }
+                }, failure: { (error, _) in
+                    reject(error)
+                })
+        }
+    }
+
+    func deletePost(_ postId: String) -> Promise<()> {
+            return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(ElloAPI.deletePost(postId: postId),
+                success: { (_, _) in
+                    URLCache.shared.removeAllCachedResponses()
+                    fulfill(())
+                }, failure: { (error, _) in
+                    reject(error)
                 }
-                else {
-                    let error = NSError.uncastableJSONAble()
-                    promise.completeWithFail(error)
+            )
+        }
+    }
+
+    func deleteComment(_ postId: String, commentId: String) -> Promise<()> {
+            return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(ElloAPI.deleteComment(postId: postId, commentId: commentId),
+                success: { (_, _) in
+                    fulfill(())
+                }, failure: { (error, _) in
+                    reject(error)
                 }
-            }, failure: { (error, _) in
-                promise.completeWithFail(error)
-            })
-        return promise.future
+            )
+        }
     }
 
-    func deletePost(_ postId: String) -> Future<()> {
-        let promise = Promise<()>()
-        ElloProvider.shared.elloRequest(ElloAPI.deletePost(postId: postId),
-            success: { (_, _) in
-                URLCache.shared.removeAllCachedResponses()
-                promise.completeWithSuccess(())
-            }, failure: { (error, _) in
-                promise.completeWithFail(error)
-            }
-        )
-        return promise.future
-    }
-
-    func deleteComment(_ postId: String, commentId: String) -> Future<()> {
-        let promise = Promise<()>()
-        ElloProvider.shared.elloRequest(ElloAPI.deleteComment(postId: postId, commentId: commentId),
-            success: { (_, _) in
-                promise.completeWithSuccess(())
-            }, failure: { (error, _) in
-                promise.completeWithFail(error)
-            }
-        )
-        return promise.future
-    }
-
-    func toggleWatchPost(_ post: Post, watching: Bool) -> Future<Post> {
+    func toggleWatchPost(_ post: Post, watching: Bool) -> Promise<Post> {
         let api: ElloAPI
         if watching {
             api = ElloAPI.createWatchPost(postId: post.id)
@@ -216,28 +216,28 @@ struct PostService {
             api = ElloAPI.deleteWatchPost(postId: post.id)
         }
 
-        let promise = Promise<Post>()
-        ElloProvider.shared.elloRequest(api,
-            success: { data, _ in
-                if watching,
-                    let watch = data as? Watch,
-                    let post = watch.post
-                {
-                    promise.completeWithSuccess(post)
-                }
-                else if !watching {
-                    post.watching = false
-                    ElloLinkedStore.sharedInstance.setObject(post, forKey: post.id, type: .postsType)
-                    promise.completeWithSuccess(post)
-                }
-                else {
-                    let error = NSError.uncastableJSONAble()
-                    promise.completeWithFail(error)
-                }
-            },
-            failure: { error, _ in
-                promise.completeWithFail(error)
-            })
-        return promise.future
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(api,
+                success: { data, _ in
+                    if watching,
+                        let watch = data as? Watch,
+                        let post = watch.post
+                    {
+                        fulfill(post)
+                    }
+                    else if !watching {
+                        post.watching = false
+                        ElloLinkedStore.sharedInstance.setObject(post, forKey: post.id, type: .postsType)
+                        fulfill(post)
+                    }
+                    else {
+                        let error = NSError.uncastableJSONAble()
+                        reject(error)
+                    }
+                },
+                failure: { error, _ in
+                    reject(error)
+                })
+        }
     }
 }

--- a/Sources/Networking/PostService.swift
+++ b/Sources/Networking/PostService.swift
@@ -140,7 +140,7 @@ struct PostService {
 
     func deleteComment(_ postId: String, commentId: String) -> Promise<()> {
         return ElloProvider.shared.request(.deleteComment(postId: postId, commentId: commentId))
-            .thenFinally { _ in }
+            .asVoid()
     }
 
     func toggleWatchPost(_ post: Post, watching: Bool) -> Promise<Post> {

--- a/Sources/Networking/S3UploadingService.swift
+++ b/Sources/Networking/S3UploadingService.swift
@@ -49,14 +49,14 @@ class S3UploadingService {
             success: { credentialsData, responseConfig in
                 if let credentials = credentialsData as? AmazonCredentials {
                     self.uploader = ElloS3(credentials: credentials, filename: filename, data: data, contentType: contentType)
-                        .onSuccess({ (data: Data) in
+                        .thenFinally { (data: Data) in
                             let endpoint: String = credentials.endpoint
                             let prefix: String = credentials.prefix
                             success(URL(string: "\(endpoint)/\(prefix)/\(filename)"))
-                        })
-                        .onFailure({ (error: Swift.Error) in
+                        }
+                        .catch { (error: Swift.Error) in
                             failure(error as NSError, nil) // FIXME - is this the correct usage of Error?
-                        })
+                        }
                         .start()
                 }
                 else {

--- a/Sources/Networking/StreamService.swift
+++ b/Sources/Networking/StreamService.swift
@@ -3,7 +3,8 @@
 //
 
 import Moya
-import FutureKit
+import PromiseKit
+
 
 struct StreamLoadedNotifications {
     static let streamLoaded = TypedNotification<StreamKind>(name: "StreamLoadedNotification")
@@ -17,114 +18,114 @@ class StreamService {
 
     init() {}
 
-    func loadStream(streamKind: StreamKind) -> Future<StreamResponse> {
+    func loadStream(streamKind: StreamKind) -> Promise<StreamResponse> {
         return loadStream(endpoint: streamKind.endpoint, streamKind: streamKind)
     }
 
-    func loadStream(endpoint: ElloAPI, streamKind: StreamKind? = nil) -> Future<StreamResponse> {
-        let promise = Promise<StreamResponse>()
-        ElloProvider.shared.elloRequest(
-            endpoint,
-            success: { (data, responseConfig) in
-                if let jsonables = data as? [JSONAble] {
+    func loadStream(endpoint: ElloAPI, streamKind: StreamKind? = nil) -> Promise<StreamResponse> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(
+                endpoint,
+                success: { (data, responseConfig) in
+                    if let jsonables = data as? [JSONAble] {
+                        if let streamKind = streamKind {
+                            Preloader().preloadImages(jsonables)
+                            NewContentService().updateCreatedAt(jsonables, streamKind: streamKind)
+                        }
+                        fulfill(.jsonables(jsonables, responseConfig))
+                    }
+                    else {
+                        fulfill(.empty)
+                    }
+
+                    // this must be the last thing, after success() or noContent() is called.
                     if let streamKind = streamKind {
-                        Preloader().preloadImages(jsonables)
-                        NewContentService().updateCreatedAt(jsonables, streamKind: streamKind)
+                        postNotification(StreamLoadedNotifications.streamLoaded, value: streamKind)
                     }
-                    promise.completeWithSuccess(.jsonables(jsonables, responseConfig))
-                }
-                else {
-                    promise.completeWithSuccess(.empty)
-                }
-
-                // this must be the last thing, after success() or noContent() is called.
-                if let streamKind = streamKind {
-                    postNotification(StreamLoadedNotifications.streamLoaded, value: streamKind)
-                }
-            },
-            failure: { (error, statusCode) in
-                promise.completeWithFail(error)
-            })
-        return promise.future
+                },
+                failure: { (error, statusCode) in
+                    reject(error)
+                })
+        }
     }
 
-    func loadUser(_ endpoint: ElloAPI) -> Future<User> {
-        let promise = Promise<User>()
-        ElloProvider.shared.elloRequest(
-            endpoint,
-            success: { (data, responseConfig) in
-                if let user = data as? User {
-                    Preloader().preloadImages([user])
-                    promise.completeWithSuccess(user)
+    func loadUser(_ endpoint: ElloAPI) -> Promise<User> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(
+                endpoint,
+                success: { (data, responseConfig) in
+                    if let user = data as? User {
+                        Preloader().preloadImages([user])
+                        fulfill(user)
+                    }
+                    else {
+                        let error = NSError.uncastableJSONAble()
+                        reject(error)
+                    }
+                },
+                failure: { error, _ in
+                    reject(error)
                 }
-                else {
-                    let error = NSError.uncastableJSONAble()
-                    promise.completeWithFail(error)
-                }
-            },
-            failure: { error, _ in
-                promise.completeWithFail(error)
-            }
-        )
-        return promise.future
+            )
+        }
     }
 
-    func loadUserPosts(_ userId: String) -> Future<([Post], ResponseConfig)> {
-        let promise = Promise<([Post], ResponseConfig)>()
-        ElloProvider.shared.elloRequest(
-            ElloAPI.userStreamPosts(userId: userId),
-            success: { (data, responseConfig) in
-                let posts: [Post]?
-                if data as? String == "" {
-                    posts = []
-                }
-                else if let foundPosts = data as? [Post] {
-                    posts = foundPosts
-                }
-                else {
-                    posts = nil
-                }
-
-                if let posts = posts {
-                    Preloader().preloadImages(posts)
-                    promise.completeWithSuccess((posts, responseConfig))
-                }
-                else {
-                    let error = NSError.uncastableJSONAble()
-                    promise.completeWithFail(error)
-                }
-            },
-            failure: { error, _ in
-                promise.completeWithFail(error)
-            })
-        return promise.future
-    }
-
-    func loadMoreCommentsForPost(_ postId: String) -> Future<StreamResponse> {
-        let promise = Promise<StreamResponse>()
-        ElloProvider.shared.elloRequest(
-            .postComments(postId: postId),
-            success: { (data, responseConfig) in
-                if let comments: [ElloComment] = data as? [ElloComment] {
-                    for comment in comments {
-                        comment.loadedFromPostId = postId
+    func loadUserPosts(_ userId: String) -> Promise<([Post], ResponseConfig)> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(
+                ElloAPI.userStreamPosts(userId: userId),
+                success: { (data, responseConfig) in
+                    let posts: [Post]?
+                    if data as? String == "" {
+                        posts = []
+                    }
+                    else if let foundPosts = data as? [Post] {
+                        posts = foundPosts
+                    }
+                    else {
+                        posts = nil
                     }
 
-                    Preloader().preloadImages(comments)
-                    promise.completeWithSuccess(.jsonables(comments, responseConfig))
+                    if let posts = posts {
+                        Preloader().preloadImages(posts)
+                        fulfill((posts, responseConfig))
+                    }
+                    else {
+                        let error = NSError.uncastableJSONAble()
+                        reject(error)
+                    }
+                },
+                failure: { error, _ in
+                    reject(error)
+                })
+        }
+    }
+
+    func loadMoreCommentsForPost(_ postId: String) -> Promise<StreamResponse> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(
+                .postComments(postId: postId),
+                success: { (data, responseConfig) in
+                    if let comments: [ElloComment] = data as? [ElloComment] {
+                        for comment in comments {
+                            comment.loadedFromPostId = postId
+                        }
+
+                        Preloader().preloadImages(comments)
+                        fulfill(.jsonables(comments, responseConfig))
+                    }
+                    else if (data as? String) == "" {
+                        fulfill(.empty)
+                    }
+                    else {
+                        let error = NSError.uncastableJSONAble()
+                        reject(error)
+                    }
+                },
+                failure: { error, _ in
+                    reject(error)
                 }
-                else if (data as? String) == "" {
-                    promise.completeWithSuccess(.empty)
-                }
-                else {
-                    let error = NSError.uncastableJSONAble()
-                    promise.completeWithFail(error)
-                }
-            },
-            failure: { error, _ in
-                promise.completeWithFail(error)
-            }
-        )
-        return promise.future
+            )
+        }
     }
 }

--- a/Sources/Networking/StreamService.swift
+++ b/Sources/Networking/StreamService.swift
@@ -23,109 +23,82 @@ class StreamService {
     }
 
     func loadStream(endpoint: ElloAPI, streamKind: StreamKind? = nil) -> Promise<StreamResponse> {
-        return Promise { fulfill, reject in
-            ElloProvider.shared.elloRequest(
-                endpoint,
-                success: { (data, responseConfig) in
-                    if let jsonables = data as? [JSONAble] {
-                        if let streamKind = streamKind {
-                            Preloader().preloadImages(jsonables)
-                            NewContentService().updateCreatedAt(jsonables, streamKind: streamKind)
-                        }
-                        fulfill(.jsonables(jsonables, responseConfig))
-                    }
-                    else {
-                        fulfill(.empty)
-                    }
-
-                    // this must be the last thing, after success() or noContent() is called.
-                    if let streamKind = streamKind {
+        return ElloProvider.shared.request(endpoint)
+            .then { (data, responseConfig) -> StreamResponse in
+                if let streamKind = streamKind {
+                    nextTick {
                         postNotification(StreamLoadedNotifications.streamLoaded, value: streamKind)
                     }
-                },
-                failure: { (error, statusCode) in
-                    reject(error)
-                })
-        }
+                }
+
+                if data as? String == "" {
+                    return .empty
+                }
+                else if let jsonables = data as? [JSONAble] {
+                    if let streamKind = streamKind {
+                        Preloader().preloadImages(jsonables)
+                        NewContentService().updateCreatedAt(jsonables, streamKind: streamKind)
+                    }
+                    return .jsonables(jsonables, responseConfig)
+                }
+                else {
+                    throw NSError.uncastableJSONAble()
+                }
+            }
     }
 
     func loadUser(_ endpoint: ElloAPI) -> Promise<User> {
-        return Promise { fulfill, reject in
-            ElloProvider.shared.elloRequest(
-                endpoint,
-                success: { (data, responseConfig) in
-                    if let user = data as? User {
-                        Preloader().preloadImages([user])
-                        fulfill(user)
-                    }
-                    else {
-                        let error = NSError.uncastableJSONAble()
-                        reject(error)
-                    }
-                },
-                failure: { error, _ in
-                    reject(error)
+        return ElloProvider.shared.request(endpoint)
+            .then { data, responseConfig -> User in
+                guard let user = data as? User else {
+                    throw NSError.uncastableJSONAble()
                 }
-            )
-        }
+                Preloader().preloadImages([user])
+                return user
+            }
     }
 
     func loadUserPosts(_ userId: String) -> Promise<([Post], ResponseConfig)> {
-        return Promise { fulfill, reject in
-            ElloProvider.shared.elloRequest(
-                ElloAPI.userStreamPosts(userId: userId),
-                success: { (data, responseConfig) in
-                    let posts: [Post]?
-                    if data as? String == "" {
-                        posts = []
-                    }
-                    else if let foundPosts = data as? [Post] {
-                        posts = foundPosts
-                    }
-                    else {
-                        posts = nil
-                    }
+        return ElloProvider.shared.request(.userStreamPosts(userId: userId))
+            .then { data, responseConfig -> ([Post], ResponseConfig) in
+                let posts: [Post]?
+                if data as? String == "" {
+                    posts = []
+                }
+                else if let foundPosts = data as? [Post] {
+                    posts = foundPosts
+                }
+                else {
+                    posts = nil
+                }
 
-                    if let posts = posts {
-                        Preloader().preloadImages(posts)
-                        fulfill((posts, responseConfig))
-                    }
-                    else {
-                        let error = NSError.uncastableJSONAble()
-                        reject(error)
-                    }
-                },
-                failure: { error, _ in
-                    reject(error)
-                })
-        }
+                if let posts = posts {
+                    Preloader().preloadImages(posts)
+                    return (posts, responseConfig)
+                }
+                else {
+                    throw NSError.uncastableJSONAble()
+                }
+            }
     }
 
     func loadMoreCommentsForPost(_ postId: String) -> Promise<StreamResponse> {
-        return Promise { fulfill, reject in
-            ElloProvider.shared.elloRequest(
-                .postComments(postId: postId),
-                success: { (data, responseConfig) in
-                    if let comments: [ElloComment] = data as? [ElloComment] {
-                        for comment in comments {
-                            comment.loadedFromPostId = postId
-                        }
+        return ElloProvider.shared.request(.postComments(postId: postId))
+            .then { data, responseConfig -> StreamResponse in
+                if let comments: [ElloComment] = data as? [ElloComment] {
+                    for comment in comments {
+                        comment.loadedFromPostId = postId
+                    }
 
-                        Preloader().preloadImages(comments)
-                        fulfill(.jsonables(comments, responseConfig))
-                    }
-                    else if (data as? String) == "" {
-                        fulfill(.empty)
-                    }
-                    else {
-                        let error = NSError.uncastableJSONAble()
-                        reject(error)
-                    }
-                },
-                failure: { error, _ in
-                    reject(error)
+                    Preloader().preloadImages(comments)
+                    return .jsonables(comments, responseConfig)
                 }
-            )
-        }
+                else if (data as? String) == "" {
+                    return .empty
+                }
+                else {
+                    throw NSError.uncastableJSONAble()
+                }
+            }
     }
 }

--- a/Sources/Networking/UserService.swift
+++ b/Sources/Networking/UserService.swift
@@ -4,7 +4,7 @@
 
 import Moya
 import SwiftyJSON
-import FutureKit
+import PromiseKit
 
 
 struct UserService {
@@ -15,68 +15,68 @@ struct UserService {
         email: String,
         username: String,
         password: String,
-        invitationCode: String?) -> Future<User>
+        invitationCode: String?) -> Promise<User>
     {
-        let promise = Promise<User>()
-        ElloProvider.shared.elloRequest(ElloAPI.join(email: email, username: username, password: password, invitationCode: invitationCode),
-            success: { data, _ in
-                if let user = data as? User {
-                    promise.completeWithSuccess(user)
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(ElloAPI.join(email: email, username: username, password: password, invitationCode: invitationCode),
+                success: { data, _ in
+                    if let user = data as? User {
+                        fulfill(user)
+                    }
+                    else {
+                        let error = NSError.uncastableJSONAble()
+                        reject(error)
+                    }
+                },
+                failure: { error, _ in
+                    reject(error)
                 }
-                else {
-                    let error = NSError.uncastableJSONAble()
-                    promise.completeWithFail(error)
-                }
-            },
-            failure: { error, _ in
-                promise.completeWithFail(error)
-            }
-        )
-        return promise.future
+            )
+        }
     }
 
-    func requestPasswordReset(email: String) -> Future<()> {
-        let promise = Promise<()>()
-        ElloProvider.shared.elloRequest(ElloAPI.requestPasswordReset(email: email),
-            success: { _ in
-                promise.completeWithSuccess(())
-            },
-            failure: { error, _ in
-                promise.completeWithFail(error)
-            }
-        )
-        return promise.future
+    func requestPasswordReset(email: String) -> Promise<()> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(ElloAPI.requestPasswordReset(email: email),
+                success: { _ in
+                    fulfill(())
+                },
+                failure: { error, _ in
+                    reject(error)
+                }
+            )
+        }
     }
 
-    func resetPassword(password: String, authToken: String) -> Future<User> {
-        let promise = Promise<User>()
-        ElloProvider.shared.elloRequest(ElloAPI.resetPassword(password: password, authToken: authToken),
-            success: { user, _ in
-                if let user = user as? User {
-                    promise.completeWithSuccess(user)
+    func resetPassword(password: String, authToken: String) -> Promise<User> {
+        return Promise { fulfill, reject in
+            ElloProvider.shared.elloRequest(ElloAPI.resetPassword(password: password, authToken: authToken),
+                success: { user, _ in
+                    if let user = user as? User {
+                        fulfill(user)
+                    }
+                    else {
+                        let error = NSError.uncastableJSONAble()
+                        reject(error)
+                    }
+                },
+                failure: { error, _ in
+                    reject(error)
                 }
-                else {
-                    let error = NSError.uncastableJSONAble()
-                    promise.completeWithFail(error)
-                }
-            },
-            failure: { error, _ in
-                promise.completeWithFail(error)
-            }
-        )
-        return promise.future
+            )
+        }
     }
 
-    func setUser(categories: [Category]) -> Future<Void> {
-        let promise = Promise<Void>()
-        let categoryIds = categories.map { $0.id }
-        ElloProvider.shared.elloRequest(ElloAPI.userCategories(categoryIds: categoryIds),
-            success: { _ in
-                promise.completeWithSuccess(Void())
-            },
-            failure: { error, _ in
-                promise.completeWithFail(error)
-            })
-        return promise.future
+    func setUser(categories: [Category]) -> Promise<()> {
+        return Promise { fulfill, reject in
+            let categoryIds = categories.map { $0.id }
+            ElloProvider.shared.elloRequest(ElloAPI.userCategories(categoryIds: categoryIds),
+                success: { _ in
+                    fulfill(())
+                },
+                failure: { error, _ in
+                    reject(error)
+                })
+        }
     }
 }

--- a/Sources/Networking/UserService.swift
+++ b/Sources/Networking/UserService.swift
@@ -17,66 +17,33 @@ struct UserService {
         password: String,
         invitationCode: String?) -> Promise<User>
     {
-        return Promise { fulfill, reject in
-            ElloProvider.shared.elloRequest(ElloAPI.join(email: email, username: username, password: password, invitationCode: invitationCode),
-                success: { data, _ in
-                    if let user = data as? User {
-                        fulfill(user)
+            return ElloProvider.shared.request(.join(email: email, username: username, password: password, invitationCode: invitationCode))
+                .then { data, _ -> User in
+                    guard let user = data as? User else {
+                        throw NSError.uncastableJSONAble()
                     }
-                    else {
-                        let error = NSError.uncastableJSONAble()
-                        reject(error)
-                    }
-                },
-                failure: { error, _ in
-                    reject(error)
+                    return user
                 }
-            )
-        }
     }
 
     func requestPasswordReset(email: String) -> Promise<()> {
-        return Promise { fulfill, reject in
-            ElloProvider.shared.elloRequest(ElloAPI.requestPasswordReset(email: email),
-                success: { _ in
-                    fulfill(())
-                },
-                failure: { error, _ in
-                    reject(error)
-                }
-            )
-        }
+        return ElloProvider.shared.request(.requestPasswordReset(email: email))
+            .asVoid()
     }
 
     func resetPassword(password: String, authToken: String) -> Promise<User> {
-        return Promise { fulfill, reject in
-            ElloProvider.shared.elloRequest(ElloAPI.resetPassword(password: password, authToken: authToken),
-                success: { user, _ in
-                    if let user = user as? User {
-                        fulfill(user)
-                    }
-                    else {
-                        let error = NSError.uncastableJSONAble()
-                        reject(error)
-                    }
-                },
-                failure: { error, _ in
-                    reject(error)
+        return ElloProvider.shared.request(.resetPassword(password: password, authToken: authToken))
+            .then { user, _ -> User in
+                guard let user = user as? User else {
+                    throw NSError.uncastableJSONAble()
                 }
-            )
-        }
+                return user
+            }
     }
 
     func setUser(categories: [Category]) -> Promise<()> {
-        return Promise { fulfill, reject in
-            let categoryIds = categories.map { $0.id }
-            ElloProvider.shared.elloRequest(ElloAPI.userCategories(categoryIds: categoryIds),
-                success: { _ in
-                    fulfill(())
-                },
-                failure: { error, _ in
-                    reject(error)
-                })
-        }
+        let categoryIds = categories.map { $0.id }
+        return ElloProvider.shared.request(.userCategories(categoryIds: categoryIds))
+            .asVoid()
     }
 }

--- a/Sources/ThirdParty/PromiseKitExtensions.swift
+++ b/Sources/ThirdParty/PromiseKitExtensions.swift
@@ -1,0 +1,18 @@
+////
+///  PromiseKitExtensions.swift
+//
+
+import PromiseKit
+
+
+extension Promise {
+
+    func thenFinally(execute body: @escaping (T) throws -> Void) -> Promise<Void> {
+        return then(execute: body)
+    }
+
+    @discardableResult
+    func ignoreErrors() -> Promise<T> {
+        return self
+    }
+}

--- a/Specs/AppDelegateSpec.swift
+++ b/Specs/AppDelegateSpec.swift
@@ -11,8 +11,10 @@ import PINCache
 class AppDelegateSpec: QuickSpec {
     override func spec() {
         describe("AppDelegate") {
-            let subject = UIApplication.shared.delegate as? AppDelegate
-            subject?.setupCaches()
+            beforeEach {
+                let subject = UIApplication.shared.delegate as? AppDelegate
+                subject?.setupCaches()
+            }
 
             describe("caches") {
 

--- a/Specs/Controllers/Stream/ProfileBadgesSizeCalculatorSpec.swift
+++ b/Specs/Controllers/Stream/ProfileBadgesSizeCalculatorSpec.swift
@@ -17,8 +17,8 @@ class ProfileBadgesSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileBadgesSizeCalculator()
                 var height: CGFloat!
                 calc.calculate(StreamCellItem(jsonable: user, type: .header))
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height) == 0
             }
 
@@ -27,8 +27,8 @@ class ProfileBadgesSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileBadgesSizeCalculator()
                 var height: CGFloat!
                 calc.calculate(StreamCellItem(jsonable: user, type: .header))
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height) > 0
             }
         }

--- a/Specs/Controllers/Stream/ProfileBioSizeCalculatorSpec.swift
+++ b/Specs/Controllers/Stream/ProfileBioSizeCalculatorSpec.swift
@@ -17,8 +17,8 @@ class ProfileBioSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileBioSizeCalculator()
                 var height: CGFloat?
                 calc.calculate(StreamCellItem(jsonable: user, type: .header), maxWidth: 320)
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height) == 0
             }
 
@@ -28,8 +28,8 @@ class ProfileBioSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileBioSizeCalculator()
                 var height: CGFloat?
                 calc.calculate(StreamCellItem(jsonable: user, type: .header), maxWidth: 320)
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height) == 0
             }
 
@@ -40,8 +40,8 @@ class ProfileBioSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileBioSizeCalculator()
                 var height: CGFloat?
                 calc.calculate(StreamCellItem(jsonable: user, type: .header), maxWidth: 320)
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height).toEventually(beGreaterThan(40))
             }
         }

--- a/Specs/Controllers/Stream/ProfileLinksSizeCalculatorSpec.swift
+++ b/Specs/Controllers/Stream/ProfileLinksSizeCalculatorSpec.swift
@@ -16,8 +16,8 @@ class ProfileLinksSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileLinksSizeCalculator()
                 var height: CGFloat?
                 calc.calculate(StreamCellItem(jsonable: user, type: .header), maxWidth: 375)
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height) == 0
             }
 
@@ -27,8 +27,8 @@ class ProfileLinksSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileLinksSizeCalculator()
                 var height: CGFloat?
                 calc.calculate(StreamCellItem(jsonable: user, type: .header), maxWidth: 375)
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height) == 0
             }
 
@@ -40,8 +40,8 @@ class ProfileLinksSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileLinksSizeCalculator()
                 var height: CGFloat?
                 calc.calculate(StreamCellItem(jsonable: user, type: .header), maxWidth: 375)
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height) == 53
             }
 
@@ -55,8 +55,8 @@ class ProfileLinksSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileLinksSizeCalculator()
                 var height: CGFloat?
                 calc.calculate(StreamCellItem(jsonable: user, type: .header), maxWidth: 375)
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height) == 82
             }
 
@@ -74,8 +74,8 @@ class ProfileLinksSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileLinksSizeCalculator()
                 var height: CGFloat?
                 calc.calculate(StreamCellItem(jsonable: user, type: .header), maxWidth: 375)
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height) == 198
             }
 
@@ -89,8 +89,8 @@ class ProfileLinksSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileLinksSizeCalculator()
                 var height: CGFloat?
                 calc.calculate(StreamCellItem(jsonable: user, type: .header), maxWidth: 375)
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height) == 53
             }
 
@@ -108,8 +108,8 @@ class ProfileLinksSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileLinksSizeCalculator()
                 var height: CGFloat?
                 calc.calculate(StreamCellItem(jsonable: user, type: .header), maxWidth: 375)
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height) == 81
             }
 
@@ -121,8 +121,8 @@ class ProfileLinksSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileLinksSizeCalculator()
                 var height: CGFloat?
                 calc.calculate(StreamCellItem(jsonable: user, type: .header), maxWidth: 375)
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height) == 49
             }
         }

--- a/Specs/Controllers/Stream/ProfileNamesSizeCalculatorSpec.swift
+++ b/Specs/Controllers/Stream/ProfileNamesSizeCalculatorSpec.swift
@@ -18,8 +18,8 @@ class ProfileNamesSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileNamesSizeCalculator()
                 var height: CGFloat!
                 calc.calculate(StreamCellItem(jsonable: user, type: .header), maxWidth: 320)
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height) == 57
             }
             it("should return sensible size for two lines of text") {
@@ -30,8 +30,8 @@ class ProfileNamesSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileNamesSizeCalculator()
                 var height: CGFloat!
                 calc.calculate(StreamCellItem(jsonable: user, type: .header), maxWidth: 320)
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height) == 76
             }
         }

--- a/Specs/Controllers/Stream/ProfileStatsSizeCalculatorSpec.swift
+++ b/Specs/Controllers/Stream/ProfileStatsSizeCalculatorSpec.swift
@@ -15,8 +15,8 @@ class ProfileStatsSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileStatsSizeCalculator()
                 var height: CGFloat!
                 calc.calculate(StreamCellItem(jsonable: user, type: .header))
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height) == 60
             }
         }

--- a/Specs/Controllers/Stream/ProfileTotalCountSizeCalculatorSpec.swift
+++ b/Specs/Controllers/Stream/ProfileTotalCountSizeCalculatorSpec.swift
@@ -17,8 +17,8 @@ class ProfileTotalCountSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileTotalCountSizeCalculator()
                 var height: CGFloat!
                 calc.calculate(StreamCellItem(jsonable: user, type: .header))
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height) == 0
             }
 
@@ -27,8 +27,8 @@ class ProfileTotalCountSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileTotalCountSizeCalculator()
                 var height: CGFloat!
                 calc.calculate(StreamCellItem(jsonable: user, type: .header))
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height) == 0
             }
 
@@ -37,8 +37,8 @@ class ProfileTotalCountSizeCalculatorSpec: QuickSpec {
                 let calc = ProfileTotalCountSizeCalculator()
                 var height: CGFloat!
                 calc.calculate(StreamCellItem(jsonable: user, type: .header))
-                    .onSuccess { h in height = h }
-                    .onFail { _ in }
+                    .thenFinally { h in height = h }
+                    .catch { _ in }
                 expect(height) > 0
             }
         }

--- a/Specs/Controllers/Stream/StreamCellItemParserSpec.swift
+++ b/Specs/Controllers/Stream/StreamCellItemParserSpec.swift
@@ -32,24 +32,24 @@ class StreamCellItemParserSpec: QuickSpec {
                 it("returns an array with the proper count of stream cell items when parsing friends.json's posts") {
                     var cellItems = [StreamCellItem]()
                     StreamService().loadStream(endpoint: .following)
-                        .onSuccess { response in
+                        .thenFinally { response in
                             if case let .jsonables(jsonables, _) = response {
                                 cellItems = subject.parse(jsonables, streamKind: .following)
                             }
                         }
-                        .onFail { _ in }
+                        .catch { _ in }
                     expect(cellItems.count) == 8
                 }
 
                 it("doesn't include user's own post headers on a profile stream") {
                     var cellItems = [StreamCellItem]()
                     StreamService().loadStream(endpoint: .following)
-                        .onSuccess { response in
+                        .thenFinally { response in
                             if case let .jsonables(jsonables, _) = response {
                                 cellItems = subject.parse(jsonables, streamKind: .userStream(userParam: "42"))
                             }
                         }
-                        .onFail { _ in }
+                        .catch { _ in }
                     let header = cellItems.find { $0.type == .header }
                     expect(header).to(beNil())
                 }
@@ -62,12 +62,12 @@ class StreamCellItemParserSpec: QuickSpec {
                 it("returns an array with the proper count of stream cell items when parsing friends.json's activities") {
                     var loadedNotifications = [StreamCellItem]()
                     StreamService().loadStream(endpoint: .notificationsStream(category: nil))
-                        .onSuccess { response in
+                        .thenFinally { response in
                             if case let .jsonables(jsonables, _) = response {
                                 loadedNotifications = subject.parse(jsonables, streamKind: .notifications(category: nil))
                             }
                         }
-                        .onFail { _ in }
+                        .catch { _ in }
                     expect(loadedNotifications.count) == 14
                 }
             }

--- a/Specs/Controllers/Stream/StreamViewControllerSpec.swift
+++ b/Specs/Controllers/Stream/StreamViewControllerSpec.swift
@@ -123,14 +123,14 @@ class StreamViewControllerSpec: QuickSpec {
             beforeEach {
                 controller.streamKind = StreamKind.following
                 controller.streamService.loadStream(endpoint: controller.streamKind.endpoint)
-                    .onSuccess { response in
+                    .thenFinally { response in
                         if case let .jsonables(jsonables, responseConfig) = response {
                             controller.appendUnsizedCellItems(StreamCellItemParser().parse(jsonables, streamKind: controller.streamKind))
                             controller.responseConfig = responseConfig
                             controller.doneLoading()
                         }
                     }
-                    .onFail { _ in
+                    .catch { _ in
                         controller.doneLoading()
                     }
             }

--- a/Specs/Helpers/ElloSpecHelper.swift
+++ b/Specs/Helpers/ElloSpecHelper.swift
@@ -5,12 +5,16 @@
 @testable import Ello
 import Quick
 import Nimble_Snapshots
+import PromiseKit
 
 
 // Add in custom configuration
 class ElloConfiguration: QuickConfiguration {
     override class func configure(_ config: Configuration) {
         config.beforeSuite {
+            // make sure the promise `then` blocks are run synchronously
+            DispatchQueue.default = zalgo
+
             ElloLinkedStore.databaseName = "ello_test.sqlite"
             BadgesService.badges = [
                 "featured": Badge(slug: "featured", name: "Featured", link: "Learn More", url: nil, imageURL: nil),

--- a/Specs/Helpers/ElloSpecHelper.swift
+++ b/Specs/Helpers/ElloSpecHelper.swift
@@ -14,6 +14,14 @@ class ElloConfiguration: QuickConfiguration {
         config.beforeSuite {
             // make sure the promise `then` blocks are run synchronously
             DispatchQueue.default = zalgo
+            if ( DispatchQueue.default != zalgo ) {
+                fatalError(
+                    "Aww dang, somehow PromiseKit's `DispatchQueue.default` was " +
+                    "accessed before `zalgo` could be assigned. Add a break point to " +
+                    "PromiseKit/CorePromise/GlobalState.m, inside dispatch_queue_t PMKDefaultDispatchQueue() " +
+                    "to find out where this is being set"
+                    )
+            }
 
             ElloLinkedStore.databaseName = "ello_test.sqlite"
             BadgesService.badges = [

--- a/Specs/Networking/PostServiceSpec.swift
+++ b/Specs/Networking/PostServiceSpec.swift
@@ -22,10 +22,10 @@ class PostServiceSpec: QuickSpec {
                         var successPost: Post?
                         var failedCalled = false
                         subject.loadPost("fake-post-param", needsComments: true)
-                            .onSuccess { post in
+                            .thenFinally { post in
                                 successPost = post
                             }
-                            .onFail { _ in
+                            .catch { _ in
                                 failedCalled = true
                             }
 
@@ -44,10 +44,10 @@ class PostServiceSpec: QuickSpec {
                         var successPost: Post?
                         var failedCalled = false
                         subject.loadPost("fake-post-param", needsComments: true)
-                            .onSuccess { post in
+                            .thenFinally { post in
                                 successPost = post
                             }
-                            .onFail { _ in
+                            .catch { _ in
                                 failedCalled = true
                             }
 
@@ -65,10 +65,10 @@ class PostServiceSpec: QuickSpec {
                         var successCalled = false
                         var failedCalled = false
                         subject.deletePost("fake-post-id")
-                            .onSuccess {
+                            .then {
                                 successCalled = true
                             }
-                            .onFail { _ in
+                            .catch { _ in
                                 failedCalled = true
                             }
 
@@ -87,10 +87,10 @@ class PostServiceSpec: QuickSpec {
                         var successCalled = false
                         var failedCalled = false
                         subject.deletePost("fake-post-id")
-                            .onSuccess {
+                            .then {
                                 successCalled = true
                             }
-                            .onFail { _ in
+                            .catch { _ in
                                 failedCalled = true
                             }
 
@@ -109,10 +109,10 @@ class PostServiceSpec: QuickSpec {
                         var failedCalled = false
                         subject.deleteComment("fake-post-id",
                             commentId: "fake-comment-id")
-                            .onSuccess {
+                            .then {
                                 successCalled = true
                             }
-                            .onFail{ _ in
+                            .catch { error in
                                 failedCalled = true
                             }
 
@@ -132,10 +132,10 @@ class PostServiceSpec: QuickSpec {
                         var failedCalled = false
                         subject.deleteComment("fake-post-id",
                             commentId: "fake-comment-id")
-                            .onSuccess {
+                            .then {
                                 successCalled = true
                             }
-                            .onFail { _ in
+                            .catch { _ in
                                 failedCalled = true
                             }
 

--- a/Specs/Networking/StreamServiceSpec.swift
+++ b/Specs/Networking/StreamServiceSpec.swift
@@ -22,12 +22,12 @@ class StreamServiceSpec: QuickSpec {
                         var config: ResponseConfig?
 
                         streamService.loadStream(endpoint: ElloAPI.following)
-                            .onSuccess { response in
+                            .thenFinally { response in
                                 if case let .jsonables(jsonables, responseConfig) = response {
                                     loadedPosts = (StreamKind.following.filter(jsonables, viewsAdultContent: true) as! [Post])
                                     config = responseConfig
                                 }
-                            }.ignoreFailures()
+                            }.ignoreErrors()
 
                         expect(config?.prevQueryItems?.count) == 2
                         expect(config?.nextQueryItems?.count) == 2
@@ -62,12 +62,12 @@ class StreamServiceSpec: QuickSpec {
                         var loadedPosts: [Post]?
 
                         streamService.loadStream(endpoint: ElloAPI.following)
-                            .onSuccess { response in
+                            .thenFinally { response in
                                 if case let .jsonables(jsonables, _) = response {
                                     loadedPosts = (StreamKind.following.filter(jsonables, viewsAdultContent: true) as! [Post])
                                 }
                             }
-                            .ignoreFailures()
+                            .ignoreErrors()
 
                         let post2: Post = loadedPosts![2] as Post
 
@@ -89,11 +89,11 @@ class StreamServiceSpec: QuickSpec {
                         var loadedComments: [ElloComment]?
 
                         streamService.loadMoreCommentsForPost("111")
-                            .onSuccess { response in
+                            .thenFinally { response in
                                 if case let .jsonables(comments, _) = response {
                                     loadedComments = comments as? [ElloComment]
                                 }
-                            }.ignoreFailures()
+                            }.ignoreErrors()
 
                         expect(loadedComments!.count) == 1
 
@@ -138,12 +138,12 @@ class StreamServiceSpec: QuickSpec {
                         var loadedError: NSError?
 
                         streamService.loadStream(endpoint: ElloAPI.following)
-                        .onSuccess { response in
+                        .thenFinally { response in
                             if case let .jsonables(jsonables, _) = response {
                                 loadedJsonables = jsonables
                             }
                         }
-                        .onFail { error in
+                        .catch { error in
                             loadedError = error as NSError
                         }
 


### PR DESCRIPTION
I love the syntax and features, and the services look so much better now!

One gotcha: PromiseKit's promises usually complete on the "next tick", even when the value is available immediately, this had terrible repurcussions for our specs.  The workaround is to use PromiseKit's `zalgo` dispatch queue, which calls its `then` blocks synchronously.

[Finishes #146322753](https://www.pivotaltracker.com/story/show/146322753)