### PR TITLE
Remove all unnecessary references to 'as URL'

### DIFF
--- a/Sources/Controllers/Omnibar/OmnibarViewController.swift
+++ b/Sources/Controllers/Omnibar/OmnibarViewController.swift
@@ -232,7 +232,7 @@ class OmnibarViewController: BaseElloViewController {
                 let url = region.url
             {
                 if let imageRegionURL = region.buyButtonURL {
-                    buyButtonURL = imageRegionURL as URL
+                    buyButtonURL = imageRegionURL
                 }
                 downloads.append((index, url))
                 regions.append(.imageURL(url))

--- a/Sources/Controllers/Profile/Views/ProfileLinksView.swift
+++ b/Sources/Controllers/Profile/Views/ProfileLinksView.swift
@@ -142,7 +142,9 @@ extension ProfileLinksView {
             }
         }
 
-        button.pin_setImage(from: externalLink.iconURL! as URL!)
+        if let iconURL = externalLink.iconURL {
+            button.pin_setImage(from: iconURL)
+        }
         return button
     }
 
@@ -187,7 +189,7 @@ extension ProfileLinksView {
             let externalLink = buttonLinks[button]
             else { return }
 
-        let request = URLRequest(url: externalLink.url as URL)
+        let request = URLRequest(url: externalLink.url)
         ElloWebViewHelper.handle(request: request, origin: self)
     }
 }

