### PR TITLE
Show a spinner if promo header loads first

### DIFF
--- a/Sources/Controllers/ArtistInvites/ArtistInvitesViewController.swift
+++ b/Sources/Controllers/ArtistInvites/ArtistInvitesViewController.swift
@@ -88,7 +88,13 @@ extension ArtistInvitesViewController: StreamDestination {
     }
 
     func replacePlaceholder(type: StreamCellType.PlaceholderType, items: [StreamCellItem], completion: @escaping Block) {
-        streamViewController.replacePlaceholder(type: type, items: items, completion: completion)
+        streamViewController.replacePlaceholder(type: type, items: items) {
+            if self.streamViewController.hasCellItems(for: .promotionalHeader) && !self.streamViewController.hasCellItems(for: .artistInvites) {
+                self.streamViewController.replacePlaceholder(type: .artistInvites, items: [StreamCellItem(type: .streamLoading)])
+            }
+
+            completion()
+        }
         streamViewController.doneLoading()
     }
 

--- a/Sources/Controllers/Editorials/EditorialsViewController.swift
+++ b/Sources/Controllers/Editorials/EditorialsViewController.swift
@@ -186,7 +186,13 @@ extension EditorialsViewController: StreamDestination {
     }
 
     func replacePlaceholder(type: StreamCellType.PlaceholderType, items: [StreamCellItem], completion: @escaping Block) {
-        streamViewController.replacePlaceholder(type: type, items: items, completion: completion)
+        streamViewController.replacePlaceholder(type: type, items: items) {
+            if self.streamViewController.hasCellItems(for: .promotionalHeader) && !self.streamViewController.hasCellItems(for: .editorials) {
+                self.streamViewController.replacePlaceholder(type: .editorials, items: [StreamCellItem(type: .streamLoading)])
+            }
+
+            completion()
+        }
         streamViewController.doneLoading()
     }
 


### PR DESCRIPTION
If promos load first, which is often, there is just empty white space under the header.  This inserts a loader instead.