--- a/Sources/Controllers/Settings/SettingsViewController.swift
+++ b/Sources/Controllers/Settings/SettingsViewController.swift
@@ -238,14 +238,14 @@ class SettingsViewController: UITableViewController, ControllerThatMightHaveTheC
             coverImage.image = cachedImage
         }
         else if let imageURL = currentUser?.coverImageURL(viewsAdultContent: true, animated: true) {
-            coverImage.pin_setImage(from: imageURL as URL!)
+            coverImage.pin_setImage(from: imageURL)
         }
 
         if let cachedImage = TemporaryCache.load(.avatar) {
             avatarImage.image = cachedImage
         }
         else if let imageURL = currentUser?.avatar?.large?.url {
-            avatarImage.pin_setImage(from: imageURL as URL!)
+            avatarImage.pin_setImage(from: imageURL)
         }
 
         if currentUser?.profile?.isCommunity == true {

--- a/Sources/Controllers/Stream/CellDequeing/NotificationCellPresenter.swift
+++ b/Sources/Controllers/Stream/CellDequeing/NotificationCellPresenter.swift
@@ -47,13 +47,13 @@ struct NotificationCellPresenter {
             let aspectRatio = StreamImageCellSizeCalculator.aspectRatioForImageRegion(imageRegion)
             var imageURL: URL?
             if let asset = imageRegion.asset, !asset.isGif {
-                imageURL = asset.optimized?.url as URL?
+                imageURL = asset.optimized?.url
             }
-            else if let hdpiURL = imageRegion.asset?.hdpi?.url{
-                imageURL = hdpiURL as URL
+            else if let hdpiURL = imageRegion.asset?.hdpi?.url {
+                imageURL = hdpiURL
             }
             else {
-                imageURL = imageRegion.url as URL?
+                imageURL = imageRegion.url
             }
             cell.aspectRatio = aspectRatio
             cell.imageURL = imageURL

--- a/Sources/Controllers/Stream/CellDequeing/StreamImageCellPresenter.swift
+++ b/Sources/Controllers/Stream/CellDequeing/StreamImageCellPresenter.swift
@@ -56,7 +56,7 @@ struct StreamImageCellPresenter {
 
             if showGifInThisCell {
                 attachmentToLoad = asset.optimized
-                imageToLoad = asset.optimized?.url as URL?
+                imageToLoad = asset.optimized?.url
             }
             else {
                 attachmentToLoad = isGridView ? asset.gridLayoutAttachment : asset.oneColumnAttachment
@@ -75,7 +75,7 @@ struct StreamImageCellPresenter {
         }
 
         let imageToShow = attachmentToLoad?.image
-        imageToLoad = imageToLoad ?? attachmentToLoad?.url as URL?
+        imageToLoad = imageToLoad ?? attachmentToLoad?.url
 
         let cellMargin = calculateStreamImageMargin(cell, imageRegion: imageRegion, streamCellItem: streamCellItem)
         cell.marginType = cellMargin

--- a/Sources/Controllers/Stream/Cells/PromotionalHeaderCell.swift
+++ b/Sources/Controllers/Stream/Cells/PromotionalHeaderCell.swift
@@ -394,10 +394,10 @@ extension PromotionalHeaderCell.Config {
         tracking = category.slug
         isSponsored = category.isSponsored
         callToAction = category.ctaCaption
-        callToActionURL = category.ctaURL as URL?
+        callToActionURL = category.ctaURL
 
         if let promotional = category.randomPromotional {
-            imageURL = promotional.image?.oneColumnAttachment?.url as URL?
+            imageURL = promotional.image?.oneColumnAttachment?.url
             user = promotional.user
         }
     }
@@ -417,9 +417,9 @@ extension PromotionalHeaderCell.Config {
         title = pagePromotional.header
         body = pagePromotional.subheader
         tracking = "general"
-        imageURL = pagePromotional.tileURL as URL?
+        imageURL = pagePromotional.tileURL
         user = pagePromotional.user
         callToAction = pagePromotional.ctaCaption
-        callToActionURL = pagePromotional.ctaURL as URL?
+        callToActionURL = pagePromotional.ctaURL
     }
 }

--- a/Sources/Model/Category.swift
+++ b/Sources/Model/Category.swift
@@ -20,7 +20,7 @@ final class Category: JSONAble, Groupable {
     var groupId: String { return "Category-\(id)" }
     let name: String
     let slug: String
-    var tileURL: URL? { return tileImage?.url as URL? }
+    var tileURL: URL? { return tileImage?.url }
     var isSponsored: Bool?
     var body: String?
     var header: String?

--- a/Sources/Model/PagePromotional.swift
+++ b/Sources/Model/PagePromotional.swift
@@ -18,7 +18,7 @@ final class PagePromotional: JSONAble {
     let ctaCaption: String
     let ctaURL: URL?
     let image: Asset?
-    var tileURL: URL? { return image?.oneColumnAttachment?.url as URL? }
+    var tileURL: URL? { return image?.oneColumnAttachment?.url }
     var isCategory: Bool { return !isEditorial && !isArtistInvite }
     var isEditorial: Bool
     var isArtistInvite: Bool

--- a/Sources/Model/User.swift
+++ b/Sources/Model/User.swift
@@ -391,16 +391,16 @@ extension User {
 extension User {
     func coverImageURL(viewsAdultContent: Bool? = false, animated: Bool = false) -> URL? {
         if animated && (!postsAdultContent || viewsAdultContent == true) && coverImage?.original?.url.absoluteString.hasSuffix(".gif") == true {
-            return coverImage?.original?.url as URL?
+            return coverImage?.original?.url
         }
-        return coverImage?.oneColumnAttachment?.url as URL?
+        return coverImage?.oneColumnAttachment?.url
     }
 
     func avatarURL(viewsAdultContent: Bool? = false, animated: Bool = false) -> URL? {
         if animated && (!postsAdultContent || viewsAdultContent == true) && avatar?.original?.url.absoluteString.hasSuffix(".gif") == true {
-            return avatar?.original?.url as URL?
+            return avatar?.original?.url
         }
-        return avatar?.largeOrBest?.url as URL?
+        return avatar?.largeOrBest?.url
     }
 }
 

--- a/Sources/Networking/ProfileService.swift
+++ b/Sources/Networking/ProfileService.swift
@@ -98,7 +98,7 @@ struct ProfileService {
         if let avatarImage = avatarImage {
             S3UploadingService().upload(imageRegionData: avatarImage)
                 .then { url in
-                    avatarURL = url as URL?
+                    avatarURL = url
                 }
                 .catch { uploadError in
                     error = error ?? uploadError
@@ -114,7 +114,7 @@ struct ProfileService {
         if let coverImage = coverImage {
             S3UploadingService().upload(imageRegionData: coverImage)
                 .then { url in
-                    coverImageURL = url as URL?
+                    coverImageURL = url
                 }
                 .catch { uploadError in
                     error = error ?? uploadError

--- a/Sources/Utilities/Preloader.swift
+++ b/Sources/Utilities/Preloader.swift
@@ -18,20 +18,20 @@ struct Preloader {
                 let author = authorable.author,
                 let avatarURL = author.avatarURL()
             {
-                preloadUrl(avatarURL as URL)
+                preloadUrl(avatarURL)
             }
             // post / comment avatars
             else if let authorable = jsonable as? Authorable,
                 let author = authorable.author,
                 let avatarURL = author.avatarURL()
             {
-                preloadUrl(avatarURL as URL)
+                preloadUrl(avatarURL)
             }
             // user's posts avatars
             else if let user = jsonable as? User,
                 let userAvatarURL = user.avatarURL()
             {
-                preloadUrl(userAvatarURL as URL)
+                preloadUrl(userAvatarURL)
             }
 
             // activity image regions
@@ -58,13 +58,13 @@ struct Preloader {
             else if let category = jsonable as? Category,
                 let url = category.tileURL
             {
-                preloadUrl(url as URL)
+                preloadUrl(url)
             }
             // promotionals
             else if let promotional = jsonable as? PagePromotional,
                 let url = promotional.tileURL
             {
-                preloadUrl(url as URL)
+                preloadUrl(url)
             }
 
             // TODO: account for discovery when the api includes assets in the discovery
@@ -79,7 +79,7 @@ struct Preloader {
                     let asset = imageRegion.asset,
                     let attachment = asset.oneColumnAttachment
                 {
-                    preloadUrl(attachment.url as URL)
+                    preloadUrl(attachment.url)
                 }
             }
         }
@@ -97,7 +97,7 @@ struct Preloader {
                 let asset = imageRegion.asset,
                 let attachment = asset.oneColumnAttachment
             {
-                preloadUrl(attachment.url as URL)
+                preloadUrl(attachment.url)
             }
         }
     }

--- a/Sources/Views/CategoryCardView.swift
+++ b/Sources/Views/CategoryCardView.swift
@@ -72,7 +72,7 @@ class CategoryCardView: View {
             let imageView = UIImageView()
             imageView.clipsToBounds = true
             imageView.contentMode = .scaleAspectFill
-            imageView.pin_setImage(from: url as URL!)
+            imageView.pin_setImage(from: url)
             addSubview(imageView)
             imageView.snp.makeConstraints { $0.edges.equalTo(self) }
         }

--- a/Specs/Controllers/Stream/Cells/NotificationCellSpec.swift
+++ b/Specs/Controllers/Stream/Cells/NotificationCellSpec.swift
@@ -80,7 +80,7 @@ class NotificationCellSpec: QuickSpec {
                         subject.aspectRatio = aspectRatio
                         subject.buyButtonVisible = buyButton
                         if hasImage {
-                            subject.imageURL = URL(string: "http://ello.co/image.png") as URL?
+                            subject.imageURL = URL(string: "http://ello.co/image.png")
                             subject.notificationImageView.image = image
                         }
 

--- a/Specs/Extensions/UIWebViewSpecs.swift
+++ b/Specs/Extensions/UIWebViewSpecs.swift
@@ -16,7 +16,7 @@ class UIWebViewSpecs: QuickSpec, UIWebViewDelegate {
             beforeEach() {
                 let html = "<div id=\"post-container\"><img style=\"width: 100pt; height: 100pt;\" width=\"100\" height=\"100\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNiAAAABgADNjd8qAAAAABJRU5ErkJggg==\" /></div>"
                 self.webView = UIWebView(frame: .zero)
-                self.webView.loadHTMLString(html, baseURL: URL(string: "/") as URL?)
+                self.webView.loadHTMLString(html, baseURL: URL(string: "/"))
                 self.webView.delegate = self
             }
 

--- a/Specs/Utilities/SafariActivitySpec.swift
+++ b/Specs/Utilities/SafariActivitySpec.swift
@@ -68,7 +68,7 @@ class SafariActivitySpec: QuickSpec {
                             expect(subject.url).to(beNil())
                         }
                         else {
-                            expect(subject.url) == expected as URL?
+                            expect(subject.url) == expected
                         }
                     }
                 }

--- a/Specs/Views/AvatarButtonSpec.swift
+++ b/Specs/Views/AvatarButtonSpec.swift
@@ -21,33 +21,33 @@ class AvatarButtonSpec: QuickSpec {
                 }
 
                 it("should assign the asset url via User") {
-                    let asset = Asset(url: url as URL)
+                    let asset = Asset(url: url)
                     user.avatar = asset
                     subject.setUserAvatarURL(user.avatarURL())
-                    expect(subject.imageURL) == url as URL
+                    expect(subject.imageURL) == url
                 }
 
                 it("should assign the asset url") {
-                    subject.setUserAvatarURL(url as URL)
-                    expect(subject.imageURL) == url as URL
+                    subject.setUserAvatarURL(url)
+                    expect(subject.imageURL) == url
                 }
 
                 it("should assign the asset large url") {
                     let asset = Asset(id: NSUUID().uuidString)
-                    let attachment = Attachment(url: url as URL)
+                    let attachment = Attachment(url: url)
                     asset.large = attachment
                     user.avatar = asset
                     subject.setUserAvatarURL(user.avatarURL())
-                    expect(subject.imageURL) == url as URL
+                    expect(subject.imageURL) == url
                 }
 
                 it("should assign the asset optimized url") {
                     let asset = Asset(id: NSUUID().uuidString)
-                    let attachment = Attachment(url: url as URL)
+                    let attachment = Attachment(url: url)
                     asset.optimized = attachment
                     user.avatar = asset
                     subject.setUserAvatarURL(user.avatarURL())
-                    expect(subject.imageURL) == url as URL
+                    expect(subject.imageURL) == url
                 }
 
             }


### PR DESCRIPTION
This requirement went away in swift 2 or 3